### PR TITLE
#384 - Add contact@righttoknow recipients to contact page

### DIFF
--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -1,0 +1,101 @@
+<% @title = "Contact us" %>
+
+<%= foi_error_messages_for :contact %>
+
+<h1><%= @title %></h1>
+
+<div id="contact_preamble">
+
+    <% if !flash[:notice] %>
+        <h2>Contact an authority to get official information</h2>
+        <ul>
+            <li><a href="<%= new_request_path %>">Go here</a> to make a request, in public, for information
+            from public authorities.</li>
+
+            <li>
+            Asking for private information about yourself?
+            Please read our
+            <a href="<%= help_requesting_path(:anchor => 'data_protection') %>">help page</a>.
+            </li>
+        </ul>
+
+    <% end %>
+
+    <h2>Contact the <%= site_name %> team</h2>
+    <% if !flash[:notice] %>
+            <ul>
+            <li>
+            Please read the  <a href="<%= help_about_path %>">help page</a> first, as it may
+            answer your question quicker.
+            </li>
+
+            <li>We'd love to hear how you've found using this site.
+               Either fill in this form, or send an email to <a
+               href="mailto:<%=@contact_email%>"><%=@contact_email%></a>
+            </li>
+
+            <li>We are a <strong>charity</strong> and not part of the
+            Government.</li>
+            </ul>
+    <% end %>
+</div>
+
+<%= form_for :contact do |f| %>
+
+    <% if not @user %>
+        <p>
+            <label class="form_label" for="contact_name">Your name:</label>
+            <%= f.text_field :name, :size => 20 %>
+            (or <%= link_to "sign in", signin_path(:r => request.fullpath) %>)
+        </p>
+
+        <p>
+            <label class="form_label" for="contact_email">Your email:</label>
+            <%= f.text_field :email, :size => 20 %>
+        </p>
+    <% end %>
+
+    <p>
+        <label class="form_label" for="contact_subject">Subject:</label>
+        <%= f.text_field :subject, :size => 50 %>
+    </p>
+
+    <p>
+        <label class="form_label" for="contact_message">Message to website:</label>
+        <%= f.text_area :message, :rows => 10, :cols => 60 %>
+    </p>
+
+    <p style="display:none;">
+        <%= f.label :comment, 'Do not fill in this field' %>
+        <%= f.text_field :comment %>
+    </p>
+
+    <% if !@last_request.nil? %>
+        <p>
+            <label class="form_label" for="contact_message">Include link to request:</label>
+            <%=request_link(@last_request) %>
+            <%= submit_tag "remove", :name => 'remove' %>
+        </p>
+    <% end %>
+    <% if !@last_body.nil? %>
+        <p>
+            <label class="form_label" for="contact_message">Include link to authority:</label>
+            <%=public_body_link(@last_body) %>
+            <%= submit_tag "remove", :name => 'remove' %>
+        </p>
+    <% end %>
+
+    <p class="form_note">
+    We can only help you with <strong>technical problems</strong>, or questions
+    about Freedom of Information.
+    </P>
+
+
+    <div class="form_button">
+        <%= hidden_field_tag(:submitted_contact_form, 1) %>
+        <%= submit_tag "Send message to the charity", :disable_with => "Sending..." %>
+        &lt;-- we run this site, not the Government!
+    </div>
+
+<% end %>
+

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -33,8 +33,10 @@
                Either fill in this form, or send an email to
                <a href="mailto:<%=@contact_email%>"><%=@contact_email%></a>.
 
-               <p> When you get in touch with us (either by email at <%=@contact_email%> or by
-                 using the form below) a copy is sent to the following people:
+               <p>
+                   When you get in touch with us (either by email at <%=@contact_email%> or by
+                   using the form below) a copy is sent to the following people:
+               </p>
                <ul>
                     <li>Ben Fairless (ben@righttoknow.org.au)</li>
                     <li>Brendan Molloy (brendan@righttoknow.org.au)</li>
@@ -42,7 +44,7 @@
                     <li>Katherine Szuminska (kat@righttoknow.org.au)</li>
                     <li>Luke Bacon (luke@oaf.org.au)</li>
                     <li>Matthew Landauer (matthew@righttoknow.org.au)</li>
