### PR TITLE
#329 Enable New Authority Form

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -63,7 +63,7 @@ See the Information Commissioner's Guidelines <a href="http://www.oaic.gov.au/pu
 
 <dd>
 <p>At the moment we aim to cover all Australian Federal public authorities. We plan to add State and Local Government authorities soon.</p>
-<p>Please <a href="/help/contact">contact us</a> with the name of the public authority and,
+<p>Please <a href="/change_request/new">contact us</a> with the name of the public authority and,
 if you can find it, their contact email address for Freedom of Information requests.
 </p>
 <p>If you'd like to help add a whole category (new state or local government region etc.) of public authority to the site, we'd love
@@ -82,7 +82,7 @@ organisations:</p>
   <li> Those formally subject to the Freedom of Information Act</li>
   <li> Those which choose to voluntarily comply with the Freedom of Information Act</li>
   <li> Those which aren't subject to the Act but we think should be, on grounds
-  such as them having significant public responsibilities. 
+  such as them having significant public responsibilities.
   </li>
 </ul>
 
@@ -226,9 +226,9 @@ spent on marshmallows in the past year than in the past ten years.
     checking that they received the request. It was sent to them by email.
     </li>
     <li>If they have not received it, the problem is most likely due to
-    "spam filters". Refer the authority to the measures in the answer 
-    '<a href="/help/officers#spam_problems">I can see a request on <%= site_name %>, but we never got it by email!</a>' 
-    in the FOI officers section of this help. 
+    "spam filters". Refer the authority to the measures in the answer
+    '<a href="/help/officers#spam_problems">I can see a request on <%= site_name %>, but we never got it by email!</a>'
+    in the FOI officers section of this help.
     </li>
     <li>If you're still having no luck, then you can ask for an internal review,
     or complain to the Information Commissioner about the authority, or both.
@@ -333,7 +333,7 @@ you can always make the same request again via <%= site_name %>.
 
 <dt id="moderation">How do you moderate request annotations? <a href="#moderation">#</a> </dt>
 
-<dd> 
+<dd>
 <p>Annotations on <%= site_name %> are to help
 people get the information they want, or to give them pointers to places they
 can go to help them act on it. We reserve the right to remove anything else.


### PR DESCRIPTION
Enable the New Authority Form which allows authorities to be requested
and approved via the Admin interface, instead of via Contact Us.
