### PR TITLE
Remove "You Can" from Help pages

### DIFF
--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -43,7 +43,7 @@
   </dd>
 
   <dt id="who">Who makes <%= site_name %>? <a href="#who">#</a> </dt>
-  <dd><%= site_name %> is a project of the OpenAustralia Foundation, a charity, and was developed with software by the UK organisation mySociety. It was made possible by a <a href="https://www.openaustraliafoundation.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation from Guy King</a>. If you like what we're doing, then you can <a href="https://www.openaustraliafoundation.org.au/donate/righttoknow/">make a donation</a>.
+  <dd><%= site_name %> is a project of the OpenAustralia Foundation, a charity, and was developed with software by the UK organisation mySociety. It was made possible by a <a href="https://www.openaustraliafoundation.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation from Guy King</a>. If you like what we're doing, then please consider <a href="https://www.openaustraliafoundation.org.au/donate/righttoknow/">making a donation</a>.
   </dd>
 
   <dt id="updates">How can I keep up with news about <%= site_name %>? <a href="#updates">#</a> </dt>

--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -43,10 +43,7 @@
   </dd>
 
   <dt id="who">Who makes <%= site_name %>? <a href="#who">#</a> </dt>
-  <dd><%= site_name %> is a project of the OpenAustralia Foundation, a charity,
-    and was developed with software by the UK organisation mySociety. It was made possible by a
-    <a href="https://www.openaustraliafoundation.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation from Guy King</a>. 
-    If you like what we're doing, then please consider <a href="https://www.openaustraliafoundation.org.au/donate/righttoknow/">making a donation</a>.
+  <dd><%= site_name %> is a project of the OpenAustralia Foundation, a charity, and was developed with software by the UK organisation mySociety. It was made possible by a <a href="https://www.openaustraliafoundation.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation from Guy King</a>. If you like what we're doing, then you can <a href="https://www.openaustraliafoundation.org.au/donate/righttoknow/">make a donation</a>.
   </dd>
 
   <dt id="updates">How can I keep up with news about <%= site_name %>? <a href="#updates">#</a> </dt>

--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -43,7 +43,10 @@
   </dd>
 
   <dt id="who">Who makes <%= site_name %>? <a href="#who">#</a> </dt>
-  <dd><%= site_name %> is a project of the OpenAustralia Foundation, a charity, and was developed with software by the UK organisation mySociety. It was made possible by a <a href="https://www.openaustraliafoundation.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation from Guy King</a>. If you like what we're doing, then you can <a href="https://www.openaustraliafoundation.org.au/donate/righttoknow/">make a donation</a>.
+  <dd><%= site_name %> is a project of the OpenAustralia Foundation, a charity,
+    and was developed with software by the UK organisation mySociety. It was made possible by a
+    <a href="https://www.openaustraliafoundation.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation from Guy King</a>. 
+    If you like what we're doing, then please consider <a href="https://www.openaustraliafoundation.org.au/donate/righttoknow/">making a donation</a>.
   </dd>
 
   <dt id="updates">How can I keep up with news about <%= site_name %>? <a href="#updates">#</a> </dt>

--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -19,10 +19,10 @@ lots of things that are similar in use to an API as they are requested.
 
 <h2> 1. Linking to new requests </h2>
 
-<p>To assist users in making new requests you can link to a pre-filled request form. The details of which public authority the request is addressed to and the contents of the body of the request message are part of the URL.</p>
+<p>To assist users in making new requests it's possible to link to a pre-filled request form. The details of which public authority the request is addressed to and the contents of the body of the request message are part of the URL.</p>
 
 <p>A link to a new request for a particular public authority, uses a URL of the form
-<%= link_to new_request_to_body_url(:url_name => "defence") , new_request_to_body_url(:url_name => "defence") %>. 
+<%= link_to new_request_to_body_url(:url_name => "defence") , new_request_to_body_url(:url_name => "defence") %>.
 These are the <%= link_to "parameters", "http://en.wikipedia.org/wiki/URL", :title => "Wikipedia entry for URL including information on URL syntax" %> you can add to those URLs, either in a normal hyperlink or through a form.</p>
 
 <ul>