-                </ul></p>
+                </ul>
                 <p>
                 Having a group contact email address is a really useful thing. There's less
                 chance that something important will be missed if one of us is away from our computer.

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -31,7 +31,24 @@
 
             <li>We'd love to hear how you've found using this site.
                Either fill in this form, or send an email to <a
-               href="mailto:<%=@contact_email%>"><%=@contact_email%></a>
+               href="mailto:<%=@contact_email%>"><%=@contact_email%></a>. 
+               
+               When you email us at <%=@contact_email%> your emails go to the following people:
+               <ul>
+                    <li>Ben Fairless (ben@righttoknow.org.au)</li>
+                    <li>Brendan Molloy (brendan@righttoknow.org.au)</li>
+                    <li>Henare Degan (henare@oaf.org.au)</li>
+                    <li>Katherine Szuminska (kat@righttoknow.org.au)</li>
+                    <li>Luke Bacon (luke@oaf.org.au)</li>
+                    <li>Matthew Landauer (matthew@righttoknow.org.au)</li>
+                </ul></p>
+                <p>
+                Having a group contact email address is a really useful thing. There's less
+                chance that something important will be missed if one of us is away from our computer.
+                That said, we feel it's important that you can put names to the people behind the email address.
+                That's transparency!
+                </p>
+                
             </li>
 
             <li>We are a <strong>charity</strong> and not part of the

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -29,15 +29,16 @@
             answer your question quicker.
             </li>
 
-            <li>We'd love to hear how you've found using this site.
-               Either fill in this form, or send an email to
-               <a href="mailto:<%=@contact_email%>"><%=@contact_email%></a>.
+            <li>
+                We'd love to hear how you've found using this site.
+                Either fill in this form, or send an email to
+                <a href="mailto:<%=@contact_email%>"><%=@contact_email%></a>.
 
-               <p>
-                   When you get in touch with us (either by email at <%=@contact_email%> or by
-                   using the form below) a copy is sent to the following people:
-               </p>
-               <ul>
+                <p>
+                    When you get in touch with us (either by email at <%=@contact_email%> or by
+                    using the form below) a copy is sent to the following people:
+                </p>
+                <ul>
                     <li>Ben Fairless (ben@righttoknow.org.au)</li>
                     <li>Brendan Molloy (brendan@righttoknow.org.au)</li>
                     <li>Henare Degan (henare@oaf.org.au)</li>
@@ -46,12 +47,11 @@
                     <li>Matthew Landauer (matthew@righttoknow.org.au)</li>
                 </ul>
                 <p>
-                Having a group contact email address is a really useful thing. There's less
-                chance that something important will be missed if one of us is away from our computer.
-                That said, we feel it's important that you can put names to the people
-                behind the email address. That's transparency!
+                    Having a group contact email address is a really useful thing. There's less
+                    chance that something important will be missed if one of us is away from our computer.
+                    That said, we feel it's important that you can put names to the people
+                    behind the email address. That's transparency!
                 </p>
-
             </li>
 
             <li>We are a <strong>charity</strong> and not part of the

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -30,10 +30,11 @@
             </li>
 
             <li>We'd love to hear how you've found using this site.
-               Either fill in this form, or send an email to <a
-               href="mailto:<%=@contact_email%>"><%=@contact_email%></a>. 
-               
-               When you email us at <%=@contact_email%> your emails go to the following people:
+               Either fill in this form, or send an email to
+               <a href="mailto:<%=@contact_email%>"><%=@contact_email%></a>.
+
+               <p> When you get in touch with us (either by email at <%=@contact_email%> or by
+                 using the form below) a copy is sent to the following people:
                <ul>
                     <li>Ben Fairless (ben@righttoknow.org.au)</li>
                     <li>Brendan Molloy (brendan@righttoknow.org.au)</li>
@@ -45,10 +46,10 @@
                 <p>
                 Having a group contact email address is a really useful thing. There's less
                 chance that something important will be missed if one of us is away from our computer.
-                That said, we feel it's important that you can put names to the people behind the email address.
-                That's transparency!
+                That said, we feel it's important that you can put names to the people
+                behind the email address. That's transparency!
                 </p>
-                
+
             </li>
 
             <li>We are a <strong>charity</strong> and not part of the
@@ -115,4 +116,3 @@
     </div>
 
 <% end %>
-


### PR DESCRIPTION
fixes #384

Adding everyone to the contact page. Can you check that you're happy with the wording, I'll need to test it tonight (don't have my laptop with me at the moment).
