### PR TITLE
Flexibility in "name" of request type (#428)

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -5,11 +5,4 @@
 # See http://stackoverflow.com/questions/7072758/plugin-not-reloading-in-development-mode
 #
 Rails.configuration.to_prepare do
-    OutgoingMessage.class_eval do
-        # Add intro paragraph to new request template
-        def default_letter
-            return nil if self.message_type == 'followup'
-            #"If you uncomment this line, this text will appear as default text in every message"    
-        end
-    end        
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -9,75 +9,75 @@ Rails.configuration.to_prepare do
       PublicBody.class_eval do
       # ACT (only has state, no councils)
           def actstate?
-            self.has_tag?('ACT_state')
+            has_tag?('ACT_state')
           end
       # NSW
           # NSW State
           def nswstate?
-            self.has_tag?('NSW_state')
+            has_tag?('NSW_state')
           end
           # NSW Council
           def nswcouncil?
-            self.has_tag?('NSW_council')
+            has_tag?('NSW_council')
           end
       # NT
           #NT State
           def ntstate?
-            self.has_tag?('NT_state')
+            has_tag?('NT_state')
           end
           # NT Council
           def ntcouncil?
-            self.has_tag?('NT_council')
+            has_tag?('NT_council')
           end
       #QLD
           # QLD State
           def qldstate?
-            self.has_tag?('QLD_state')
+            has_tag?('QLD_state')
           end
           # QLD Council
           def qldcouncil?
-            self.has_tag?('QLD_council')
+            has_tag?('QLD_council')
           end
       #SA
           # SA State
           def sastate?
-            self.has_tag?('SA_state')
+            has_tag?('SA_state')
           end
           # SA Council
           def sacouncil?
-            self.has_tag?('SA_council')
+            has_tag?('SA_council')
           end
       #TAS
           # TAS State
           def tasstate?
-            self.has_tag?('TAS_state')
+            has_tag?('TAS_state')
           end
           # TAS Council
           def tascouncil?
-            self.has_tag?('TAS_council')
+            has_tag?('TAS_council')
           end
       #VIC
           # VIC State
           def vicstate?
-            self.has_tag?('VIC_state')
+            has_tag?('VIC_state')
           end
           # VIC Council
           def viccouncil?
-            self.has_tag?('VIC_council')
+            has_tag?('VIC_council')
           end
       #WA
           # WA State
           def wastate?
-            self.has_tag?('WA_state')
+            has_tag?('WA_state')
           end
           # WA Council
           def wacouncil?
-            self.has_tag?('WA_council')
+            has_tag?('WA_council')
           end
       # Federal
       # This is a backup in case the law changes, we can easily modify it here
           def federalbody?
-            self.has_tag?('federal')
+            has_tag?('federal')
           end
       end
 
@@ -87,194 +87,194 @@ Rails.configuration.to_prepare do
       # Two sorts of laws for requests, FOI or EIR
       def law_used_full
         # ACT
-          if self.public_body.actstate?
+          if public_body.actstate?
             _("Freedom of Information")
         # NSW
-          elsif self.public_body.nswstate?
+          elsif public_body.nswstate?
             _("Government Information (Public Access)")
-          elsif self.public_body.nswcouncil?
+          elsif public_body.nswcouncil?
             _("Government Information (Public Access)")
         # NT
-          elsif self.public_body.ntstate?
+          elsif public_body.ntstate?
             _("Freedom of Information")
-          elsif self.public_body.ntcouncil?
+          elsif public_body.ntcouncil?
             _("Freedom of Information")
         # QLD
-          elsif self.public_body.qldstate?
+          elsif public_body.qldstate?
             _("Right to Information")
-          elsif self.public_body.qldcouncil?
+          elsif public_body.qldcouncil?
             _("Right to Information")
         # SA
-          elsif self.public_body.sastate?
+          elsif public_body.sastate?
             _("Freedom of Information")
-          elsif self.public_body.sacouncil?
+          elsif public_body.sacouncil?
             _("Freedom of Information")
         # TAS
-          elsif self.public_body.tasstate?
+          elsif public_body.tasstate?
             _("Right to Information")
-          elsif self.public_body.tascouncil?
+          elsif public_body.tascouncil?
             _("Right to Information")
         # VIC
-          elsif self.public_body.vicstate?
+          elsif public_body.vicstate?
             _("Freedom of Information")
-          elsif self.public_body.viccouncil?
+          elsif public_body.viccouncil?
             _("Freedom of Information")
         # WA
-          elsif self.public_body.wastate?
+          elsif public_body.wastate?
             _("Freedom of Information")
-          elsif self.public_body.wacouncil?
+          elsif public_body.wacouncil?
             _("Freedom of Information")
         # Fallback
-          elsif self.law_used == 'foi'
+          elsif law_used == 'foi'
               _("Freedom of Information")
-          elsif self.law_used == 'eir'
+          elsif law_used == 'eir'
               _("Environmental Information Regulations")
           else
-              raise "Unknown law used '" + self.law_used + "'"
+              raise "Unknown law used '" + law_used + "'"
           end
       end
       def law_used_short
         # ACT
-          if self.public_body.actstate?
+          if public_body.actstate?
             _("FOI")
         # NSW
-          elsif self.public_body.nswstate?
+          elsif public_body.nswstate?
             _("GIPA")
-          elsif self.public_body.nswcouncil?
+          elsif public_body.nswcouncil?
                 _("GIPA")
         # NT
-          elsif self.public_body.ntstate?
+          elsif public_body.ntstate?
             _("FOI")
-          elsif self.public_body.ntcouncil?
+          elsif public_body.ntcouncil?
             _("FOI")
         # QLD
-          elsif self.public_body.qldstate?
+          elsif public_body.qldstate?
             _("RTI")
-          elsif self.public_body.ntcouncil?
+          elsif public_body.ntcouncil?
             _("RTI")
         # SA
-          elsif self.public_body.sastate?
+          elsif public_body.sastate?
             _("FOI")
-          elsif self.public_body.sacouncil?
+          elsif public_body.sacouncil?
             _("FOI")
         # TAS
-          elsif self.public_body.tasstate?
+          elsif public_body.tasstate?
             _("RTI")
-          elsif self.public_body.tascouncil?
+          elsif public_body.tascouncil?
             _("RTI")
         # VIC
-          elsif self.public_body.vicstate?
+          elsif public_body.vicstate?
             _("FOI")
-          elsif self.public_body.viccouncil?
+          elsif public_body.viccouncil?
             _("FOI")
         # WA
-          elsif self.public_body.wastate?
+          elsif public_body.wastate?
             _("FOI")
-          elsif self.public_body.wacouncil?
+          elsif public_body.wacouncil?
             _("FOI")
         # Fallback
-          elsif self.law_used == 'foi'
+          elsif law_used == 'foi'
               _("FOI")
-          elsif self.law_used == 'eir'
+          elsif law_used == 'eir'
               _("EIR")
           else
-              raise "Unknown law used '" + self.law_used + "'"
+              raise "Unknown law used '" + law_used + "'"
           end
       end
       def law_used_act
         # ACT
-          if self.public_body.actstate?
+          if public_body.actstate?
             _("Freedom of Information Act 1989 (ACT)")
         # NSW
-          elsif self.public_body.nswstate?
+          elsif public_body.nswstate?
               _("Government Information (Public Access) Act 2009 (NSW)")
-          elsif self.public_body.nswcouncil?
+          elsif public_body.nswcouncil?
               _("Government Information (Public Access) Act 2009 (NSW)")
         # NT
-          elsif self.public_body.ntstate?
+          elsif public_body.ntstate?
               _("Information Act (NT)")
-          elsif self.public_body.ntcouncil?
+          elsif public_body.ntcouncil?
               _("Information Act (NT)")
         # QLD
-          elsif self.public_body.qldstate?
+          elsif public_body.qldstate?
               _("Right to Information Act 2009 (QLD)")
-          elsif self.public_body.ntcouncil?
+          elsif public_body.ntcouncil?
               _("Right to Information Act 2009 (QLD)")
         # SA
-          elsif self.public_body.sastate?
+          elsif public_body.sastate?
               _("Freedom of Information Act 1991 (SA)")
-          elsif self.public_body.sacouncil?
+          elsif public_body.sacouncil?
               _("Freedom of Information Act 1991 (SA)")
         # TAS
-          elsif self.public_body.tasstate?
+          elsif public_body.tasstate?
               _("Right to Information Act 2009 (QLD)")
-          elsif self.public_body.tascouncil?
+          elsif public_body.tascouncil?
               _("Right to Information Act 2009 (QLD)")
         # VIC
-          elsif self.public_body.vicstate?
+          elsif public_body.vicstate?
               _("Freedom of Information Act 1982 (VIC)")
-          elsif self.public_body.viccouncil?
+          elsif public_body.viccouncil?
               _("Freedom of Information Act 1982 (VIC)")
         # WA
-          elsif self.public_body.wastate?
+          elsif public_body.wastate?
               _("Freedom of Information Act 1992 (WA)")
-          elsif self.public_body.wacouncil?
+          elsif public_body.wacouncil?
               _("Freedom of Information Act 1992 (WA)")
         # Fallback
-          elsif self.law_used == 'foi'
+          elsif law_used == 'foi'
               _("Freedom of Information Act")
-          elsif self.law_used == 'eir'
+          elsif law_used == 'eir'
               _("Environmental Information Regulations")
           else
-              raise "Unknown law used '" + self.law_used + "'"
+              raise "Unknown law used '" + law_used + "'"
           end
       end
       def law_used_with_a
         # ACT
-          if self.public_body.actstate?
+          if public_body.actstate?
             _("A Freedom of Information request")
         # NSW
-          elsif self.public_body.nswstate?
+          elsif public_body.nswstate?
               _("A Government Information (Public Access) request")
-          elsif self.public_body.nswcouncil?
+          elsif public_body.nswcouncil?
             _("A Government Information (Public Access) request")
         # NT
-          elsif self.public_body.ntstate?
+          elsif public_body.ntstate?
             _("A Freedom of Information request")
-          elsif self.public_body.ntcouncil?
+          elsif public_body.ntcouncil?
             _("A Freedom of Information request")
         # QLD
-          elsif self.public_body.qldstate?
+          elsif public_body.qldstate?
             _("A Right to Information request")
-          elsif self.public_body.qldcouncil?
+          elsif public_body.qldcouncil?
             _("A Right to Information request")
         # TAS
-          elsif self.public_body.tasstate?
+          elsif public_body.tasstate?
             _("A Right to Information request")
-          elsif self.public_body.tascouncil?
+          elsif public_body.tascouncil?
             _("A Right to Information request")
         # SA
-          elsif self.public_body.sastate?
+          elsif public_body.sastate?
             _("A Freedom of Information request")
-          elsif self.public_body.sacouncil?
+          elsif public_body.sacouncil?
             _("A Freedom of Information request")
         # VIC
-          elsif self.public_body.vicstate?
+          elsif public_body.vicstate?
             _("A Freedom of Information request")
-          elsif self.public_body.viccouncil?
+          elsif public_body.viccouncil?
             _("A Freedom of Information request")
         # WA
-          elsif self.public_body.wastate?
+          elsif public_body.wastate?
             _("A Freedom of Information request")
-          elsif self.public_body.wacouncil?
+          elsif public_body.wacouncil?
             _("A Freedom of Information request")
         # Fallback
-          elsif self.law_used == 'foi'
+          elsif law_used == 'foi'
               _("A Freedom of Information request")
-          elsif self.law_used == 'eir'
+          elsif law_used == 'eir'
               _("An Environmental Information Regulations request")
           else
-              raise "Unknown law used '" + self.law_used + "'"
+              raise "Unknown law used '" + law_used + "'"
           end
       end
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -5,79 +5,27 @@
 # See http://stackoverflow.com/questions/7072758/plugin-not-reloading-in-development-mode
 #
 Rails.configuration.to_prepare do
-    # Define which state each authority belongs in
     PublicBody.class_eval do
-        # ACT (only has state, no councils)
-        def actstate?
-            has_tag?('ACT_state')
-        end
-        # NSW
-        # NSW State
-        def nswstate?
-            has_tag?('NSW_state')
-        end
-        # NSW Council
-        def nswcouncil?
-            has_tag?('NSW_council')
-        end
-        # NT
-        #NT State
-        def ntstate?
-            has_tag?('NT_state')
-        end
-        # NT Council
-        def ntcouncil?
-            has_tag?('NT_council')
-        end
-        #QLD
-        # QLD State
-        def qldstate?
-            has_tag?('QLD_state')
-        end
-        # QLD Council
-        def qldcouncil?
-            has_tag?('QLD_council')
-        end
-        #SA
-        # SA State
-        def sastate?
-            has_tag?('SA_state')
-        end
-        # SA Council
-        def sacouncil?
-            has_tag?('SA_council')
-        end
-        #TAS
-        # TAS State
-        def tasstate?
-            has_tag?('TAS_state')
-        end
-        # TAS Council
-        def tascouncil?
-            has_tag?('TAS_council')
-        end
-        #VIC
-        # VIC State
-        def vicstate?
-            has_tag?('VIC_state')
-        end
-        # VIC Council
-        def viccouncil?
-            has_tag?('VIC_council')
-        end
-        #WA
-        # WA State
-        def wastate?
-            has_tag?('WA_state')
-        end
-        # WA Council
-        def wacouncil?
-            has_tag?('WA_council')
-        end
-        # Federal
-        # This is a backup in case the law changes, we can easily modify it here
-        def federalbody?
-            has_tag?('federal')
+        def jurisdiction
+            if has_tag?('ACT_state')
+                :act
+            elsif has_tag?('NSW_state') || has_tag?('NSW_council')
+                :nsw
+            elsif has_tag?('NT_state') || has_tag?('NT_council')
+                :nt
+            elsif has_tag?('QLD_state') || has_tag?('QLD_council')
+                :qld
+            elsif has_tag?('SA_state') || has_tag?('SA_council')
+                :sa
+            elsif has_tag?('TAS_state') || has_tag?('TAS_council')
+                :tas
+            elsif has_tag?('VIC_state') || has_tag?('VIC_council')
+                :vic
+            elsif has_tag?('WA_state') || has_tag?('WA_council')
+                :wa
+            elsif has_tag?('federal')
+                :federal
+            end
         end
     end
 

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -99,6 +99,11 @@ Rails.configuration.to_prepare do
             return _("Freedom of Information")
           elsif self.public_body.ntcouncil?
             return _("Freedom of Information")
+        # QLD
+          elsif self.public_body.qldstate?
+            return _("Right to Information")
+          elsif self.public_body.ntcouncil?
+            return _("Right to Information")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information")
@@ -122,6 +127,11 @@ Rails.configuration.to_prepare do
             return _("FOI")
           elsif self.public_body.ntcouncil?
             return _("FOI")
+        # QLD
+          elsif self.public_body.qldstate?
+            return _("RTI")
+          elsif self.public_body.ntcouncil?
+            return _("RTI")
         # Fallback
           elsif self.law_used == 'foi'
               return _("FOI")
@@ -145,6 +155,11 @@ Rails.configuration.to_prepare do
               return _("Information Act (NT)")
           elsif self.public_body.ntcouncil?
               return _("Information Act (NT)")
+        # QLD
+          elsif self.public_body.qldstate?
+              return _("Right to Information Act 2009 (QLD)")
+          elsif self.public_body.ntcouncil?
+              return _("Right to Information Act 2009 (QLD)")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information Act")
@@ -168,6 +183,11 @@ Rails.configuration.to_prepare do
             return _("A Freedom of Information request")
           elsif self.public_body.ntcouncil?
             return _("A Freedom of Information request")
+        # QLD
+          elsif self.public_body.qldstate?
+            return _("A Right to Information request")
+          elsif self.public_body.ntcouncil?
+            return _("A Right to Information request")
         # Fallback
           elsif self.law_used == 'foi'
               return _("A Freedom of Information request")

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -74,5 +74,10 @@ Rails.configuration.to_prepare do
           def wacouncil?
             return self.has_tag?('WA_council')
           end
-
+      # Federal
+      # This is a backup in case the law changes, we can easily modify it here
+          def federalbody?
+            return self.has_tag?('federal')
+          end
+      end
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -86,7 +86,9 @@ Rails.configuration.to_prepare do
     InfoRequest.class_eval do
       # Two sorts of laws for requests, FOI or EIR
       def law_used_full
-          if self.law_used == 'foi'
+          if self.public_body.actstate?
+            return _("Freedom of Information")
+          elsif self.law_used == 'foi'
               return _("Freedom of Information")
           elsif self.law_used == 'eir'
               return _("Environmental Information Regulations")
@@ -95,7 +97,9 @@ Rails.configuration.to_prepare do
           end
       end
       def law_used_short
-          if self.law_used == 'foi'
+          if self.public_body.actstate?
+            return _("FOI")
+          elsif self.law_used == 'foi'
               return _("FOI")
           elsif self.law_used == 'eir'
               return _("EIR")
@@ -104,7 +108,9 @@ Rails.configuration.to_prepare do
           end
       end
       def law_used_act
-          if self.law_used == 'foi'
+          if self.public_body.actstate?
+            return _("Freedom of Information Act 1989 (ACT)")
+          elsif self.law_used == 'foi'
               return _("Freedom of Information Act")
           elsif self.law_used == 'eir'
               return _("Environmental Information Regulations")
@@ -113,7 +119,9 @@ Rails.configuration.to_prepare do
           end
       end
       def law_used_with_a
-          if self.law_used == 'foi'
+          if self.public_body.actstate?
+            return _("A Freedom of Information request")
+          elsif self.law_used == 'foi'
               return _("A Freedom of Information request")
           elsif self.law_used == 'eir'
               return _("An Environmental Information Regulations request")

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -56,4 +56,13 @@ Rails.configuration.to_prepare do
           def tascouncil?
             return self.has_tag?('TAS_council')
           end
+      #VIC
+          # VIC State
+          def vicstate?
+            return self.has_tag?('VIC_state')
+          end
+          # VIC Council
+          def viccouncil?
+            return self.has_tag?('VIC_council')
+          end
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -47,5 +47,13 @@ Rails.configuration.to_prepare do
           def sacouncil?
             return self.has_tag?('SA_council')
           end
-
+      #TAS
+          # TAS State
+          def tasstate?
+            return self.has_tag?('TAS_state')
+          end
+          # TAS Council
+          def tascouncil?
+            return self.has_tag?('TAS_council')
+          end
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -142,9 +142,9 @@ Rails.configuration.to_prepare do
               return _("Government Information (Public Access) Act 2009 (NSW)")
         # NT
           elsif self.public_body.ntstate?
-              return _("Information Act ")
+              return _("Information Act (NT)")
           elsif self.public_body.ntcouncil?
-              return _("Information Act")
+              return _("Information Act (NT)")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information Act")

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -119,6 +119,11 @@ Rails.configuration.to_prepare do
             return _("Freedom of Information")
           elsif self.public_body.viccouncil?
             return _("Freedom of Information")
+        # WA
+          elsif self.public_body.wastate?
+            return _("Freedom of Information")
+          elsif self.public_body.wacouncil?
+            return _("Freedom of Information")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information")
@@ -161,6 +166,11 @@ Rails.configuration.to_prepare do
           elsif self.public_body.vicstate?
             return _("FOI")
           elsif self.public_body.viccouncil?
+            return _("FOI")
+        # WA
+          elsif self.public_body.wastate?
+            return _("FOI")
+          elsif self.public_body.wacouncil?
             return _("FOI")
         # Fallback
           elsif self.law_used == 'foi'
@@ -205,6 +215,11 @@ Rails.configuration.to_prepare do
               return _("Freedom of Information Act 1982 (VIC)")
           elsif self.public_body.viccouncil?
               return _("Freedom of Information Act 1982 (VIC)")
+        # WA
+          elsif self.public_body.wastate?
+              return _("Freedom of Information Act 1992 (WA)")
+          elsif self.public_body.wacouncil?
+              return _("Freedom of Information Act 1992 (WA)")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information Act")
@@ -247,6 +262,11 @@ Rails.configuration.to_prepare do
           elsif self.public_body.vicstate?
             return _("A Freedom of Information request")
           elsif self.public_body.viccouncil?
+            return _("A Freedom of Information request")
+        # WA
+          elsif self.public_body.wastate?
+            return _("A Freedom of Information request")
+          elsif self.public_body.wacouncil?
             return _("A Freedom of Information request")
         # Fallback
           elsif self.law_used == 'foi'

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -42,198 +42,60 @@ Rails.configuration.to_prepare do
         end
 
         def law_used_full
-            # ACT
-            if public_body.actstate?
-                _("Freedom of Information")
-            # NSW
-            elsif public_body.nswstate?
+            if australian_law_used == "gipa"
                 _("Government Information (Public Access)")
-            elsif public_body.nswcouncil?
-                _("Government Information (Public Access)")
-            # NT
-            elsif public_body.ntstate?
-                _("Freedom of Information")
-            elsif public_body.ntcouncil?
-                _("Freedom of Information")
-            # QLD
-            elsif public_body.qldstate?
+            elsif australian_law_used == "rti"
                 _("Right to Information")
-            elsif public_body.qldcouncil?
-                _("Right to Information")
-            # SA
-            elsif public_body.sastate?
+            elsif australian_law_used == 'foi'
                 _("Freedom of Information")
-            elsif public_body.sacouncil?
-                _("Freedom of Information")
-            # TAS
-            elsif public_body.tasstate?
-                _("Right to Information")
-            elsif public_body.tascouncil?
-                _("Right to Information")
-            # VIC
-            elsif public_body.vicstate?
-                _("Freedom of Information")
-            elsif public_body.viccouncil?
-                _("Freedom of Information")
-            # WA
-            elsif public_body.wastate?
-                _("Freedom of Information")
-            elsif public_body.wacouncil?
-                _("Freedom of Information")
-            # Fallback
-            elsif law_used == 'foi'
-                _("Freedom of Information")
-            elsif law_used == 'eir'
+            elsif australian_law_used == 'eir'
                 _("Environmental Information Regulations")
             else
-                raise "Unknown law used '" + law_used + "'"
+                raise "Unknown law used '" + australian_law_used + "'"
             end
         end
 
         def law_used_short
-            # ACT
-            if public_body.actstate?
-                _("FOI")
-            # NSW
-            elsif public_body.nswstate?
+            if australian_law_used == "gipa"
                 _("GIPA")
-            elsif public_body.nswcouncil?
-                _("GIPA")
-            # NT
-            elsif public_body.ntstate?
-                _("FOI")
-            elsif public_body.ntcouncil?
-                _("FOI")
-            # QLD
-            elsif public_body.qldstate?
+            elsif australian_law_used == "rti"
                 _("RTI")
-            elsif public_body.ntcouncil?
-                _("RTI")
-            # SA
-            elsif public_body.sastate?
+            elsif australian_law_used == 'foi'
                 _("FOI")
-            elsif public_body.sacouncil?
-                _("FOI")
-            # TAS
-            elsif public_body.tasstate?
-                _("RTI")
-            elsif public_body.tascouncil?
-                _("RTI")
-            # VIC
-            elsif public_body.vicstate?
-                _("FOI")
-            elsif public_body.viccouncil?
-                _("FOI")
-            # WA
-            elsif public_body.wastate?
-                _("FOI")
-            elsif public_body.wacouncil?
-                _("FOI")
-            # Fallback
-            elsif law_used == 'foi'
-                _("FOI")
-            elsif law_used == 'eir'
+            elsif australian_law_used == 'eir'
                 _("EIR")
             else
-                raise "Unknown law used '" + law_used + "'"
+                raise "Unknown law used '" + australian_law_used + "'"
             end
         end
 
+        # Unused method
         def law_used_act
-            # ACT
-            if public_body.actstate?
-                _("Freedom of Information Act 1989 (ACT)")
-            # NSW
-            elsif public_body.nswstate?
-                _("Government Information (Public Access) Act 2009 (NSW)")
-            elsif public_body.nswcouncil?
-                _("Government Information (Public Access) Act 2009 (NSW)")
-            # NT
-            elsif public_body.ntstate?
-                _("Information Act (NT)")
-            elsif public_body.ntcouncil?
-                _("Information Act (NT)")
-            # QLD
-            elsif public_body.qldstate?
-                _("Right to Information Act 2009 (QLD)")
-            elsif public_body.ntcouncil?
-                _("Right to Information Act 2009 (QLD)")
-            # SA
-            elsif public_body.sastate?
-                _("Freedom of Information Act 1991 (SA)")
-            elsif public_body.sacouncil?
-                _("Freedom of Information Act 1991 (SA)")
-            # TAS
-            elsif public_body.tasstate?
-                _("Right to Information Act 2009 (QLD)")
-            elsif public_body.tascouncil?
-                _("Right to Information Act 2009 (QLD)")
-            # VIC
-            elsif public_body.vicstate?
-                _("Freedom of Information Act 1982 (VIC)")
-            elsif public_body.viccouncil?
-                _("Freedom of Information Act 1982 (VIC)")
-            # WA
-            elsif public_body.wastate?
-                _("Freedom of Information Act 1992 (WA)")
-            elsif public_body.wacouncil?
-                _("Freedom of Information Act 1992 (WA)")
-            # Fallback
-            elsif law_used == 'foi'
+            if australian_law_used == "gipa"
+                _("Government Information (Public Access) Act")
+            elsif australian_law_used == "rti"
+                _("Right to Information Act")
+            elsif australian_law_used == 'foi'
                 _("Freedom of Information Act")
-            elsif law_used == 'eir'
+            elsif australian_law_used == 'eir'
                 _("Environmental Information Regulations")
             else
-                raise "Unknown law used '" + law_used + "'"
+                raise "Unknown law used '" + australian_law_used + "'"
             end
         end
 
+        # Unused method
         def law_used_with_a
-            # ACT
-            if public_body.actstate?
-                _("A Freedom of Information request")
-            # NSW
-            elsif public_body.nswstate?
+            if australian_law_used == "gipa"
                 _("A Government Information (Public Access) request")
-            elsif public_body.nswcouncil?
-                _("A Government Information (Public Access) request")
-            # NT
-            elsif public_body.ntstate?
-                _("A Freedom of Information request")
-            elsif public_body.ntcouncil?
-                _("A Freedom of Information request")
-            # QLD
-            elsif public_body.qldstate?
+            elsif australian_law_used == "rti"
                 _("A Right to Information request")
-            elsif public_body.qldcouncil?
-                _("A Right to Information request")
-            # TAS
-            elsif public_body.tasstate?
-                _("A Right to Information request")
-            elsif public_body.tascouncil?
-                _("A Right to Information request")
-            # SA
-            elsif public_body.sastate?
+            elsif australian_law_used == 'foi'
                 _("A Freedom of Information request")
-            elsif public_body.sacouncil?
-                _("A Freedom of Information request")
-            # VIC
-            elsif public_body.vicstate?
-                _("A Freedom of Information request")
-            elsif public_body.viccouncil?
-                _("A Freedom of Information request")
-            # WA
-            elsif public_body.wastate?
-                _("A Freedom of Information request")
-            elsif public_body.wacouncil?
-                _("A Freedom of Information request")
-            # Fallback
-            elsif law_used == 'foi'
-                _("A Freedom of Information request")
-            elsif law_used == 'eir'
+            elsif australian_law_used == 'eir'
                 _("An Environmental Information Regulations request")
             else
-                raise "Unknown law used '" + law_used + "'"
+                raise "Unknown law used '" + australian_law_used + "'"
             end
         end
     end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -31,7 +31,16 @@ Rails.configuration.to_prepare do
 
     # This uses the defintions above to determine the name of the relevant law
     InfoRequest.class_eval do
-        # Two sorts of laws for requests, FOI or EIR
+        def australian_law_used
+            if public_body.jurisdiction == :nsw
+                "gipa"
+            elsif public_body.jurisdiction == :qld || public_body.jurisdiction == :tas
+                "rti"
+            else
+                "foi"
+            end
+        end
+
         def law_used_full
             # ACT
             if public_body.actstate?

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -104,6 +104,11 @@ Rails.configuration.to_prepare do
             return _("Right to Information")
           elsif self.public_body.ntcouncil?
             return _("Right to Information")
+        # SA
+          elsif self.public_body.sastate?
+            return _("Freedom of Information")
+          elsif self.public_body.sacouncil?
+            return _("Freedom of Information")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information")
@@ -132,6 +137,11 @@ Rails.configuration.to_prepare do
             return _("RTI")
           elsif self.public_body.ntcouncil?
             return _("RTI")
+        # SA
+          elsif self.public_body.sastate?
+            return _("FOI")
+          elsif self.public_body.sacouncil?
+            return _("FOI")
         # Fallback
           elsif self.law_used == 'foi'
               return _("FOI")
@@ -160,6 +170,11 @@ Rails.configuration.to_prepare do
               return _("Right to Information Act 2009 (QLD)")
           elsif self.public_body.ntcouncil?
               return _("Right to Information Act 2009 (QLD)")
+        # SA
+          elsif self.public_body.sastate?
+              return _("Freedom of Information Act 1991 (SA)")
+          elsif self.public_body.sacouncil?
+              return _("Freedom of Information Act 1991 (SA)")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information Act")
@@ -188,6 +203,11 @@ Rails.configuration.to_prepare do
             return _("A Right to Information request")
           elsif self.public_body.ntcouncil?
             return _("A Right to Information request")
+        # SA
+          elsif self.public_body.sastate?
+            return _("A Freedom of Information request")
+          elsif self.public_body.sacouncil?
+            return _("A Freedom of Information request")
         # Fallback
           elsif self.law_used == 'foi'
               return _("A Freedom of Information request")

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -86,8 +86,11 @@ Rails.configuration.to_prepare do
     InfoRequest.class_eval do
       # Two sorts of laws for requests, FOI or EIR
       def law_used_full
+        # ACT
           if self.public_body.actstate?
             return _("Freedom of Information")
+
+        # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information")
           elsif self.law_used == 'eir'
@@ -97,8 +100,11 @@ Rails.configuration.to_prepare do
           end
       end
       def law_used_short
+        # ACT
           if self.public_body.actstate?
             return _("FOI")
+
+        # Fallback
           elsif self.law_used == 'foi'
               return _("FOI")
           elsif self.law_used == 'eir'
@@ -108,8 +114,10 @@ Rails.configuration.to_prepare do
           end
       end
       def law_used_act
+        # ACT
           if self.public_body.actstate?
             return _("Freedom of Information Act 1989 (ACT)")
+        # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information Act")
           elsif self.law_used == 'eir'

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -80,4 +80,45 @@ Rails.configuration.to_prepare do
             return self.has_tag?('federal')
           end
       end
+
+
+# This uses the defintions above to determine the name of the relevant law
+    InfoRequest.class_eval do
+      # Two sorts of laws for requests, FOI or EIR
+      def law_used_full
+          if self.law_used == 'foi'
+              return _("Freedom of Information")
+          elsif self.law_used == 'eir'
+              return _("Environmental Information Regulations")
+          else
+              raise "Unknown law used '" + self.law_used + "'"
+          end
+      end
+      def law_used_short
+          if self.law_used == 'foi'
+              return _("FOI")
+          elsif self.law_used == 'eir'
+              return _("EIR")
+          else
+              raise "Unknown law used '" + self.law_used + "'"
+          end
+      end
+      def law_used_act
+          if self.law_used == 'foi'
+              return _("Freedom of Information Act")
+          elsif self.law_used == 'eir'
+              return _("Environmental Information Regulations")
+          else
+              raise "Unknown law used '" + self.law_used + "'"
+          end
+      end
+      def law_used_with_a
+          if self.law_used == 'foi'
+              return _("A Freedom of Information request")
+          elsif self.law_used == 'eir'
+              return _("An Environmental Information Regulations request")
+          else
+              raise "Unknown law used '" + self.law_used + "'"
+          end
+      end
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -89,7 +89,11 @@ Rails.configuration.to_prepare do
         # ACT
           if self.public_body.actstate?
             return _("Freedom of Information")
-
+        # NSW
+          elsif self.public_body.nswstate?
+            return _("Government Information (Public Access)")
+          elsif self.public_body.nswcouncil?
+            return _("Government Information (Public Access)")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information")
@@ -103,7 +107,11 @@ Rails.configuration.to_prepare do
         # ACT
           if self.public_body.actstate?
             return _("FOI")
-
+        # NSW
+          elsif self.public_body.nswstate?
+            return _("GIPA")
+          elsif self.public_body.nswcouncil?
+                return _("GIPA")
         # Fallback
           elsif self.law_used == 'foi'
               return _("FOI")
@@ -117,6 +125,11 @@ Rails.configuration.to_prepare do
         # ACT
           if self.public_body.actstate?
             return _("Freedom of Information Act 1989 (ACT)")
+        # NSW
+          elsif self.public_body.nswstate?
+              return _("GIPA")
+          elsif self.public_body.nswcouncil?
+              return _("GIPA")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information Act")
@@ -129,6 +142,12 @@ Rails.configuration.to_prepare do
       def law_used_with_a
           if self.public_body.actstate?
             return _("A Freedom of Information request")
+        # NSW
+          elsif self.public_body.nswstate?
+              return _("A Government Information (Public Access) request")
+          elsif self.public_body.nswcouncil?
+            return _("A Government Information (Public Access) request")
+
           elsif self.law_used == 'foi'
               return _("A Freedom of Information request")
           elsif self.law_used == 'eir'

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -29,4 +29,13 @@ Rails.configuration.to_prepare do
           def ntcouncil?
             return self.has_tag?('NT_council')
           end
+      #QLD
+          # QLD State
+          def qldstate?
+            return self.has_tag?('QLD_state')
+          end
+          # QLD Council
+          def qldcouncil?
+            return self.has_tag?('QLD_council')
+          end
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -9,75 +9,75 @@ Rails.configuration.to_prepare do
       PublicBody.class_eval do
       # ACT (only has state, no councils)
           def actstate?
-            return self.has_tag?('ACT_state')
+            self.has_tag?('ACT_state')
           end
       # NSW
           # NSW State
           def nswstate?
-            return self.has_tag?('NSW_state')
+            self.has_tag?('NSW_state')
           end
           # NSW Council
           def nswcouncil?
-            return self.has_tag?('NSW_council')
+            self.has_tag?('NSW_council')
           end
       # NT
           #NT State
           def ntstate?
-            return self.has_tag?('NT_state')
+            self.has_tag?('NT_state')
           end
           # NT Council
           def ntcouncil?
-            return self.has_tag?('NT_council')
+            self.has_tag?('NT_council')
           end
       #QLD
           # QLD State
           def qldstate?
-            return self.has_tag?('QLD_state')
+            self.has_tag?('QLD_state')
           end
           # QLD Council
           def qldcouncil?
-            return self.has_tag?('QLD_council')
+            self.has_tag?('QLD_council')
           end
       #SA
           # SA State
           def sastate?
-            return self.has_tag?('SA_state')
+            self.has_tag?('SA_state')
           end
           # SA Council
           def sacouncil?
-            return self.has_tag?('SA_council')
+            self.has_tag?('SA_council')
           end
       #TAS
           # TAS State
           def tasstate?
-            return self.has_tag?('TAS_state')
+            self.has_tag?('TAS_state')
           end
           # TAS Council
           def tascouncil?
-            return self.has_tag?('TAS_council')
+            self.has_tag?('TAS_council')
           end
       #VIC
           # VIC State
           def vicstate?
-            return self.has_tag?('VIC_state')
+            self.has_tag?('VIC_state')
           end
           # VIC Council
           def viccouncil?
-            return self.has_tag?('VIC_council')
+            self.has_tag?('VIC_council')
           end
       #WA
           # WA State
           def wastate?
-            return self.has_tag?('WA_state')
+            self.has_tag?('WA_state')
           end
           # WA Council
           def wacouncil?
-            return self.has_tag?('WA_council')
+            self.has_tag?('WA_council')
           end
       # Federal
       # This is a backup in case the law changes, we can easily modify it here
           def federalbody?
-            return self.has_tag?('federal')
+            self.has_tag?('federal')
           end
       end
 
@@ -88,47 +88,47 @@ Rails.configuration.to_prepare do
       def law_used_full
         # ACT
           if self.public_body.actstate?
-            return _("Freedom of Information")
+            _("Freedom of Information")
         # NSW
           elsif self.public_body.nswstate?
-            return _("Government Information (Public Access)")
+            _("Government Information (Public Access)")
           elsif self.public_body.nswcouncil?
-            return _("Government Information (Public Access)")
+            _("Government Information (Public Access)")
         # NT
           elsif self.public_body.ntstate?
-            return _("Freedom of Information")
+            _("Freedom of Information")
           elsif self.public_body.ntcouncil?
-            return _("Freedom of Information")
+            _("Freedom of Information")
         # QLD
           elsif self.public_body.qldstate?
-            return _("Right to Information")
+            _("Right to Information")
           elsif self.public_body.qldcouncil?
-            return _("Right to Information")
+            _("Right to Information")
         # SA
           elsif self.public_body.sastate?
-            return _("Freedom of Information")
+            _("Freedom of Information")
           elsif self.public_body.sacouncil?
-            return _("Freedom of Information")
+            _("Freedom of Information")
         # TAS
           elsif self.public_body.tasstate?
-            return _("Right to Information")
+            _("Right to Information")
           elsif self.public_body.tascouncil?
-            return _("Right to Information")
+            _("Right to Information")
         # VIC
           elsif self.public_body.vicstate?
-            return _("Freedom of Information")
+            _("Freedom of Information")
           elsif self.public_body.viccouncil?
-            return _("Freedom of Information")
+            _("Freedom of Information")
         # WA
           elsif self.public_body.wastate?
-            return _("Freedom of Information")
+            _("Freedom of Information")
           elsif self.public_body.wacouncil?
-            return _("Freedom of Information")
+            _("Freedom of Information")
         # Fallback
           elsif self.law_used == 'foi'
-              return _("Freedom of Information")
+              _("Freedom of Information")
           elsif self.law_used == 'eir'
-              return _("Environmental Information Regulations")
+              _("Environmental Information Regulations")
           else
               raise "Unknown law used '" + self.law_used + "'"
           end
@@ -136,47 +136,47 @@ Rails.configuration.to_prepare do
       def law_used_short
         # ACT
           if self.public_body.actstate?
-            return _("FOI")
+            _("FOI")
         # NSW
           elsif self.public_body.nswstate?
-            return _("GIPA")
+            _("GIPA")
           elsif self.public_body.nswcouncil?
-                return _("GIPA")
+                _("GIPA")
         # NT
           elsif self.public_body.ntstate?
-            return _("FOI")
+            _("FOI")
           elsif self.public_body.ntcouncil?
-            return _("FOI")
+            _("FOI")
         # QLD
           elsif self.public_body.qldstate?
-            return _("RTI")
+            _("RTI")
           elsif self.public_body.ntcouncil?
-            return _("RTI")
+            _("RTI")
         # SA
           elsif self.public_body.sastate?
-            return _("FOI")
+            _("FOI")
           elsif self.public_body.sacouncil?
-            return _("FOI")
+            _("FOI")
         # TAS
           elsif self.public_body.tasstate?
-            return _("RTI")
+            _("RTI")
           elsif self.public_body.tascouncil?
-            return _("RTI")
+            _("RTI")
         # VIC
           elsif self.public_body.vicstate?
-            return _("FOI")
+            _("FOI")
           elsif self.public_body.viccouncil?
-            return _("FOI")
+            _("FOI")
         # WA
           elsif self.public_body.wastate?
-            return _("FOI")
+            _("FOI")
           elsif self.public_body.wacouncil?
-            return _("FOI")
+            _("FOI")
         # Fallback
           elsif self.law_used == 'foi'
-              return _("FOI")
+              _("FOI")
           elsif self.law_used == 'eir'
-              return _("EIR")
+              _("EIR")
           else
               raise "Unknown law used '" + self.law_used + "'"
           end
@@ -184,47 +184,47 @@ Rails.configuration.to_prepare do
       def law_used_act
         # ACT
           if self.public_body.actstate?
-            return _("Freedom of Information Act 1989 (ACT)")
+            _("Freedom of Information Act 1989 (ACT)")
         # NSW
           elsif self.public_body.nswstate?
-              return _("Government Information (Public Access) Act 2009 (NSW)")
+              _("Government Information (Public Access) Act 2009 (NSW)")
           elsif self.public_body.nswcouncil?
-              return _("Government Information (Public Access) Act 2009 (NSW)")
+              _("Government Information (Public Access) Act 2009 (NSW)")
         # NT
           elsif self.public_body.ntstate?
-              return _("Information Act (NT)")
+              _("Information Act (NT)")
           elsif self.public_body.ntcouncil?
-              return _("Information Act (NT)")
+              _("Information Act (NT)")
         # QLD
           elsif self.public_body.qldstate?
-              return _("Right to Information Act 2009 (QLD)")
+              _("Right to Information Act 2009 (QLD)")
           elsif self.public_body.ntcouncil?
-              return _("Right to Information Act 2009 (QLD)")
+              _("Right to Information Act 2009 (QLD)")
         # SA
           elsif self.public_body.sastate?
-              return _("Freedom of Information Act 1991 (SA)")
+              _("Freedom of Information Act 1991 (SA)")
           elsif self.public_body.sacouncil?
-              return _("Freedom of Information Act 1991 (SA)")
+              _("Freedom of Information Act 1991 (SA)")
         # TAS
           elsif self.public_body.tasstate?
-              return _("Right to Information Act 2009 (QLD)")
+              _("Right to Information Act 2009 (QLD)")
           elsif self.public_body.tascouncil?
-              return _("Right to Information Act 2009 (QLD)")
+              _("Right to Information Act 2009 (QLD)")
         # VIC
           elsif self.public_body.vicstate?
-              return _("Freedom of Information Act 1982 (VIC)")
+              _("Freedom of Information Act 1982 (VIC)")
           elsif self.public_body.viccouncil?
-              return _("Freedom of Information Act 1982 (VIC)")
+              _("Freedom of Information Act 1982 (VIC)")
         # WA
           elsif self.public_body.wastate?
-              return _("Freedom of Information Act 1992 (WA)")
+              _("Freedom of Information Act 1992 (WA)")
           elsif self.public_body.wacouncil?
-              return _("Freedom of Information Act 1992 (WA)")
+              _("Freedom of Information Act 1992 (WA)")
         # Fallback
           elsif self.law_used == 'foi'
-              return _("Freedom of Information Act")
+              _("Freedom of Information Act")
           elsif self.law_used == 'eir'
-              return _("Environmental Information Regulations")
+              _("Environmental Information Regulations")
           else
               raise "Unknown law used '" + self.law_used + "'"
           end
@@ -232,47 +232,47 @@ Rails.configuration.to_prepare do
       def law_used_with_a
         # ACT
           if self.public_body.actstate?
-            return _("A Freedom of Information request")
+            _("A Freedom of Information request")
         # NSW
           elsif self.public_body.nswstate?
-              return _("A Government Information (Public Access) request")
+              _("A Government Information (Public Access) request")
           elsif self.public_body.nswcouncil?
-            return _("A Government Information (Public Access) request")
+            _("A Government Information (Public Access) request")
         # NT
           elsif self.public_body.ntstate?
-            return _("A Freedom of Information request")
+            _("A Freedom of Information request")
           elsif self.public_body.ntcouncil?
-            return _("A Freedom of Information request")
+            _("A Freedom of Information request")
         # QLD
           elsif self.public_body.qldstate?
-            return _("A Right to Information request")
+            _("A Right to Information request")
           elsif self.public_body.qldcouncil?
-            return _("A Right to Information request")
+            _("A Right to Information request")
         # TAS
           elsif self.public_body.tasstate?
-            return _("A Right to Information request")
+            _("A Right to Information request")
           elsif self.public_body.tascouncil?
-            return _("A Right to Information request")
+            _("A Right to Information request")
         # SA
           elsif self.public_body.sastate?
-            return _("A Freedom of Information request")
+            _("A Freedom of Information request")
           elsif self.public_body.sacouncil?
-            return _("A Freedom of Information request")
+            _("A Freedom of Information request")
         # VIC
           elsif self.public_body.vicstate?
-            return _("A Freedom of Information request")
+            _("A Freedom of Information request")
           elsif self.public_body.viccouncil?
-            return _("A Freedom of Information request")
+            _("A Freedom of Information request")
         # WA
           elsif self.public_body.wastate?
-            return _("A Freedom of Information request")
+            _("A Freedom of Information request")
           elsif self.public_body.wacouncil?
-            return _("A Freedom of Information request")
+            _("A Freedom of Information request")
         # Fallback
           elsif self.law_used == 'foi'
-              return _("A Freedom of Information request")
+              _("A Freedom of Information request")
           elsif self.law_used == 'eir'
-              return _("An Environmental Information Regulations request")
+              _("An Environmental Information Regulations request")
           else
               raise "Unknown law used '" + self.law_used + "'"
           end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -109,6 +109,11 @@ Rails.configuration.to_prepare do
             return _("Freedom of Information")
           elsif self.public_body.sacouncil?
             return _("Freedom of Information")
+        # TAS
+          elsif self.public_body.tasstate?
+            return _("Right to Information")
+          elsif self.public_body.tascouncil?
+            return _("Right to Information")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information")
@@ -142,6 +147,11 @@ Rails.configuration.to_prepare do
             return _("FOI")
           elsif self.public_body.sacouncil?
             return _("FOI")
+        # TAS
+          elsif self.public_body.tasstate?
+            return _("RTI")
+          elsif self.public_body.tascouncil?
+            return _("RTI")
         # Fallback
           elsif self.law_used == 'foi'
               return _("FOI")
@@ -175,6 +185,11 @@ Rails.configuration.to_prepare do
               return _("Freedom of Information Act 1991 (SA)")
           elsif self.public_body.sacouncil?
               return _("Freedom of Information Act 1991 (SA)")
+        # TAS
+          elsif self.public_body.tasstate?
+              return _("Right to Information Act 2009 (QLD)")
+          elsif self.public_body.tascouncil?
+              return _("Right to Information Act 2009 (QLD)")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information Act")
@@ -202,6 +217,11 @@ Rails.configuration.to_prepare do
           elsif self.public_body.qldstate?
             return _("A Right to Information request")
           elsif self.public_body.ntcouncil?
+            return _("A Right to Information request")
+        # TAS
+          elsif self.public_body.tasstate?
+            return _("A Right to Information request")
+          elsif self.public_body.tascouncil?
             return _("A Right to Information request")
         # SA
           elsif self.public_body.sastate?

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -216,7 +216,7 @@ Rails.configuration.to_prepare do
         # QLD
           elsif self.public_body.qldstate?
             return _("A Right to Information request")
-          elsif self.public_body.ntcouncil?
+          elsif self.public_body.qldcouncil?
             return _("A Right to Information request")
         # TAS
           elsif self.public_body.tasstate?

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -20,4 +20,13 @@ Rails.configuration.to_prepare do
           def nswcouncil?
             return self.has_tag?('NSW_council')
           end
+      # NT
+          #NT State
+          def ntstate?
+            return self.has_tag?('NT_state')
+          end
+          # NT Council
+          def ntcouncil?
+            return self.has_tag?('NT_council')
+          end
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -114,6 +114,11 @@ Rails.configuration.to_prepare do
             return _("Right to Information")
           elsif self.public_body.tascouncil?
             return _("Right to Information")
+        # VIC
+          elsif self.public_body.vicstate?
+            return _("Freedom of Information")
+          elsif self.public_body.viccouncil?
+            return _("Freedom of Information")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information")
@@ -152,6 +157,11 @@ Rails.configuration.to_prepare do
             return _("RTI")
           elsif self.public_body.tascouncil?
             return _("RTI")
+        # VIC
+          elsif self.public_body.vicstate?
+            return _("FOI")
+          elsif self.public_body.viccouncil?
+            return _("FOI")
         # Fallback
           elsif self.law_used == 'foi'
               return _("FOI")
@@ -190,6 +200,11 @@ Rails.configuration.to_prepare do
               return _("Right to Information Act 2009 (QLD)")
           elsif self.public_body.tascouncil?
               return _("Right to Information Act 2009 (QLD)")
+        # VIC
+          elsif self.public_body.vicstate?
+              return _("Freedom of Information Act 1982 (VIC)")
+          elsif self.public_body.viccouncil?
+              return _("Freedom of Information Act 1982 (VIC)")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information Act")
@@ -227,6 +242,11 @@ Rails.configuration.to_prepare do
           elsif self.public_body.sastate?
             return _("A Freedom of Information request")
           elsif self.public_body.sacouncil?
+            return _("A Freedom of Information request")
+        # VIC
+          elsif self.public_body.vicstate?
+            return _("A Freedom of Information request")
+          elsif self.public_body.viccouncil?
             return _("A Freedom of Information request")
         # Fallback
           elsif self.law_used == 'foi'

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -102,7 +102,7 @@ Rails.configuration.to_prepare do
         # QLD
           elsif self.public_body.qldstate?
             return _("Right to Information")
-          elsif self.public_body.ntcouncil?
+          elsif self.public_body.qldcouncil?
             return _("Right to Information")
         # SA
           elsif self.public_body.sastate?

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -65,4 +65,14 @@ Rails.configuration.to_prepare do
           def viccouncil?
             return self.has_tag?('VIC_council')
           end
+      #WA
+          # WA State
+          def wastate?
+            return self.has_tag?('WA_state')
+          end
+          # WA Council
+          def wacouncil?
+            return self.has_tag?('WA_council')
+          end
+
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -5,4 +5,10 @@
 # See http://stackoverflow.com/questions/7072758/plugin-not-reloading-in-development-mode
 #
 Rails.configuration.to_prepare do
+  # Define which state each authority belongs in
+      PublicBody.class_eval do
+      # ACT (only has state, no councils)
+          def actstate?
+            return self.has_tag?('ACT_state')
+          end  
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -49,7 +49,7 @@ Rails.configuration.to_prepare do
             when "foi"
                 _("Freedom of Information")
             else
-                raise "Unknown law used '" + australian_law_used + "'"
+                raise "Unknown law used '#{australian_law_used}'"
             end
         end
 
@@ -62,7 +62,7 @@ Rails.configuration.to_prepare do
             when "foi"
                 _("FOI")
             else
-                raise "Unknown law used '" + australian_law_used + "'"
+                raise "Unknown law used '#{australian_law_used}'"
             end
         end
 
@@ -76,7 +76,7 @@ Rails.configuration.to_prepare do
             when "foi"
                 _("Freedom of Information Act")
             else
-                raise "Unknown law used '" + australian_law_used + "'"
+                raise "Unknown law used '#{australian_law_used}'"
             end
         end
 
@@ -90,7 +90,7 @@ Rails.configuration.to_prepare do
             when "foi"
                 _("A Freedom of Information request")
             else
-                raise "Unknown law used '" + australian_law_used + "'"
+                raise "Unknown law used '#{australian_law_used}'"
             end
         end
     end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -278,3 +278,4 @@ Rails.configuration.to_prepare do
           end
       end
 end
+end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -94,6 +94,11 @@ Rails.configuration.to_prepare do
             return _("Government Information (Public Access)")
           elsif self.public_body.nswcouncil?
             return _("Government Information (Public Access)")
+        # NT
+          elsif self.public_body.ntstate?
+            return _("Freedom of Information")
+          elsif self.public_body.ntcouncil?
+            return _("Freedom of Information")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information")
@@ -112,6 +117,11 @@ Rails.configuration.to_prepare do
             return _("GIPA")
           elsif self.public_body.nswcouncil?
                 return _("GIPA")
+        # NT
+          elsif self.public_body.ntstate?
+            return _("FOI")
+          elsif self.public_body.ntcouncil?
+            return _("FOI")
         # Fallback
           elsif self.law_used == 'foi'
               return _("FOI")
@@ -130,6 +140,11 @@ Rails.configuration.to_prepare do
               return _("GIPA")
           elsif self.public_body.nswcouncil?
               return _("GIPA")
+        # NT
+          elsif self.public_body.ntstate?
+              return _("Information Act ")
+          elsif self.public_body.ntcouncil?
+              return _("Information Act")
         # Fallback
           elsif self.law_used == 'foi'
               return _("Freedom of Information Act")
@@ -148,6 +163,11 @@ Rails.configuration.to_prepare do
               return _("A Government Information (Public Access) request")
           elsif self.public_body.nswcouncil?
             return _("A Government Information (Public Access) request")
+        # NT
+          elsif self.public_body.ntstate?
+            return _("A Freedom of Information request")
+          elsif self.public_body.ntcouncil?
+            return _("A Freedom of Information request")
         # Fallback
           elsif self.law_used == 'foi'
               return _("A Freedom of Information request")

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -38,4 +38,14 @@ Rails.configuration.to_prepare do
           def qldcouncil?
             return self.has_tag?('QLD_council')
           end
+      #SA
+          # SA State
+          def sastate?
+            return self.has_tag?('SA_state')
+          end
+          # SA Council
+          def sacouncil?
+            return self.has_tag?('SA_council')
+          end
+
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -5,277 +5,279 @@
 # See http://stackoverflow.com/questions/7072758/plugin-not-reloading-in-development-mode
 #
 Rails.configuration.to_prepare do
-# Define which state each authority belongs in
-      PublicBody.class_eval do
-      # ACT (only has state, no councils)
-          def actstate?
+    # Define which state each authority belongs in
+    PublicBody.class_eval do
+        # ACT (only has state, no councils)
+        def actstate?
             has_tag?('ACT_state')
-          end
-      # NSW
-          # NSW State
-          def nswstate?
+        end
+        # NSW
+        # NSW State
+        def nswstate?
             has_tag?('NSW_state')
-          end
-          # NSW Council
-          def nswcouncil?
+        end
+        # NSW Council
+        def nswcouncil?
             has_tag?('NSW_council')
-          end
-      # NT
-          #NT State
-          def ntstate?
+        end
+        # NT
+        #NT State
+        def ntstate?
             has_tag?('NT_state')
-          end
-          # NT Council
-          def ntcouncil?
+        end
+        # NT Council
+        def ntcouncil?
             has_tag?('NT_council')
-          end
-      #QLD
-          # QLD State
-          def qldstate?
+        end
+        #QLD
+        # QLD State
+        def qldstate?
             has_tag?('QLD_state')
-          end
-          # QLD Council
-          def qldcouncil?
+        end
+        # QLD Council
+        def qldcouncil?
             has_tag?('QLD_council')
-          end
-      #SA
-          # SA State
-          def sastate?
+        end
+        #SA
+        # SA State
+        def sastate?
             has_tag?('SA_state')
-          end
-          # SA Council
-          def sacouncil?
+        end
+        # SA Council
+        def sacouncil?
             has_tag?('SA_council')
-          end
-      #TAS
-          # TAS State
-          def tasstate?
+        end
+        #TAS
+        # TAS State
+        def tasstate?
             has_tag?('TAS_state')
-          end
-          # TAS Council
-          def tascouncil?
+        end
+        # TAS Council
+        def tascouncil?
             has_tag?('TAS_council')
-          end
-      #VIC
-          # VIC State
-          def vicstate?
+        end
+        #VIC
+        # VIC State
+        def vicstate?
             has_tag?('VIC_state')
-          end
-          # VIC Council
-          def viccouncil?
+        end
+        # VIC Council
+        def viccouncil?
             has_tag?('VIC_council')
-          end
-      #WA
-          # WA State
-          def wastate?
+        end
+        #WA
+        # WA State
+        def wastate?
             has_tag?('WA_state')
-          end
-          # WA Council
-          def wacouncil?
+        end
+        # WA Council
+        def wacouncil?
             has_tag?('WA_council')
-          end
-      # Federal
-      # This is a backup in case the law changes, we can easily modify it here
-          def federalbody?
+        end
+        # Federal
+        # This is a backup in case the law changes, we can easily modify it here
+        def federalbody?
             has_tag?('federal')
-          end
-      end
+        end
+    end
 
-
-# This uses the defintions above to determine the name of the relevant law
+    # This uses the defintions above to determine the name of the relevant law
     InfoRequest.class_eval do
-      # Two sorts of laws for requests, FOI or EIR
-      def law_used_full
-        # ACT
-          if public_body.actstate?
-            _("Freedom of Information")
-        # NSW
-          elsif public_body.nswstate?
-            _("Government Information (Public Access)")
-          elsif public_body.nswcouncil?
-            _("Government Information (Public Access)")
-        # NT
-          elsif public_body.ntstate?
-            _("Freedom of Information")
-          elsif public_body.ntcouncil?
-            _("Freedom of Information")
-        # QLD
-          elsif public_body.qldstate?
-            _("Right to Information")
-          elsif public_body.qldcouncil?
-            _("Right to Information")
-        # SA
-          elsif public_body.sastate?
-            _("Freedom of Information")
-          elsif public_body.sacouncil?
-            _("Freedom of Information")
-        # TAS
-          elsif public_body.tasstate?
-            _("Right to Information")
-          elsif public_body.tascouncil?
-            _("Right to Information")
-        # VIC
-          elsif public_body.vicstate?
-            _("Freedom of Information")
-          elsif public_body.viccouncil?
-            _("Freedom of Information")
-        # WA
-          elsif public_body.wastate?
-            _("Freedom of Information")
-          elsif public_body.wacouncil?
-            _("Freedom of Information")
-        # Fallback
-          elsif law_used == 'foi'
-              _("Freedom of Information")
-          elsif law_used == 'eir'
-              _("Environmental Information Regulations")
-          else
-              raise "Unknown law used '" + law_used + "'"
-          end
-      end
-      def law_used_short
-        # ACT
-          if public_body.actstate?
-            _("FOI")
-        # NSW
-          elsif public_body.nswstate?
-            _("GIPA")
-          elsif public_body.nswcouncil?
+        # Two sorts of laws for requests, FOI or EIR
+        def law_used_full
+            # ACT
+            if public_body.actstate?
+                _("Freedom of Information")
+            # NSW
+            elsif public_body.nswstate?
+                _("Government Information (Public Access)")
+            elsif public_body.nswcouncil?
+                _("Government Information (Public Access)")
+            # NT
+            elsif public_body.ntstate?
+                _("Freedom of Information")
+            elsif public_body.ntcouncil?
+                _("Freedom of Information")
+            # QLD
+            elsif public_body.qldstate?
+                _("Right to Information")
+            elsif public_body.qldcouncil?
+                _("Right to Information")
+            # SA
+            elsif public_body.sastate?
+                _("Freedom of Information")
+            elsif public_body.sacouncil?
+                _("Freedom of Information")
+            # TAS
+            elsif public_body.tasstate?
+                _("Right to Information")
+            elsif public_body.tascouncil?
+                _("Right to Information")
+            # VIC
+            elsif public_body.vicstate?
+                _("Freedom of Information")
+            elsif public_body.viccouncil?
+                _("Freedom of Information")
+            # WA
+            elsif public_body.wastate?
+                _("Freedom of Information")
+            elsif public_body.wacouncil?
+                _("Freedom of Information")
+            # Fallback
+            elsif law_used == 'foi'
+                _("Freedom of Information")
+            elsif law_used == 'eir'
+                _("Environmental Information Regulations")
+            else
+                raise "Unknown law used '" + law_used + "'"
+            end
+        end
+
+        def law_used_short
+            # ACT
+            if public_body.actstate?
+                _("FOI")
+            # NSW
+            elsif public_body.nswstate?
                 _("GIPA")
-        # NT
-          elsif public_body.ntstate?
-            _("FOI")
-          elsif public_body.ntcouncil?
-            _("FOI")
-        # QLD
-          elsif public_body.qldstate?
-            _("RTI")
-          elsif public_body.ntcouncil?
-            _("RTI")
-        # SA
-          elsif public_body.sastate?
-            _("FOI")
-          elsif public_body.sacouncil?
-            _("FOI")
-        # TAS
-          elsif public_body.tasstate?
-            _("RTI")
-          elsif public_body.tascouncil?
-            _("RTI")
-        # VIC
-          elsif public_body.vicstate?
-            _("FOI")
-          elsif public_body.viccouncil?
-            _("FOI")
-        # WA
-          elsif public_body.wastate?
-            _("FOI")
-          elsif public_body.wacouncil?
-            _("FOI")
-        # Fallback
-          elsif law_used == 'foi'
-              _("FOI")
-          elsif law_used == 'eir'
-              _("EIR")
-          else
-              raise "Unknown law used '" + law_used + "'"
-          end
-      end
-      def law_used_act
-        # ACT
-          if public_body.actstate?
-            _("Freedom of Information Act 1989 (ACT)")
-        # NSW
-          elsif public_body.nswstate?
-              _("Government Information (Public Access) Act 2009 (NSW)")
-          elsif public_body.nswcouncil?
-              _("Government Information (Public Access) Act 2009 (NSW)")
-        # NT
-          elsif public_body.ntstate?
-              _("Information Act (NT)")
-          elsif public_body.ntcouncil?
-              _("Information Act (NT)")
-        # QLD
-          elsif public_body.qldstate?
-              _("Right to Information Act 2009 (QLD)")
-          elsif public_body.ntcouncil?
-              _("Right to Information Act 2009 (QLD)")
-        # SA
-          elsif public_body.sastate?
-              _("Freedom of Information Act 1991 (SA)")
-          elsif public_body.sacouncil?
-              _("Freedom of Information Act 1991 (SA)")
-        # TAS
-          elsif public_body.tasstate?
-              _("Right to Information Act 2009 (QLD)")
-          elsif public_body.tascouncil?
-              _("Right to Information Act 2009 (QLD)")
-        # VIC
-          elsif public_body.vicstate?
-              _("Freedom of Information Act 1982 (VIC)")
-          elsif public_body.viccouncil?
-              _("Freedom of Information Act 1982 (VIC)")
-        # WA
-          elsif public_body.wastate?
-              _("Freedom of Information Act 1992 (WA)")
-          elsif public_body.wacouncil?
-              _("Freedom of Information Act 1992 (WA)")
-        # Fallback
-          elsif law_used == 'foi'
-              _("Freedom of Information Act")
-          elsif law_used == 'eir'
-              _("Environmental Information Regulations")
-          else
-              raise "Unknown law used '" + law_used + "'"
-          end
-      end
-      def law_used_with_a
-        # ACT
-          if public_body.actstate?
-            _("A Freedom of Information request")
-        # NSW
-          elsif public_body.nswstate?
-              _("A Government Information (Public Access) request")
-          elsif public_body.nswcouncil?
-            _("A Government Information (Public Access) request")
-        # NT
-          elsif public_body.ntstate?
-            _("A Freedom of Information request")
-          elsif public_body.ntcouncil?
-            _("A Freedom of Information request")
-        # QLD
-          elsif public_body.qldstate?
-            _("A Right to Information request")
-          elsif public_body.qldcouncil?
-            _("A Right to Information request")
-        # TAS
-          elsif public_body.tasstate?
-            _("A Right to Information request")
-          elsif public_body.tascouncil?
-            _("A Right to Information request")
-        # SA
-          elsif public_body.sastate?
-            _("A Freedom of Information request")
-          elsif public_body.sacouncil?
-            _("A Freedom of Information request")
-        # VIC
-          elsif public_body.vicstate?
-            _("A Freedom of Information request")
-          elsif public_body.viccouncil?
-            _("A Freedom of Information request")
-        # WA
-          elsif public_body.wastate?
-            _("A Freedom of Information request")
-          elsif public_body.wacouncil?
-            _("A Freedom of Information request")
-        # Fallback
-          elsif law_used == 'foi'
-              _("A Freedom of Information request")
-          elsif law_used == 'eir'
-              _("An Environmental Information Regulations request")
-          else
-              raise "Unknown law used '" + law_used + "'"
-          end
-      end
-end
+            elsif public_body.nswcouncil?
+                _("GIPA")
+            # NT
+            elsif public_body.ntstate?
+                _("FOI")
+            elsif public_body.ntcouncil?
+                _("FOI")
+            # QLD
+            elsif public_body.qldstate?
+                _("RTI")
+            elsif public_body.ntcouncil?
+                _("RTI")
+            # SA
+            elsif public_body.sastate?
+                _("FOI")
+            elsif public_body.sacouncil?
+                _("FOI")
+            # TAS
+            elsif public_body.tasstate?
+                _("RTI")
+            elsif public_body.tascouncil?
+                _("RTI")
+            # VIC
+            elsif public_body.vicstate?
+                _("FOI")
+            elsif public_body.viccouncil?
+                _("FOI")
+            # WA
+            elsif public_body.wastate?
+                _("FOI")
+            elsif public_body.wacouncil?
+                _("FOI")
+            # Fallback
+            elsif law_used == 'foi'
+                _("FOI")
+            elsif law_used == 'eir'
+                _("EIR")
+            else
+                raise "Unknown law used '" + law_used + "'"
+            end
+        end
+
+        def law_used_act
+            # ACT
+            if public_body.actstate?
+                _("Freedom of Information Act 1989 (ACT)")
+            # NSW
+            elsif public_body.nswstate?
+                _("Government Information (Public Access) Act 2009 (NSW)")
+            elsif public_body.nswcouncil?
+                _("Government Information (Public Access) Act 2009 (NSW)")
+            # NT
+            elsif public_body.ntstate?
+                _("Information Act (NT)")
+            elsif public_body.ntcouncil?
+                _("Information Act (NT)")
+            # QLD
+            elsif public_body.qldstate?
+                _("Right to Information Act 2009 (QLD)")
+            elsif public_body.ntcouncil?
+                _("Right to Information Act 2009 (QLD)")
+            # SA
+            elsif public_body.sastate?
+                _("Freedom of Information Act 1991 (SA)")
+            elsif public_body.sacouncil?
+                _("Freedom of Information Act 1991 (SA)")
+            # TAS
+            elsif public_body.tasstate?
+                _("Right to Information Act 2009 (QLD)")
+            elsif public_body.tascouncil?
+                _("Right to Information Act 2009 (QLD)")
+            # VIC
+            elsif public_body.vicstate?
+                _("Freedom of Information Act 1982 (VIC)")
+            elsif public_body.viccouncil?
+                _("Freedom of Information Act 1982 (VIC)")
+            # WA
+            elsif public_body.wastate?
+                _("Freedom of Information Act 1992 (WA)")
+            elsif public_body.wacouncil?
+                _("Freedom of Information Act 1992 (WA)")
+            # Fallback
+            elsif law_used == 'foi'
+                _("Freedom of Information Act")
+            elsif law_used == 'eir'
+                _("Environmental Information Regulations")
+            else
+                raise "Unknown law used '" + law_used + "'"
+            end
+        end
+
+        def law_used_with_a
+            # ACT
+            if public_body.actstate?
+                _("A Freedom of Information request")
+            # NSW
+            elsif public_body.nswstate?
+                _("A Government Information (Public Access) request")
+            elsif public_body.nswcouncil?
+                _("A Government Information (Public Access) request")
+            # NT
+            elsif public_body.ntstate?
+                _("A Freedom of Information request")
+            elsif public_body.ntcouncil?
+                _("A Freedom of Information request")
+            # QLD
+            elsif public_body.qldstate?
+                _("A Right to Information request")
+            elsif public_body.qldcouncil?
+                _("A Right to Information request")
+            # TAS
+            elsif public_body.tasstate?
+                _("A Right to Information request")
+            elsif public_body.tascouncil?
+                _("A Right to Information request")
+            # SA
+            elsif public_body.sastate?
+                _("A Freedom of Information request")
+            elsif public_body.sacouncil?
+                _("A Freedom of Information request")
+            # VIC
+            elsif public_body.vicstate?
+                _("A Freedom of Information request")
+            elsif public_body.viccouncil?
+                _("A Freedom of Information request")
+            # WA
+            elsif public_body.wastate?
+                _("A Freedom of Information request")
+            elsif public_body.wacouncil?
+                _("A Freedom of Information request")
+            # Fallback
+            elsif law_used == 'foi'
+                _("A Freedom of Information request")
+            elsif law_used == 'eir'
+                _("An Environmental Information Regulations request")
+            else
+                raise "Unknown law used '" + law_used + "'"
+            end
+        end
+    end
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -41,11 +41,12 @@ Rails.configuration.to_prepare do
         end
 
         def law_used_full
-            if australian_law_used == "gipa"
+            case australian_law_used
+            when "gipa"
                 _("Government Information (Public Access)")
-            elsif australian_law_used == "rti"
+            when "rti"
                 _("Right to Information")
-            elsif australian_law_used == 'foi'
+            when "foi"
                 _("Freedom of Information")
             else
                 raise "Unknown law used '" + australian_law_used + "'"
@@ -53,11 +54,12 @@ Rails.configuration.to_prepare do
         end
 
         def law_used_short
-            if australian_law_used == "gipa"
+            case australian_law_used
+            when "gipa"
                 _("GIPA")
-            elsif australian_law_used == "rti"
+            when "rti"
                 _("RTI")
-            elsif australian_law_used == 'foi'
+            when "foi"
                 _("FOI")
             else
                 raise "Unknown law used '" + australian_law_used + "'"
@@ -66,11 +68,12 @@ Rails.configuration.to_prepare do
 
         # Unused method
         def law_used_act
-            if australian_law_used == "gipa"
+            case australian_law_used
+            when "gipa"
                 _("Government Information (Public Access) Act")
-            elsif australian_law_used == "rti"
+            when "rti"
                 _("Right to Information Act")
-            elsif australian_law_used == 'foi'
+            when "foi"
                 _("Freedom of Information Act")
             else
                 raise "Unknown law used '" + australian_law_used + "'"
@@ -79,11 +82,12 @@ Rails.configuration.to_prepare do
 
         # Unused method
         def law_used_with_a
-            if australian_law_used == "gipa"
+            case australian_law_used
+            when "gipa"
                 _("A Government Information (Public Access) request")
-            elsif australian_law_used == "rti"
+            when "rti"
                 _("A Right to Information request")
-            elsif australian_law_used == 'foi'
+            when "foi"
                 _("A Freedom of Information request")
             else
                 raise "Unknown law used '" + australian_law_used + "'"

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -5,7 +5,7 @@
 # See http://stackoverflow.com/questions/7072758/plugin-not-reloading-in-development-mode
 #
 Rails.configuration.to_prepare do
-  # Define which state each authority belongs in
+# Define which state each authority belongs in
       PublicBody.class_eval do
       # ACT (only has state, no councils)
           def actstate?

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -40,6 +40,8 @@ Rails.configuration.to_prepare do
             end
         end
 
+        # Used in messages shown to the user when interacting with a request
+        # and in outbound emails to the authority
         def law_used_full
             case australian_law_used
             when "gipa"
@@ -53,6 +55,8 @@ Rails.configuration.to_prepare do
             end
         end
 
+        # Used in messages shown to the user when interacting with a request
+        # and in outbound emails to the authority
         def law_used_short
             case australian_law_used
             when "gipa"
@@ -66,7 +70,8 @@ Rails.configuration.to_prepare do
             end
         end
 
-        # Unused method
+        # This method isn't currently used in Alaveteli but we're overriding it
+        # for completeness
         def law_used_act
             case australian_law_used
             when "gipa"
@@ -80,7 +85,8 @@ Rails.configuration.to_prepare do
             end
         end
 
-        # Unused method
+        # This method isn't currently used in Alaveteli but we're overriding it
+        # for completeness
         def law_used_with_a
             case australian_law_used
             when "gipa"

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -140,6 +140,7 @@ Rails.configuration.to_prepare do
           end
       end
       def law_used_with_a
+        # ACT
           if self.public_body.actstate?
             return _("A Freedom of Information request")
         # NSW
@@ -147,7 +148,7 @@ Rails.configuration.to_prepare do
               return _("A Government Information (Public Access) request")
           elsif self.public_body.nswcouncil?
             return _("A Government Information (Public Access) request")
-
+        # Fallback
           elsif self.law_used == 'foi'
               return _("A Freedom of Information request")
           elsif self.law_used == 'eir'

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -29,7 +29,6 @@ Rails.configuration.to_prepare do
         end
     end
 
-    # This uses the defintions above to determine the name of the relevant law
     InfoRequest.class_eval do
         def australian_law_used
             if public_body.jurisdiction == :nsw

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -137,9 +137,9 @@ Rails.configuration.to_prepare do
             return _("Freedom of Information Act 1989 (ACT)")
         # NSW
           elsif self.public_body.nswstate?
-              return _("GIPA")
+              return _("Government Information (Public Access) Act 2009 (NSW)")
           elsif self.public_body.nswcouncil?
-              return _("GIPA")
+              return _("Government Information (Public Access) Act 2009 (NSW)")
         # NT
           elsif self.public_body.ntstate?
               return _("Information Act ")

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -47,8 +47,6 @@ Rails.configuration.to_prepare do
                 _("Right to Information")
             elsif australian_law_used == 'foi'
                 _("Freedom of Information")
-            elsif australian_law_used == 'eir'
-                _("Environmental Information Regulations")
             else
                 raise "Unknown law used '" + australian_law_used + "'"
             end
@@ -61,8 +59,6 @@ Rails.configuration.to_prepare do
                 _("RTI")
             elsif australian_law_used == 'foi'
                 _("FOI")
-            elsif australian_law_used == 'eir'
-                _("EIR")
             else
                 raise "Unknown law used '" + australian_law_used + "'"
             end
@@ -76,8 +72,6 @@ Rails.configuration.to_prepare do
                 _("Right to Information Act")
             elsif australian_law_used == 'foi'
                 _("Freedom of Information Act")
-            elsif australian_law_used == 'eir'
-                _("Environmental Information Regulations")
             else
                 raise "Unknown law used '" + australian_law_used + "'"
             end
@@ -91,8 +85,6 @@ Rails.configuration.to_prepare do
                 _("A Right to Information request")
             elsif australian_law_used == 'foi'
                 _("A Freedom of Information request")
-            elsif australian_law_used == 'eir'
-                _("An Environmental Information Regulations request")
             else
                 raise "Unknown law used '" + australian_law_used + "'"
             end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -10,5 +10,14 @@ Rails.configuration.to_prepare do
       # ACT (only has state, no councils)
           def actstate?
             return self.has_tag?('ACT_state')
-          end  
+          end
+      # NSW
+          # NSW State
+          def nswstate?
+            return self.has_tag?('NSW_state')
+          end
+          # NSW Council
+          def nswcouncil?
+            return self.has_tag?('NSW_council')
+          end
 end


### PR DESCRIPTION
This addresses #428 by using the tags in [public_body_categories_en.rb](https://github.com/openaustralia/righttoknow/blob/production/lib/public_body_categories_en.rb) to determine:
- The request type (e.g. `Government Information (Public Access)` for NSW, or `Right to Information` for QLD and TAS)
- The appropriate acronym for the request type (e.g. `GIPA` for NSW, or `RTI` for QLD and TAS)
- The relevant Act of Parliament used (e.g. `Government Information (Public Access) Act 2009 (NSW)`  for NSW
- The request type in part of a sentence (e.g. `A Right to Information request` for TAS)

Anywhere the relevant defs are used in Alaveteli they should now reflect the name for the relevant jurisdiction.

Things to be aware of:
- This requires that the tags used are case sensitive. `NSW_state` will work, but `nsw_state` and `NSW_STATE` won't.

before @henare asks (:wink:), I've tested this in vagrant (making requests) and can see no major issues. I'm happy for it to go into staging before production if you would prefer.