--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -32,7 +32,7 @@ These are the <%= link_to "parameters", "http://en.wikipedia.org/wiki/URL", :tit
     <li> <strong>tags</strong> - space separated list of tags, so it's possible to find and link up any requests made later, e.g. <em>openlylocal spending_id:12345</em>. The : indicates it is a machine tag. The values of machine tags may also include colons, useful for URIs.
 </ul>
 
-<p>Text added to these URLs must be <em><%= link_to "URL encoded", "http://en.wikipedia.org/wiki/Percent-encoding", :title => "Wikipedia entry for Percent-Encoding" %></em>. You can use the <%= link_to "URL Decoder/Encoder at meyerweb.com", "http://meyerweb.com/eric/tools/dencoder/", :title => "URL Decoder/Encoder" %> as a tool to help encode your text.</p>
+<p>Text added to these URLs must be <em><%= link_to "URL encoded", "http://en.wikipedia.org/wiki/Percent-encoding", :title => "Wikipedia entry for Percent-Encoding" %></em>. The <%= link_to "URL Decoder/Encoder at meyerweb.com", "http://meyerweb.com/eric/tools/dencoder/", :title => "URL Decoder/Encoder" %> is a useful tool to help encode your text.</p>
 
 <p>Within a URL, multiple parameters are divided with ampersand "&amp;". For example, the following link uses both the <strong>title</strong> and <strong>default_letter</strong> paramaters: <%= link_to new_request_to_body_url(:url_name => "defence", :title => "Test Request", :default_letter => "Test request body"), new_request_to_body_url(:url_name => "defence", :title => "Test Request", :default_letter => "Test request body") %> </p>
 

--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -23,7 +23,7 @@ lots of things that are similar in use to an API as they are requested.
 
 <p>A link to a new request for a particular public authority, uses a URL of the form
 <%= link_to new_request_to_body_url(:url_name => "defence") , new_request_to_body_url(:url_name => "defence") %>.
-These are the <%= link_to "parameters", "http://en.wikipedia.org/wiki/URL", :title => "Wikipedia entry for URL including information on URL syntax" %> you can add to those URLs, either in a normal hyperlink or through a form.</p>
+These are the <%= link_to "parameters", "http://en.wikipedia.org/wiki/URL", :title => "Wikipedia entry for URL including information on URL syntax" %> that can be added to those URLs, either in a normal hyperlink or through a form.</p>
 
 <ul>
     <li> <strong>title</strong> - default summary of the new request.</li>

--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -40,8 +40,8 @@ These are the <%= link_to "parameters", "http://en.wikipedia.org/wiki/URL", :tit
 
 <h2> 2. RSS (actually, Atom) feeds </h2>
 
-<p>There are Atom feeds on most pages which list requests, which you can
-use to get updates and links in XML format. Find the URL of the Atom feed in
+<p>There are Atom feeds on most pages which list requests, which make it easy
+to get updates and links in XML format. Find the URL of the Atom feed in
 one of these ways: 
 <ul>
     <li>Look for the <img src="/images/feed-16.png" alt=""> RSS feed links.</li>

--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -29,7 +29,7 @@ These are the <%= link_to "parameters", "http://en.wikipedia.org/wiki/URL", :tit
     <li> <strong>title</strong> - default summary of the new request.</li>
     <li> <strong>default_letter</strong> - default text of the body of the letter. The salutation (Dear...) and signoff (Yours...) are wrapped round this. </li>
     <li> <strong>body</strong> - as an alternative to default_letter, this sets the default entire text of the request, so you can customise the salutation and signoff. </li>
