### PR TITLE
Fix url encoding of font link href

### DIFF
--- a/lib/views/general/_before_head_end.html.erb
+++ b/lib/views/general/_before_head_end.html.erb
@@ -1,1 +1,1 @@
-<link href='https://fonts.googleapis.com/css?family=Maven+Pro:400,700|Actor' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Maven+Pro:400,700%7CActor' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
The pipe character in the google fonts url was stopping the home page from validating, showing:

> Error Line 31, Column 118: Bad value https://fonts.googleapis.com/css?family=Maven+Pro:400,700|Actor for attribute href on element link: Illegal character in query: not a URL code point.

on the [w3c validator](http://validator.w3.org/check?uri=http%3A%2F%2Frighttoknow.org.au%2F&charset=%28detect+automatically%29&doctype=Inline&group=0).
This commit encodes the pipe character. I've tested that the source validates using the direct input option.

fixes #375
