### PR TITLE
Email Disclaimer Changes (#352)

### DIFF
--- a/lib/views/outgoing_mailer/_followup_footer.text.erb
+++ b/lib/views/outgoing_mailer/_followup_footer.text.erb
@@ -1,2 +1,3 @@
 <%= _('Disclaimer: The views expressed in this request are those of the sender, and are not endorsed by Right to Know or the OpenAustralia Foundation. ')%>
+
 <%= _('This message and any reply that you make will be published on the internet. More Information can be found at:')%> <%= help_officers_url %>

--- a/lib/views/outgoing_mailer/_followup_footer.text.erb
+++ b/lib/views/outgoing_mailer/_followup_footer.text.erb
@@ -1,9 +1,2 @@
-<%= _('Write your response as plain text. Only send PDF documents as a last resort. Government guidelines make it clear that PDF is not an acceptable format for you to use in the delivery of government information.') %>
-<%= help_officers_url(:anchor => "pdf") %>
-
-<%= _('This request is being made by an individual using the Right to Know website. The unique email address provided by the service for this request satisfies s.15(2)(c) of the Freedom of Information Act.')%>
-
-<%= _('Disclaimer: This message and any reply that you make will be published on the internet. Our privacy and copyright policies:')%>
-<%= help_officers_url %>
-
-<%= _('If you find this service useful as an FOI officer, please ask your web manager to link to us from your organisation\'s FOI page.')%>
+<%= _('Disclaimer: The views expressed in this request are those of the sender, and are not endorsed by Right to Know or the OpenAustralia Foundation. ')%>
+<%= _('This message and any reply that you make will be published on the internet. More Information can be found at:')%> <%= help_officers_url %>

--- a/lib/views/outgoing_mailer/followup.text.erb
+++ b/lib/views/outgoing_mailer/followup.text.erb
@@ -1,0 +1,10 @@
+<%= raw @outgoing_message.body.strip %>
+
+<%= raw @outgoing_message.quoted_part_to_append_to_email.strip %>
+
+-------------------------------------------------------------------
+<%= _('Please use this email address for all replies to this request:')%>
+<%= @info_request.incoming_email %>
+
+<%= render :partial => 'followup_footer' %>
+-------------------------------------------------------------------

--- a/lib/views/outgoing_mailer/followup.text.erb
+++ b/lib/views/outgoing_mailer/followup.text.erb
@@ -3,8 +3,7 @@
 <%= raw @outgoing_message.quoted_part_to_append_to_email.strip %>
 
 -------------------------------------------------------------------
-<%= _('Please use this email address for all replies to this request:')%>
-<%= @info_request.incoming_email %>
+<%= _('Please use this email address for all replies to this request:')%> <%= @info_request.incoming_email %>
 
 <%= render :partial => 'followup_footer' %>
 -------------------------------------------------------------------

--- a/lib/views/outgoing_mailer/initial_request.text.erb
+++ b/lib/views/outgoing_mailer/initial_request.text.erb
@@ -1,0 +1,13 @@
+<%= raw @outgoing_message.body.strip %>
+
+-------------------------------------------------------------------
+
+<%= _('Please use this email address for all replies to this request:')%>
+<%= @info_request.incoming_email %>
+
+<%= _('Is {{email_address}} the wrong address for {{type_of_request}} requests to {{public_body_name}}? If so, please contact us using this form:', :email_address => @info_request.public_body.request_email, :type_of_request =>  @info_request.law_used_full, :public_body_name => @info_request.public_body.name)%>
+<%= new_change_request_url(:body => @info_request.public_body.url_name) %>
+
+<%= render :partial => 'followup_footer' %>
+
+-------------------------------------------------------------------

--- a/lib/views/outgoing_mailer/initial_request.text.erb
+++ b/lib/views/outgoing_mailer/initial_request.text.erb
@@ -2,8 +2,8 @@
 
 -------------------------------------------------------------------
 
-<%= _('Please use this email address for all replies to this request:')%>
-<%= @info_request.incoming_email %>
+<%= _('Please use this email address for all replies to this request:')%> <%= @info_request.incoming_email %>
+<%= _(' This email address satisfies s.15(2)(c) of the Freedom of Information Act.')%>
 
 <%= _('Is {{email_address}} the wrong address for {{type_of_request}} requests to {{public_body_name}}? If so, please contact us using this form:', :email_address => @info_request.public_body.request_email, :type_of_request =>  @info_request.law_used_full, :public_body_name => @info_request.public_body.name)%>
 <%= new_change_request_url(:body => @info_request.public_body.url_name) %>


### PR DESCRIPTION
My suggested fix of #352 

I've made the email signature read like this:

<b> Initial Request </b>

<i>Please use this email address for all replies to this request: [FOI Request Email]@righttoknow.org.au
This email address satisfies s.15(2)(c) of the Freedom of Information Act.

<i>Is [FOI Contact Address] the wrong address for Freedom of Information requests to Right to Know? If so, please contact us using this form: http://test.righttoknow.org.au/change_request/new?body=rtk

<i>Disclaimer: The views expressed in this request are those of the sender, and are not endorsed by Right to Know or the OpenAustralia Foundation.

<i>This message and any reply that you make will be published on the internet. More Information can be found at http://test.righttoknow.org.au/help/officers</i>

<b> Follow-Up Messages </b>

<i>Please use this email address for all replies to this request: [FOI Request Email]@righttoknow.org.au

<i>Disclaimer: The views expressed in this request are those of the sender, and are not endorsed by Right to Know or the OpenAustralia Foundation.

<i>This message and any reply that you make will be published on the internet. More Information can be found at http://test.righttoknow.org.au/help/officers