-    <li> <strong>tags</strong> - space separated list of tags, so you can find and link up any requests made later, e.g. <em>openlylocal spending_id:12345</em>. The : indicates it is a machine tag. The values of machine tags may also include colons, useful for URIs.
+    <li> <strong>tags</strong> - space separated list of tags, so it's possible to find and link up any requests made later, e.g. <em>openlylocal spending_id:12345</em>. The : indicates it is a machine tag. The values of machine tags may also include colons, useful for URIs.
 </ul>
 
 <p>Text added to these URLs must be <em><%= link_to "URL encoded", "http://en.wikipedia.org/wiki/Percent-encoding", :title => "Wikipedia entry for Percent-Encoding" %></em>. You can use the <%= link_to "URL Decoder/Encoder at meyerweb.com", "http://meyerweb.com/eric/tools/dencoder/", :title => "URL Decoder/Encoder" %> as a tool to help encode your text.</p>

--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -50,7 +50,7 @@ one of these ways:
 </ul>
 
 <p>In particular, even complicated search queries have Atom feeds.
-You can do all sorts of things with them, such as query by authority, by file
+You're able to do all sorts of things with them, such as query by authority, by file
 type, by date range, or by status. See the <%= link_to "advanced search tips", advanced_search_path %>
 for details.
 

--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -28,7 +28,7 @@ These are the <%= link_to "parameters", "http://en.wikipedia.org/wiki/URL", :tit
 <ul>
     <li> <strong>title</strong> - default summary of the new request.</li>
     <li> <strong>default_letter</strong> - default text of the body of the letter. The salutation (Dear...) and signoff (Yours...) are wrapped round this. </li>
-    <li> <strong>body</strong> - as an alternative to default_letter, this sets the default entire text of the request, so you can customise the salutation and signoff. </li>
+    <li> <strong>body</strong> - as an alternative to default_letter, this sets the default entire text of the request, so it's possible to customise the salutation and signoff. </li>
     <li> <strong>tags</strong> - space separated list of tags, so it's possible to find and link up any requests made later, e.g. <em>openlylocal spending_id:12345</em>. The : indicates it is a machine tag. The values of machine tags may also include colons, useful for URIs.
 </ul>
 

--- a/lib/views/help/credits.html.erb
+++ b/lib/views/help/credits.html.erb
@@ -60,7 +60,7 @@
 <dd>
     <p>Yes please! We're built out of our supporters and volunteers.</p>
     <ul>
-    <li>You can <a href="https://www.openaustraliafoundation.org.au/donate/righttoknow/">make a donation</a>. We're a charity with Deductible Gift Recipient (DGR) status. That means your donation is tax-deductible.</li>
+    <li>Please consider <a href="https://www.openaustraliafoundation.org.au/donate/righttoknow/">making a donation</a>. We're a charity with Deductible Gift Recipient (DGR) status. That means your donation is tax-deductible.</li>
     <li>Help people find successful requests, and monitor performance of authorities, by
     <a href="/categorise/play">playing the categorisation game</a>. </li>
     <li>Find out the Freedom of Information email addresses of <a href="/help/requesting#missing_body">authorities that we're missing</a>.</li>

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -26,8 +26,8 @@
 <dd><p><%= site_name %> is a service run by a charity. It helps ordinary members
 of the public make FOI requests, and easily track and share the responses.</p>
 
-<p>The FOI request you received was made by someone using <%= site_name %>. You can
-simply reply to the request as you would any other request from an individual.
+<p>The FOI request you received was made by someone using <%= site_name %>.
+All you need to do is reply to the request as you would any other request from an individual.
 The only difference is that your response will be automatically published on
 the Internet.
 </p>

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -34,7 +34,7 @@ the Internet.
 <p>If you have privacy or other concerns, please read the answers below.
 You might also like to read the <a
 href="/help/about">introduction to <%= site_name %></a> to find out more about what
-the site does from the point of view of someone requesting information. You can also search the
+the site does from the point of view of someone requesting information. We also suggest searching the
 site to find the authority that you work for, and view the status of
 any requests made using the site.
 

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -87,7 +87,7 @@ for you to see if one of our users is making vexatious requests. </p>
 
 <dd><p>If a request appears on the site, then we have attempted to send it to
 the authority by email. Any delivery failure messages will automatically
