### PR TITLE
Help Text Updates to #missing_body on the help/requesting page

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -59,8 +59,8 @@ The Freedom of Information Act simply says that "every person has a legally enfo
 <dt id="missing_body">You're missing the public authority that I want to request from! <a href="#missing_body">#</a> </dt>
 
 <dd>
-<p>At the moment we aim to cover all Australian Federal public authorities. We plan to add State and Local Government authorities soon.</p>
-<p>Please <a href="/change_request/new">contact us</a> with the name of the public authority and,
+<p>At the moment we aim to cover public authorities in the Australian Federal Government and the ACT. We plan to add more State and Local Government authorities soon.</p>
+<p>If we are missing an authority from the Federal Government or the ACT, please <a href="/change_request/new">contact us</a> with the name of the public authority and,
 if you can find it, their contact email address for Freedom of Information requests.
 </p>
 <p>If you'd like to help add a whole category (new state or local government region etc.) of public authority to the site, we'd love


### PR DESCRIPTION
Fixes #399, changes the text from:

> At the moment we aim to cover all Australian Federal public authorities. We plan to add State and Local Government authorities soon.
> 
> Please contact us with the name of the public authority and, if you can find it, their contact email address for Freedom of Information requests.

To:

> At the moment we aim to cover public authorities in the Australian Federal Government and the ACT. We plan to add more State and Local Government authorities soon.
> 
> If we are missing an authority from the Federal Government or the ACT, please contact us with the name of the public authority and, if you can find it, their contact email address for Freedom of Information requests.
