### PR TITLE
Wording change on the "Select an Authority Page"

### DIFF
--- a/locale-theme/en/app.po
+++ b/locale-theme/en/app.po
@@ -22,7 +22,7 @@ msgid "<strong><code>requested_from:home_office</code></strong> to search reques
 msgstr "<strong><code>requested_from:abc</code></strong> to search requests from the Australian Broadcasting Corporation, typing the name as in the URL."
 
 msgid "First, type in the <strong>name of the UK public authority</strong> you'd\\n           like information from. <strong>By law, they have to respond</strong>\\n           (<a href=\"{{url}}\">why?</a>)."
-msgstr "First, type in the <strong>name of the Australian public authority</strong> you'd\\n           like information from. <strong>By law, they have to respond</strong>\\n           (<a href=\"{{url}}\">why?</a>)."
+msgstr "First, type in the <strong>name of the Australian Federal Government or ACT Government authority</strong> you'd\\n           like information from. <strong>By law, they have to respond</strong>\\n           (<a href=\"{{url}}\">why?</a>)."
 
 msgid "Ask for <strong>specific</strong> documents or information, this site is not suitable for general enquiries."
 msgstr "Ask for <strong>specific documents</strong>, this site is not suitable for general enquiries (<a href="/help/requesting#documents">why?</a>)."


### PR DESCRIPTION
This changes the wording on the Making Request/Select Authority page from:

> First, type in the <strong>name of the Australian public authority</strong> you'd like information from. <strong>By law, they have to respond</strong>

To:

> First, type in the <strong>name of the Australian Federal Government or ACT Government authority</strong> you'd like information from. <strong>By law, they have to respond</strong>

This emphasises who we cover when someone goes to make a request.