-appear on the site. You can check the address we're using with the "View FOI
+appear on the site. We strongly suggest you check the address we're using with the "View FOI
 email address" link which appears on the page for the authority. <a
 href="/help/contact">Contact us</a> if there is a better address we can
 use.</p>

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -68,7 +68,7 @@ publish it widely.
 <dd>Yes. For the purposes of keeping track of responses we use
 computer-generated email addresses for each request. However, before
 they can send a request, each user must register on the site with a
-unique email address that we then verify. You can search this site and
+unique email address that we then verify. It's possible to search this site and
 find a page listing all requests that each person has made.
 </dd>
 

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -121,10 +121,10 @@ each request page.
 
 <dt id="large_file">How can I send a large file, which won't go by email? <a href="#large_file">#</a> </dt>
 
-<dd>Instead of email, you can respond to a request directly from your web
-browser, including uploading a file. To do this, choose "respond to request" at
-the bottom of the request's page. <a href="/help/contact">Contact us</a> if it
-is too big for even that (more than, say, 50Mb).
+<dd>We encourage authorities who need to send large files to respond to a request directly from your web
+browser, as this provides the ability to upload files which can't be sent via email.
+To do this, choose "respond to request" at the bottom of the request's page.
+<a href="/help/contact">Contact us</a> if it is too big for even that (more than, say, 50Mb).
 </dd>
 
 <dt id="names">Why do you publish the names of public servants and the text of emails? <a href="#names">#</a> </dt>

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -66,7 +66,7 @@ get in touch with you to assist you with your research or to campaign with you.
 <dt id="real_name">Can I make a Freedom of Information request using a pseudonym? <a href="#real_name">#</a> </dt>
 
 <dd>
-<p>Yes, you can use a pseudonym. Be careful though. It might make it impossible to follow up if you think a decision needs to be reviewed.</p>
+<p>Generally, there are no issues with using a pseudonym. Be careful though. It might make it impossible to follow up if you think a decision needs to be reviewed.</p>
 
 <p>The Federal Information Commissioner guidelines <a href="http://www.oaic.gov.au/freedom-of-information/applying-the-foi-act/foi-guidelines/part-3-processing-requests-for-access#right">say</a> that "The FOI Act does not require an applicant to disclose or provide proof of their identity" but that the "agency or minister should consider whether collection of information about the applicant's identity is required to assess the request".</p>
 

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -89,9 +89,7 @@ get in touch with you to assist you with your research or to campaign with you.
 <p>
   If an authority only has a paper copy of the information that you want,
   they may ask you for a postal address. To start with, ask them
-  to scan in the documents for you. You can even offer to gift them a scanner,
-  which in one particular case embarrassed the organisation into finding one
-  they had already.
+  to scan in the documents for you.
 </p>
 <p>
   If they claim it's becase they want to send you large files, like a video

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -38,7 +38,7 @@ relating to a request you made, an email alert that you have signed up for,
 or for other reasons that you specifically authorise. </p>
 
 <p>You will also receive emails from the <a href="https://www.openaustraliafoundation.org.au/">OpenAustralia Foundation</a>,
-the charity that runs <%= site_name %>. You can unsubscribe from these emails without affecting any alerts from <%= site_name %>. </p>
+the charity that runs <%= site_name %>. It's possible to unsubscribe from these emails without affecting any alerts from <%= site_name %>. </p>
 
 <p> We will never give or sell your email addresses to anyone else, unless we are obliged
 to by law, or you ask us to.</p>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -202,8 +202,8 @@ spent on marshmallows in the past year than in the past ten years.
 </p>
 
 <p>
