### PR TITLE
Add magnifying glass icon back to header search bar

### DIFF
--- a/assets/stylesheets/custom.css.scss
+++ b/assets/stylesheets/custom.css.scss
@@ -218,7 +218,7 @@ color:#005068;
 
 #navigation_search input#navigation_search_query {
   border-color: #888;
-  background-image: image-url('search-icon.png') no-repeat left center;
+  background: image-url('search-icon.png') no-repeat left center;
   background-color: white;
   padding-left: 2em;
   border-radius: 5px;


### PR DESCRIPTION
There was an error in the background image syntax.

Before:
![screen shot 2015-03-03 at 5 01 40 pm](https://cloud.githubusercontent.com/assets/1239550/6457249/15218b74-c1c7-11e4-82e3-55babe1d16bf.png)

After:
![screen shot 2015-03-03 at 5 01 44 pm](https://cloud.githubusercontent.com/assets/1239550/6457246/0ae140e6-c1c7-11e4-942b-6107bc08596e.png)

fixes #347
