### PR TITLE
Change "Unhappy" help page - External Review

### DIFF
--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -78,7 +78,7 @@ in your complaint or print out the whole page of your request and all attachment
 </p>
 
 <p>
-  <%= site_name %> has no special facilities for handling a review at this stage.
+  <%= site_name %> has no special facilities for handling an external review at this stage.
   You can leave annotations on your request keeping people informed of progress.
 </p>
 


### PR DESCRIPTION
Minor change that clarifies that RTK has no special facilities for handling _external_ reviews. We support internal reviews!