-  <%= site_name %> will email you if you don't get a timely response.  You can
-  then send the public authority a message to remind them, and tell them if they
+  <%= site_name %> will email you if you don't get a timely response. We suggest that you
+  send the public authority a message to remind them, and tell them if they
   are breaking the law.
 </p>
 

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -212,7 +212,7 @@ spent on marshmallows in the past year than in the past ten years.
 <dt id="no_response">What if I never get a response? <a href="#no_response">#</a> </dt>
 
 <dd>
-<p>There are several things you can do if you never get a response.</p>
+<p>Don't panic! There are several reasons why an authority may not have responded to your request.</p>
 <ul>
     <li>Sometimes there has been a genuine problem and the authority never
     received the request. It is worth telephoning the authority and politely

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -223,7 +223,7 @@ spent on marshmallows in the past year than in the past ten years.
     '<a href="/help/officers#spam_problems">I can see a request on <%= site_name %>, but we never got it by email!</a>'
     in the FOI officers section of this help.
     </li>
-    <li>If you're still having no luck, then you can ask for an internal review,
+    <li>If you're still having no luck, then it may be possible to ask for an internal review,
     or complain to an Information Commissioner, Ombudsman, or Tribunal about the authority, or both.
     Read our page '<a href="/help/unhappy">Unhappy about the response you got?</a>'.
 </ul>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -296,8 +296,7 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
   <p>
     If you'd like to request personal information you must do so privately by
     asking the public authority directly. Agencies will often give you this
-    information when you ask for it or you can formally request it using a
-    relevant law.
+    information when you ask for it, however in some cases a formal request may be required.
   </p>
 
   <p>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -294,7 +294,7 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
   </p>
 
   <p>
-    If you'd like to request personal information you can do so privately by
+    If you'd like to request personal information you must do so privately by
     asking the public authority directly. Agencies will often give you this
     information when you ask for it or you can formally request it using a
     relevant law.

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -254,8 +254,8 @@ then read our page '<a href="/help/unhappy">Unhappy about the response you got?<
   </p>
 </blockquote>
 
-<p>You can, of course, write articles about the information or summarise it, or
-quote parts of it. We also think you should feel free to republish the
+<p>Generally, there are no issues with writing articles about the information or summarising it, or
+quoting parts of it. We also think you should feel free to republish the
 information in full, just as we do, even though in theory you might not be
 allowed to do so.  See <a href="/help/officers#copyright">our policy on copyright</a>.</p>
 

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -119,8 +119,7 @@ run your campaign, we encourage you to use it to get the information you
 need. We also encourage to run your campaign elsewhere - one effective
 and very easy way is to <%= link_to 'start your own blog',
 "https://wordpress.com/"%>. You are welcome to link to your campaign
-from this site in an annotation to your request (you can make
-annotations after submitting the request).
+from this site in an annotation to your request.
 </p>
 
 </dd>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -174,7 +174,7 @@ keep your request focused</a> and ask for specific existing documents.
 </ul>
 
 <p>Sometimes an authority will refuse your request, saying that the cost
-of handling it exceeds a level that would detriment their day to day work. At this point you can refine your
+of handling it exceeds a level that would detriment their day to day work. At this point you have the opportunity to refine your
 request. e.g. it would be much cheaper for an authority to tell you the amount
 spent on marshmallows in the past year than in the past ten years.
 </p>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -61,7 +61,7 @@ The Freedom of Information Acts simply say that "every person has a legally enfo
 <dd>
 <p>At the moment we aim to cover public authorities in the Australian Federal Government and the ACT. We plan to add more State and Local Government authorities soon.</p>
 <p>If we are missing an authority from the Federal Government or the ACT, please <a href="/change_request/new">contact us</a> with the name of the public authority and,
-if you can find it, their contact email address for Freedom of Information requests.
+where possible, their contact email address for Freedom of Information requests
 </p>
 <p>If you'd like to help add a whole category (new state or local government region etc.) of public authority to the site, we'd love
 to hear from you too.

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -334,7 +334,7 @@ to the other authorities, you must copy and paste it by hand.
 and does not try to be an archive of all Freedom of Information requests. We'll never support uploading
 other requests. For one thing, we wouldn't be able to verify that other
 responses actually came from the authority. If this really matters to you,
-you can always make the same request again via <%= site_name %>.
+please consider making the same request again via <%= site_name %>.
 </dd>
 
 <dt id="moderation">How do you moderate request annotations? <a href="#moderation">#</a> </dt>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -44,7 +44,7 @@ to your request '<%=request_link(@info_request) %>'?
 
 <p>
   If you are still unhappy after the public authority has done their internal review,
-  then you can contact an external reviewer to review the decision or make a complaint.
+  then contact an external reviewer to review the decision or make a complaint.
   You don't have to go through an internal review before going to an external reviewer
   but they usually recommend it.
 </p>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -96,7 +96,7 @@ then make Freedom of Information requests to them.</li>
 finding the answer. MPs can write directly to ministers or departments, and
 can ask written questions in Parliament.</li>
 <li>Ask <strong>other researchers</strong> who are interested in a similar
-issue to yours for ideas. You can sometimes find them by browsing this site;
+issue to yours for ideas. Sometimes you'll find them by browsing this site;
 contact any registered user from their page. There may be an Internet
 forum or group that they hang out in.</li>
 </ul>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -84,7 +84,7 @@ in your complaint or print out the whole page of your request and all attachment
 
 <h1 id="other_means">3. Using other means to answer your question <a class="hover_a" href="#other_means">#</a> </h1>
 
-<p>You can try persuing your problem or your research in other ways.
+<p>Sometimes, it's better to try persuing your problem or your research in other ways.
 
 <ul>
 <li>Make a <strong>new Freedom of Information request</strong> for summary information, or for

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -61,7 +61,7 @@ to your request '<%=request_link(@info_request) %>'?
     <a href="http://www.oaic.gov.au/freedom-of-information/foi-reviews">Information Commissioner</a>.
   </li>
   <li>
-    For <strong>ACT Authorities</strong>, you can complain to the
+    For <strong>ACT Authorities</strong>, it's best to escalate to the
     <a href="http://ombudsman.act.gov.au/pages/making-a-complaint/complaints-the-ombudsman-can-investigate/freedom-of-information.php">Ombudsman</a>.
   </li>
 </ul>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -51,7 +51,7 @@ to your request '<%=request_link(@info_request) %>'?
 
 <p>
   Who you should contact for an external review depends on what law governs the authority you
-  requested information from. If you need a hand, you can always
+  requested information from. If you need a hand, please feel free to
   <%= link_to "contact us", help_contact_path %>.
 </p>
 

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -79,7 +79,7 @@ in your complaint or print out the whole page of your request and all attachment
 
 <p>
   <%= site_name %> has no special facilities for handling a review at this stage.
-  You can leave annotations on your request keeping people informed of progress.
+  It's a good idea to leave annotations on your request if you want to keep people informed of the progress of your external review.
 </p>
 
 <h1 id="other_means">3. Using other means to answer your question <a class="hover_a" href="#other_means">#</a> </h1>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -17,7 +17,7 @@ to your request '<%=request_link(@info_request) %>'?
 <li>Your request was refused, but without a reason valid under the law</li>
 </ul>
 
-<p>... you can</p>
+<p>... you have a few options:</p>
 
 <ol>
 <li>Ask for an <strong>internal review</strong> at the public authority.</li>

--- a/lib/views/user/_signup.html.erb
+++ b/lib/views/user/_signup.html.erb
@@ -10,7 +10,7 @@
         <%= text_field 'user_signup', 'email', { :size => 20, :tabindex => 60 } %>
     </p>
     <div class="form_item_note">
-        <%= _('You can find out on how we use your email address on our
+        <%= _('Find out on how we use your email address on our
          <a href="{{url}}">privacy page</a>. ', :url => help_privacy_path) %>
     </div>
 


### PR DESCRIPTION
This PR fixes #420. It is currently a work in progress.
