### PR TITLE
Adjust responsive theme to match current Right To Know theme on wide screens

### DIFF
--- a/assets/stylesheets/responsive/_settings.scss
+++ b/assets/stylesheets/responsive/_settings.scss
@@ -1,0 +1,5 @@
+$main_menu-mobile_menu_cutoff: 58em;
+$row-width: 64em;
+$body-font-family: "Helvetica Neue", Arial, Helvetica, Helmet, Freesans, sans-serif;
+$form-label-font-color: #333333;
+$base-font-size: 16px;

--- a/assets/stylesheets/responsive/_settings.scss
+++ b/assets/stylesheets/responsive/_settings.scss
@@ -1,5 +1,5 @@
 $main_menu-mobile_menu_cutoff: 58em;
-$row-width: 64em;
+$row-width: 56.5em;
 $body-font-family: "Helvetica Neue", Arial, Helvetica, Helmet, Freesans, sans-serif;
 $form-label-font-color: #333333;
 $base-font-size: 16px;

--- a/assets/stylesheets/responsive/_settings.scss
+++ b/assets/stylesheets/responsive/_settings.scss
@@ -1,5 +1,5 @@
 $main_menu-mobile_menu_cutoff: 58em;
-$row-width: 56.5em;
+$row-width: 60em;
 $body-font-family: "Helvetica Neue", Arial, Helvetica, Helmet, Freesans, sans-serif;
 $form-label-font-color: #333333;
 $base-font-size: 15px;

--- a/assets/stylesheets/responsive/_settings.scss
+++ b/assets/stylesheets/responsive/_settings.scss
@@ -2,4 +2,4 @@ $main_menu-mobile_menu_cutoff: 58em;
 $row-width: 56.5em;
 $body-font-family: "Helvetica Neue", Arial, Helvetica, Helmet, Freesans, sans-serif;
 $form-label-font-color: #333333;
-$base-font-size: 16px;
+$base-font-size: 15px;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -119,6 +119,26 @@ color:#444;
 color:#ffffff;
 }
 
+#navigation_search {
+  opacity: inherit;
+}
+
+#navigation_search p {
+  margin-right: inherit;
+}
+
+#navigation_search input#navigation_search_query {
+  border-color: #888;
+  background-image: image-url('search-icon.png') no-repeat left center;
+  background-color: white;
+  padding-left: 2em;
+  border-radius: 5px;
+}
+
+#navigation_search input#navigation_search_button {
+  display: none;
+}
+
 // Main Body
 
 #content {
@@ -211,26 +231,6 @@ color:#005068;
   font-family:'Maven Pro', Arial, sans-serif;
   font-size: 15px;
   width: 33em;
-}
-
-#navigation_search {
-  opacity: inherit;
-}
-
-#navigation_search p {
-  margin-right: inherit;
-}
-
-#navigation_search input#navigation_search_query {
-  border-color: #888;
-  background-image: image-url('search-icon.png') no-repeat left center;
-  background-color: white;
-  padding-left: 2em;
-  border-radius: 5px;
-}
-
-#navigation_search input#navigation_search_button {
-  display: none;
 }
 
 // Buttons

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -984,6 +984,7 @@ padding-right: 0;
   background-color: #D5FFD8;
   border: #1EFF38 solid 1px;
   font-style: italic;
+  padding: 0.5em;
 }
 
 #request_new #request_header_text,

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -290,11 +290,6 @@ font-family: $body-font-family;
 font-weight:400;
 }
 
-.request_listing span.desc {
-background: image-url('quote-marks.png') no-repeat;
-color:#444;
-}
-
 span#to_public_body {
 font-family: $body-font-family;
 }
@@ -348,6 +343,11 @@ color:#005068;
 }
 
 .request_listing {
+  span.desc {
+    background: image-url('quote-marks.png') no-repeat;
+    color:#444;
+  }
+
   span.bottomline {
     font-style: normal;
     margin-bottom: 0;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1132,10 +1132,14 @@ h3.title {
 }
 
 #request_search_ahead_results {
-  margin-left: 11em;
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-left: 11em;
+  }
 
   h3:first-child {
-    margin-top: 0;
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin-top: 0;
+    }
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -695,6 +695,13 @@ div.correspondence p.preview_subject {
   background: #E9FDD3;
   color: #333;
   border-radius: 6px;
+
+  hr {
+    border-width: 0 0 1px;
+    border-style: dotted;
+    border-color: #b0ca86;
+    margin: 20px 0;
+  }
 }
 
 #describe_state_form_1 {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -886,6 +886,32 @@ p#sign_in_reason, p#superuser_message {
   line-height: 1em;
 }
 
+label.form_label {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    display: block;
+    float: left;
+    clear: none;
+    width: 110px;
+    text-align: left;
+    margin: 2px 0 0;
+    padding: 0 10px 0 0;
+  }
+}
+
+#signup .form_item_note, #signin .form_note {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    font-size: 0.9em;
+    margin-left: 11.5em;
+    width: inherit;
+  }
+}
+
+#sign_together .form_button {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-left: 10.5em;
+  }
+}
+
 // Date Picker
 
 #ui-datepicker-div {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -889,6 +889,14 @@ h2.publicbody_results {
   }
 }
 
+#preview_form div.comment_in_request {
+  margin-left: 0;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin-left: 3em;
+  }
+}
+
 // Forms
 
 form input[type=text], form input[type=password] {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -76,6 +76,12 @@ a {
   }
 }
 
+small {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    font-size: smaller;
+  }
+}
+
 .entirebody {
   background-color: white;
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -370,6 +370,19 @@ color:#005068;
   }
 }
 
+#public_body_list {
+  ul {
+    margin: 1em 0;
+    padding-left: 40px;
+    line-height: 1.2;
+    list-style-type: disc;
+  }
+
+  li {
+    margin-bottom: 0;
+  }
+}
+
 // Buttons
 
 form input[type=submit],a.link_button_green,a.link_button_green_large {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1387,9 +1387,13 @@ padding-top:1em;
     padding: 0;
     width: 221px;
 
-    input[type="text"] {
+    h2 {
+      margin-bottom: 15px;
+    }
+
+    #query {
       margin-bottom: 0;
-      width: 210px;
+      width: 212px;
     }
   }
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1025,6 +1025,15 @@ padding-right: 0;
   font-size: 1em;
 }
 
+.form_item_note {
+  margin-top: -1em;
+
+  p + & {
+    top: 0;
+    position: static;
+  }
+}
+
 #middle_strip {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     margin-top: -.5em;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -108,7 +108,44 @@ color:#444;
 }
 
 #navigation_search {
+  padding: 0 13px 10px;
   opacity: inherit;
+  background-color: $righttoknow-primary-color-lighter;
+
+  /* hide unless toggled open
+     on small screens */
+  display: none;
+
+  #banner:target & {
+    display: block;
+  }
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    display: block;
+    position: absolute;
+    z-index: 150;
+    text-align: right;
+    width: auto;
+    right: 0;
+    top: 10px;
+    background-color: transparent;
+  }
+
+  form {
+    padding: 0;
+  }
+
+  /* Hide the label visually */
+  label {
+    position: absolute !important;
+    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+    clip: rect(1px, 1px, 1px, 1px);
+    padding:0 !important;
+    border:0 !important;
+    height: 1px !important;
+    width: 1px !important;
+    overflow: hidden;
+  }
 }
 
 #navigation_search p {
@@ -121,6 +158,17 @@ color:#444;
 #navigation_search input#navigation_search_button {
   padding-left: 2em;
   border-radius: 5px;
+  background: image-url('search-icon.png') no-repeat left center #ffffff;
+  width: 100%;
+  border-color: #888;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    margin: 5px -1px 0 0;
+    padding: 5px 0 5px 2em;
+    width: 20.25em;
+    height: 24px;
+    font-size: 0.8em;
+  }
 }
 
 // Site Footer

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -999,6 +999,8 @@ padding-right: 0;
     float: left;
     width: 8%;
     height: 100px;
+    padding: 0;
+    white-space: onwrap;
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -311,11 +311,15 @@ color:#444;
   }
 
   .footer_right {
-    margin-top: 22px;
+    margin-top: 15px;
 
     @include respond-min(51em) {
       float: right;
       text-align: left;
+    }
+
+    ul {
+      margin-top: 0;
     }
   }
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1005,7 +1005,6 @@ h3.title {
   }
 
   span#to_public_body {
-    margin-bottom: 0;
     font-size: 1.1em;
   }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -897,6 +897,11 @@ h2.publicbody_results {
   }
 }
 
+#help_unhappy {
+  margin-left: 0;
+  margin-right: 0;
+}
+
 // Forms
 
 form input[type=text], form input[type=password] {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -732,6 +732,10 @@ padding-right: 0;
     @include clearfix;
   }
 
+  span#to_public_body {
+    margin-bottom: 0;
+  }
+
   label {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       display: block;
@@ -776,6 +780,12 @@ padding-right: 0;
   #outgoing_message_body {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       width: 34em;
+    }
+  }
+
+  input {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin-bottom: 0;
     }
   }
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -634,6 +634,12 @@ color: #a60201;
   }
 }
 
+div.correspondence p.preview_subject {
+  font-size: 1.2em;
+  margin-left: 10px;
+  line-height: 25px;
+}
+
 // Forms
 
 form#signin_form input[type=text], form#signin_form input[type=password], form#signup_form input[type=text], form#signup_form input[type=password] {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -798,7 +798,7 @@ div.correspondence p.preview_subject {
   }
 
   div {
-    margin: 0 0 1em;
+    margin: 0 0 1.3em;
 
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       margin: 0;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -349,7 +349,7 @@ color:#005068;
 }
 
 .request_listing, .body_listing, .user_listing {
-  margin: 0 0 -1px;
+  margin-bottom: -1px;
   border-bottom: 1px solid #DDD;
   padding: 12px 0 6px;
   font-size: 0.9em;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1045,6 +1045,7 @@ label.form_label {
     text-align: left;
     margin: 2px 0 0;
     padding: 0 10px 0 0;
+    line-height: normal;
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -346,6 +346,7 @@ color:#005068;
   span.desc {
     background: image-url('quote-marks.png') no-repeat;
     min-height: 2em;
+    padding: 0 0 0 40px;
   }
 
   span.bottomline {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -22,6 +22,30 @@ background-color: #f0f0f0;
 #footer {
   border-top: 1px #ddd solid;
   background-color: #f0f0f0;
+
+  img {
+    border: 1px #ddd solid;
+    vertical-align: middle;
+  }
+
+  ul {
+    list-style: none;
+    padding-left: 0;
+  }
+
+  li {
+    margin-top: 5px;
+  }
+
+  p {
+    margin-top: 0;
+  }
+
+  .right {
+    margin-top: 22px;
+    float: right;
+    text-align: left;
+  }
 }
 
 #footer_inner {
@@ -52,35 +76,6 @@ float: none;
   margin-bottom: 50px;
   float: left;
   text-align: left;
-}
-
-#footer img {
-  border: 1px #ddd solid;
-  vertical-align: middle;
-}
-
-#oaf ul {
-  list-style: none;
-  padding-left: 0;
-}
-
-#footer ul li {
-  margin-top: 5px;
-}
-
-#footer p {
-  margin-top: 0;
-}
-
-#footer .right {
-  margin-top: 22px;
-  float: right;
-  text-align: left;
-}
-
-#footer .right ul {
-  list-style: none;
-  padding-left: 0;
 }
 
 // Site Header

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -676,76 +676,77 @@ padding-top:1em;
 // Front Page
 
 #frontpage_splash {
-background: none;
-}
+  background: none;
 
-#frontpage_splash h1 {
-font-family: $heading-font-family;
-font-size:39px;
-color:#005068;
-font-weight:400;
-margin:0 0 20px;
-}
+  h1 {
+    font-family: $heading-font-family;
+    font-size:39px;
+    color:#005068;
+    font-weight:400;
+    margin:0 0 20px;
 
-#frontpage_splash h1 strong {
-font-family: $heading-font-family;
-font-size:54px;
-line-height: 1em;
-color:#005068;
-font-weight:400;
-}
+    strong {
+      font-family: $heading-font-family;
+      font-size:54px;
+      line-height: 1em;
+      color:#005068;
+      font-weight:400;
+    }
 
-#frontpage_splash h1 span {
-font-family: $heading-font-family;
-font-style:inherit;
-font-size:39px;
-color:#005068;
-}
+    span {
+      font-family: $heading-font-family;
+      font-style:inherit;
+      font-size:39px;
+      color:#005068;
+    }
+  }
 
-#frontpage_splash h2 {
-font-size:26px;
-font-weight:400;
-color:#005068;
-font-family: $heading-font-family;
-}
+  h2 {
+    font-size:26px;
+    font-weight:400;
+    color:#005068;
+    font-family: $heading-font-family;
 
-#frontpage_splash h2 strong {
-font-size:31px;
-color:#005068;
-font-family: $heading-font-family;
-}
+    strong {
+      font-size:31px;
+      color:#005068;
+      font-family: $heading-font-family;
+    }
 
-#frontpage_splash h2 span {
-color:#005068;
-font-style:inherit;
-font-size:19px;
-font-family: $heading-font-family;
-}
+    span {
+      color:#005068;
+      font-style:inherit;
+      font-size:19px;
+      font-family: $heading-font-family;
+    }
+  }
 
-#frontpage_splash #frontpage_right_to_know {
-  margin-top: 80px;
-  width: 221px;
-  float: left;
+  #frontpage_right_to_know {
+    margin-top: 80px;
+    width: 221px;
+    float: left;
+  }
+
+  #frontpage_start_request {
+    margin-top: 50px;
+    margin-left: 70px;
+    margin-right: 70px;
+    width: 291px;
+    float: left;
+  }
+
+  #frontpage_search_box {
+    margin-top: 80px;
+    width: 221px;
+    float: left;
+    margin-bottom: 0px;
+  }
 }
 
 #frontpage_right_to_know h2, #frontpage_search_box h2 {
   margin-top: 0px;
 }
 
-#frontpage_splash #frontpage_start_request {
-  margin-top: 50px;
-  margin-left: 70px;
-  margin-right: 70px;
-  width: 291px;
-  float: left;
-}
-
-#frontpage_splash #frontpage_search_box {
-  margin-top: 80px;
-  width: 221px;
-  float: left;
-  margin-bottom: 0px;
-}
 
 // Front Page Supporting Orgs section
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -887,8 +887,11 @@ padding-right: 0;
   border-radius: 6px;
   -moz-border-radius: 6px;
   font-weight: 400;
-  width: 554px;
   margin: 20px 0 30px;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    width: 554px;
+  }
 }
 
 #error, .errorExplanation, #hidden_request {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -389,9 +389,10 @@ color:#005068;
 }
 
 .request_listing, .body_listing, .user_listing {
+  margin-top: 0;
   margin-bottom: -1px;
   border-bottom: 1px solid #DDD;
-  padding: 12px 0 6px;
+  padding: 15px 0 6px;
   line-height: normal;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ){

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -20,14 +20,25 @@ background-color: #f0f0f0;
 // Site Footer
 
 #footer {
-  float: inherit;
   border-top: 1px #ddd solid;
+  background-color: #f0f0f0;
 }
 
 #footer_inner {
 max-width:$row-width;
-position:relative;
-margin:auto;
+margin: auto;
+@include grid-column(12);
+@include clearfix;
+float: none;
+
+  @include ie8{
+    padding-left: 0.9375em;
+    padding-right: 0.9375em;
+  }
+
+  @include lte-ie7 {
+    width: 56.125em;
+  }
 }
 
 #oaf_logo {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -11,6 +11,52 @@ font-family: $body-font-family;
 background-color: #f0f0f0;
 }
 
+h1,h2,h3 {
+font-family: $heading-font-family;
+ color:#005068;
+}
+
+h1 {
+color:#005068;
+font-size:42px;
+}
+
+h2 {
+font-size:1.4em;
+}
+
+h2,dt {
+color:#005068;
+font-family: $heading-font-family;
+font-weight:400;
+}
+
+h3 {
+color:#005068;
+font-weight:400;
+}
+
+p {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+p.subtitle {
+color:#005068;
+}
+
+a, a:hover {
+  color:#A60201;
+}
+
+a, .request_listing .requester a {
+  text-decoration: none;
+}
+
+a:hover, .request_listing .requester a:hover {
+  text-decoration: underline;
+}
+
 .entirebody {
   background-color: white;
 }
@@ -240,53 +286,6 @@ float: none;
 
 #content {
   padding-top: 2em;
-}
-
-h1,h2,h3 {
-font-family: $heading-font-family;
- color:#005068;
-}
-
-h1 {
-color:#005068;
-font-size:42px;
-}
-
-h2 {
-font-size:1.4em;
-}
-
-
-h2,dt {
-color:#005068;
-font-family: $heading-font-family;
-font-weight:400;
-}
-
-h3 {
-color:#005068;
-font-weight:400;
-}
-
-a, a:hover {
-  color:#A60201;
-}
-
-a, .request_listing .requester a {
-  text-decoration: none;
-}
-
-a:hover, .request_listing .requester a:hover {
-  text-decoration: underline;
-}
-
-p {
-  margin-top: 1em;
-  margin-bottom: 1em;
-}
-
-p.subtitle {
-color:#005068;
 }
 
 .request_listing span.head a,.user_listing span.head a,.body_listing span.head a {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -98,6 +98,14 @@ box-shadow: 0 0 10px;
     padding: .5em 1em;
     border-radius: .3em;
     text-align: center;
+
+    @include respond-min( 22em ) {
+      margin-top: 1.3em;
+    }
+
+    @include respond-min( 24em ) {
+      margin-top: 1.8em;
+    }
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -321,6 +321,10 @@ color:#444;
     ul {
       margin-top: 0;
     }
+
+    li:first-child {
+      margin-bottom: 1em;
+    }
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -37,6 +37,11 @@ font-weight:400;
 h3 {
 color:#005068;
 font-weight:400;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-top: 3px;
+    margin-bottom: 10px;
+  }
 }
 
 dl {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -425,11 +425,6 @@ a.link_button_green:hover,a.link_button_green_large:hover {
   color: white;
 }
 
-
-a.link_button_green_large {
-background-image: image-url('button-gradient-large.png');
-}
-
 form input[type=submit],a.link_button_green {
 background-image: image-url('button-gradient.png');
 }
@@ -460,6 +455,14 @@ form input[type=submit],a.link_button_green, a.link_button_green_large {
     background: linear-gradient(to bottom,  #c2ff50 0%,#8cbe46 100%);
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c2ff50', endColorstr='#8cbe46',GradientType=0 );
   }
+}
+
+a.link_button_green_large {
+// background-image: image-url('button-gradient-large.png');
+display: inline-block;
+font-size: 2em;
+line-height: 22px;
+padding-bottom: 7px;
 }
 
 /* Mostly magic for adding page curls */
@@ -723,24 +726,54 @@ padding-top:1em;
 }
 
 #frontpage_right_to_know {
-  margin-top: 80px;
-  width: 221px;
-  float: left;
+  @include grid-column($columns:12);
+
+  // @include respond-min( 30em ) {
+  //   @include grid-column($columns:6);
+  // }
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-top: 80px;
+    @include grid-column($columns:4, $float:left);
+  }
 }
 
 #frontpage_start_request {
-  margin-top: 50px;
-  margin-left: 70px;
-  margin-right: 70px;
-  width: 291px;
-  float: left;
+  @include grid-column($columns:12);
+
+  @include respond-min( 30em ) {
+    @include grid-column($columns:6);
+  }
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-top: 50px;
+    // margin-left: 70px;
+    // margin-right: 70px;
+    // width: 291px;
+    // float: left;
+    @include grid-column($columns:4.5, $float:left);
+  }
 }
 
 #frontpage_search_box {
-  margin-top: 80px;
-  width: 221px;
-  float: left;
-  margin-bottom: 0px;
+  margin-top: 2em;
+  @include grid-column($columns:12);
+
+  @include respond-min( 30em ) {
+    @include grid-column($columns:6);
+  }
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    // width: 221px;
+    // float: left;
+    margin-top: 70px;
+    margin-bottom: 0px;
+    @include grid-column($columns:3.5, $float:left);
+
+    input[type="text"] {
+      margin-bottom: 0;
+    }
+  }
 }
 
 #frontpage_right_to_know h2, #frontpage_search_box h2 {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -526,80 +526,6 @@ div.correspondence:after {
   right: 12px;
 }
 
-// Front Page
-
-#frontpage_splash {
-background: none;
-}
-
-#frontpage_splash h1 {
-font-family: $heading-font-family;
-font-size:39px;
-color:#005068;
-font-weight:400;
-margin:0 0 20px;
-}
-
-#frontpage_splash h1 strong {
-font-family: $heading-font-family;
-font-size:54px;
-line-height: 1em;
-color:#005068;
-font-weight:400;
-}
-
-#frontpage_splash h1 span {
-font-family: $heading-font-family;
-font-style:inherit;
-font-size:39px;
-color:#005068;
-}
-
-#frontpage_splash h2 {
-font-size:26px;
-font-weight:400;
-color:#005068;
-font-family: $heading-font-family;
-}
-
-#frontpage_splash h2 strong {
-font-size:31px;
-color:#005068;
-font-family: $heading-font-family;
-}
-
-#frontpage_splash h2 span {
-color:#005068;
-font-style:inherit;
-font-size:19px;
-font-family: $heading-font-family;
-}
-
-#frontpage_splash #frontpage_right_to_know {
-  margin-top: 80px;
-  width: 221px;
-  float: left;
-}
-
-#frontpage_right_to_know h2, #frontpage_search_box h2 {
-  margin-top: 0px;
-}
-
-#frontpage_splash #frontpage_start_request {
-  margin-top: 50px;
-  margin-left: 70px;
-  margin-right: 70px;
-  width: 291px;
-  float: left;
-}
-
-#frontpage_splash #frontpage_search_box {
-  margin-top: 80px;
-  width: 221px;
-  float: left;
-  margin-bottom: 0px;
-}
-
 // Special components
 
 p.public-body-name-prefix {
@@ -745,6 +671,80 @@ color:#FFF;
 
 div.pagination {
 padding-top:1em;
+}
+
+// Front Page
+
+#frontpage_splash {
+background: none;
+}
+
+#frontpage_splash h1 {
+font-family: $heading-font-family;
+font-size:39px;
+color:#005068;
+font-weight:400;
+margin:0 0 20px;
+}
+
+#frontpage_splash h1 strong {
+font-family: $heading-font-family;
+font-size:54px;
+line-height: 1em;
+color:#005068;
+font-weight:400;
+}
+
+#frontpage_splash h1 span {
+font-family: $heading-font-family;
+font-style:inherit;
+font-size:39px;
+color:#005068;
+}
+
+#frontpage_splash h2 {
+font-size:26px;
+font-weight:400;
+color:#005068;
+font-family: $heading-font-family;
+}
+
+#frontpage_splash h2 strong {
+font-size:31px;
+color:#005068;
+font-family: $heading-font-family;
+}
+
+#frontpage_splash h2 span {
+color:#005068;
+font-style:inherit;
+font-size:19px;
+font-family: $heading-font-family;
+}
+
+#frontpage_splash #frontpage_right_to_know {
+  margin-top: 80px;
+  width: 221px;
+  float: left;
+}
+
+#frontpage_right_to_know h2, #frontpage_search_box h2 {
+  margin-top: 0px;
+}
+
+#frontpage_splash #frontpage_start_request {
+  margin-top: 50px;
+  margin-left: 70px;
+  margin-right: 70px;
+  width: 291px;
+  float: left;
+}
+
+#frontpage_splash #frontpage_search_box {
+  margin-top: 80px;
+  width: 221px;
+  float: left;
+  margin-bottom: 0px;
 }
 
 // Front Page Supporting Orgs section

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -697,10 +697,35 @@ input::-moz-focus-inner
 
 #date_range label.title,#filter_requests_form label.title,h3.title {
 width:120px;
+padding-right: 0;
+}
+
+.list-filter-item {
+  h3.title {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      display: inline-block;
+      vertical-align: middle;
+      margin-top: 2px;
+    }
+  }
+
+  input {
+    margin-bottom: 0.7em;
+    height: auto;
+  }
+}
+
+#filter_requests_form .list-filter-item, #search_form .list-filter-item, #filter_form .list-filter-item {
+  margin-bottom: 0;
 }
 
 .filter-request-types {
-  width: 445px;
+  margin-bottom: 1em;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    width: 405px;
+    vertical-align: top;
+  }
 }
 
 div.pagination {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1054,7 +1054,15 @@ label.form_label {
 #sign_together {
   h1 {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      margin: .25em 0 1em 2.4em;
+      margin: .25em 0 1em 2.375em;
+    }
+  }
+
+  #right_half {
+    h1 {
+      @include respond-min( $main_menu-mobile_menu_cutoff ) {
+        margin: .25em 0 1em 2.125em;
+      }
     }
   }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -593,6 +593,7 @@ background-image: image-url('button-gradient.png');
 }
 
 form input[type=submit],a.link_button_green, a.link_button_green_large {
+  padding: 0 6px;
   color: #fff;
   font-size: 18px;
   border: solid 1px #69952f;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -497,6 +497,19 @@ color:#005068;
   }
 }
 
+#request_list {
+  h1 {
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      margin-bottom: 15px;
+    }
+  }
+
+  .foi_results {
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      margin-top: 0;
+    }
+  }
+}
 
 .body_listing {
   border-bottom: 1px solid #DDD;
@@ -892,7 +905,7 @@ input::-moz-focus-inner
 }
 
 #date_range label.title,#filter_requests_form label.title,h3.title {
-width:120px;
+width:125px;
 padding-right: 0;
 }
 
@@ -901,7 +914,7 @@ padding-right: 0;
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       display: inline-block;
       vertical-align: middle;
-      margin-top: 2px;
+      margin-top: 11px;
     }
   }
 
@@ -915,12 +928,19 @@ padding-right: 0;
   margin-bottom: 0;
 }
 
+#filter_requests_form, #filter_requests_form input[type="submit"] {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-bottom: 5px;
+  }
+}
+
 .filter-request-types {
   margin-bottom: 1em;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     width: 405px;
     vertical-align: top;
+    margin-bottom: 11px;
   }
 }
 
@@ -1225,6 +1245,10 @@ background:#005068;
 color:#FFF;
 }
 
+input.use-datepicker[type=text] {
+  width: 142px;
+  background: url(/assets/calendar.png) no-repeat 115px 3px;
+}
 
 div.pagination {
 padding-top:1em;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -353,10 +353,6 @@ float: none;
   }
 }
 
-span#to_public_body {
-font-family: $body-font-family;
-}
-
 #middle_strip {
 color:#005068;
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -36,6 +36,10 @@ font-size:42px;
 h2 {
 font-size:1.4em;
 font-weight:400;
+
+  #right_column_flip & {
+    margin-bottom: 17.340px;
+  }
 }
 
 h3 {
@@ -841,10 +845,6 @@ div.correspondence p.preview_subject {
 }
 
 #public_body_list {
-  #right_column_flip h2 {
-    margin-bottom: 17.340px;
-  }
-
   li {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       line-height: normal;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -280,6 +280,11 @@ a:hover, .request_listing .requester a:hover {
   text-decoration: underline;
 }
 
+p {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
 p.subtitle {
 color:#005068;
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -640,6 +640,14 @@ div.correspondence p.preview_subject {
   line-height: 25px;
 }
 
+#notice {
+  padding: 0 1em;
+  font-size: 1.4em;
+  background: #E9FDD3;
+  color: #517704;
+  border: #B0CA86 1px solid;
+}
+
 // Forms
 
 form#signin_form input[type=text], form#signin_form input[type=password], form#signup_form input[type=text], form#signup_form input[type=password] {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -387,6 +387,12 @@ color:#005068;
     min-height: 36px;
     padding: 3px 0 0 27px;
   }
+
+  .request_right {
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      padding-left: 0;
+    }
+  }
 }
 
 #public_body_list {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1,3 +1,6 @@
+$body-font-family: 'Maven Pro', Arial, sans-serif;
+$heading-font-family: 'Actor', Arial, sans-serif;
+
 // Basic styles
 
 body {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1273,6 +1273,44 @@ padding-top:1em;
     font-size: 28px;
 }
 
+#frontpage_examples {
+  ul {
+    padding-bottom: 1em;
+  }
+
+  #examples_0 {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      padding-right: .5em;
+    }
+  }
+
+  #examples_1 {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      padding-right: .5em;
+      padding-left: .75em;
+    }
+
+    ul li {
+      @include respond-min( $main_menu-mobile_menu_cutoff ) {
+        padding: 5px 0;
+      }
+    }
+
+    li:last-child {
+      border-bottom: 0;
+    }
+  }
+
+  .excerpt {
+    cursor: pointer;
+    background: url('/assets/quote-marks.png') no-repeat scroll 0% 0% transparent;
+    color: #444;
+    line-height: 18px;
+    min-height: 30px;
+    padding: 0px 0px 0px 40px;
+  }
+}
+
 // Front Page Supporting Orgs section
 
 #frontpage_supporting {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -330,6 +330,36 @@ color:#005068;
   width: 33em;
 }
 
+.request_listing, .body_listing, .user_listing {
+  margin: 0 0 -1px;
+  border-bottom: 1px solid #DDD;
+  padding: 12px 0 6px;
+  font-size: 0.9em;
+  line-height: normal;
+}
+
+.body_listing, .user_listing {
+  span.desc, span.bottomline {
+    font-style: normal;
+    font-weight: 400;
+    margin: 0;
+    padding: 0;
+  }
+}
+
+.request_listing {
+  span.bottomline {
+    font-style: normal;
+    margin-bottom: 0;
+    margin-top: 12px;
+    background-position: top left;
+    font-size: 1.1em;
+    font-weight: 400;
+    min-height: 36px;
+    padding: 3px 0 0 27px;
+  }
+}
+
 // Buttons
 
 form input[type=submit],a.link_button_green,a.link_button_green_large {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -497,6 +497,19 @@ color:#005068;
   }
 }
 
+
+.body_listing {
+  border-bottom: 1px solid #DDD;
+  margin: 0 0 -1px;
+  padding: 12px 0 6px;
+
+  .head {
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      margin-bottom: 2px;
+    }
+  }
+}
+
 #public_body_list {
   ul {
     margin: 1em 0;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -74,12 +74,17 @@ background: #d0ffff;
 
 #logged_in_bar {
 color:#444;
-font-size: 0.9em;
+
+@include respond-min( $main_menu-mobile_menu_cutoff ){
+  font-size: 0.9em;
+}
 
   #logged_in_links {
     a, .greeting {
-      font-weight: normal;
-      padding: 0;
+      @include respond-min( $main_menu-mobile_menu_cutoff ){
+        font-weight: normal;
+        padding: 0;
+      }
     }
   }
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -5,7 +5,7 @@ $heading-font-family: 'Actor', Arial, sans-serif;
 
 body {
 color:#444;
-font-family:'Maven Pro', Arial, sans-serif;
+font-family: $body-font-family;
 background-color: #f0f0f0;
 }
 
@@ -92,7 +92,7 @@ z-index: 90;
 }
 
 #topnav {
-font-family:'Maven Pro', Arial, sans-serif;
+font-family: $body-font-family;
 float: right;
 margin-left: 0;
 top: 100px;
@@ -149,7 +149,7 @@ color:#ffffff;
 }
 
 h1,h2,h3 {
- font-family: 'Actor', Arial, sans-serif;
+font-family: $heading-font-family;
  color:#005068;
 }
 
@@ -165,7 +165,7 @@ font-size:1.4em;
 
 h2,dt {
 color:#005068;
-font-family:'Actor', Arial, sans-serif;
+font-family: $heading-font-family;
 font-weight:400;
 }
 
@@ -192,7 +192,7 @@ color:#005068;
 
 .request_listing span.head a,.user_listing span.head a,.body_listing span.head a {
 color:#A60201;
-font-family:'Maven Pro', Arial, sans-serif;
+font-family: $body-font-family;
 font-weight:400;
 }
 
@@ -202,7 +202,7 @@ color:#444;
 }
 
 span#to_public_body {
-font-family:'Maven Pro', Arial, sans-serif;
+font-family: $body-font-family;
 }
 
 #middle_strip {
@@ -222,7 +222,7 @@ color:#005068;
 }
 
 #request_form label,label.form_label {
-font-family:'Maven Pro', Arial, sans-serif;
+font-family: $body-font-family;
 color:#005068;
 }
 
@@ -231,7 +231,7 @@ color:#005068;
 }
 
 #request_form textarea {
-  font-family:'Maven Pro', Arial, sans-serif;
+  font-family: $body-font-family;
   font-size: 15px;
   width: 33em;
 }
@@ -239,7 +239,7 @@ color:#005068;
 // Buttons
 
 form input[type=submit],a.link_button_green,a.link_button_green_large {
-font-family:'Maven Pro', Arial, sans-serif;
+font-family: $body-font-family;
 }
 
 a.link_button_green:hover,a.link_button_green_large:hover {
@@ -318,7 +318,7 @@ background: none;
 }
 
 #frontpage_splash h1 {
-font-family:'Actor', Arial, sans-serif;
+font-family: $heading-font-family;
 font-size:39px;
 color:#005068;
 font-weight:400;
@@ -326,7 +326,7 @@ margin:0 0 20px;
 }
 
 #frontpage_splash h1 strong {
-font-family:'Actor', Arial, sans-serif;
+font-family: $heading-font-family;
 font-size:54px;
 line-height: 1em;
 color:#005068;
@@ -334,7 +334,7 @@ font-weight:400;
 }
 
 #frontpage_splash h1 span {
-font-family:'Actor', Arial, sans-serif;
+font-family: $heading-font-family;
 font-style:inherit;
 font-size:39px;
 color:#005068;
@@ -344,13 +344,13 @@ color:#005068;
 font-size:26px;
 font-weight:400;
 color:#005068;
-font-family:'Actor', Arial, sans-serif;
+font-family: $heading-font-family;
 }
 
 #frontpage_splash h2 strong {
 font-size:31px;
 color:#005068;
-font-family:'Actor', Arial, sans-serif;
+font-family: $heading-font-family;
 }
 
 #frontpage_splash h2 span {
@@ -388,7 +388,7 @@ font-family: 'Actor', Arial, sans-serif;
 // Date Picker
 
 #ui-datepicker-div.ui-widget {
-font-family:'Maven Pro', Arial, sans-serif;
+font-family: $body-font-family;
 color:#005068;
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -286,6 +286,7 @@ color:#444;
 // Site Footer
 
 #footer {
+  margin-top: 4.15em;
   border-top: 1px #ddd solid;
   background-color: #f0f0f0;
   font-size: 1em;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -286,12 +286,6 @@ float: none;
   padding-top: 2em;
 }
 
-.request_listing span.head a,.user_listing span.head a,.body_listing span.head a {
-color:#A60201;
-font-family: $body-font-family;
-font-weight:400;
-}
-
 span#to_public_body {
 font-family: $body-font-family;
 }
@@ -333,6 +327,12 @@ color:#005068;
   padding: 12px 0 6px;
   font-size: 0.9em;
   line-height: normal;
+
+  span.head a {
+    color:#A60201;
+    font-family: $body-font-family;
+    font-weight:400;
+  }
 }
 
 .body_listing, .user_listing {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -455,6 +455,10 @@ color:#005068;
   }
 }
 
+.feed_link {
+  padding: 4px 0;
+}
+
 // Buttons
 
 a.link_button_green:hover,a.link_button_green_large:hover {
@@ -468,6 +472,7 @@ background-image: image-url('button-gradient.png');
 
 form input[type=submit],a.link_button_green, a.link_button_green_large {
   padding: 5px 6px;
+  display: inline-block;
   color: #fff;
   font-size: 18px;
   font-family: $body-font-family;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -600,32 +600,6 @@ font-family: $heading-font-family;
   margin-bottom: 0px;
 }
 
-// Date Picker
-
-#ui-datepicker-div {
-  box-sizing: normal;
-}
-
-#ui-datepicker-div.ui-widget {
-font-family: $body-font-family;
-color:#005068;
-}
-
-#ui-datepicker-div .ui-datepicker-header,#ui-datepicker-div .ui-widget-header {
-color:#005068;
-font-family:'Maven Pro';
-}
-
-#ui-datepicker-div .ui-state-default:hover {
-background: $righttoknow-primary-color;
-color:#FFF;
-}
-
-#ui-datepicker-div .ui-state-active {
-background:#005068;
-color:#FFF;
-}
-
 // Special components
 
 p.public-body-name-prefix {
@@ -741,6 +715,33 @@ padding-right: 0;
     vertical-align: top;
   }
 }
+
+// Date Picker
+
+#ui-datepicker-div {
+  box-sizing: normal;
+}
+
+#ui-datepicker-div.ui-widget {
+font-family: $body-font-family;
+color:#005068;
+}
+
+#ui-datepicker-div .ui-datepicker-header,#ui-datepicker-div .ui-widget-header {
+color:#005068;
+font-family:'Maven Pro';
+}
+
+#ui-datepicker-div .ui-state-default:hover {
+background: $righttoknow-primary-color;
+color:#FFF;
+}
+
+#ui-datepicker-div .ui-state-active {
+background:#005068;
+color:#FFF;
+}
+
 
 div.pagination {
 padding-top:1em;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -798,6 +798,10 @@ div.correspondence p.preview_subject {
 }
 
 #public_body_list {
+  #right_column_flip h2 {
+    margin-bottom: 17.340px;
+  }
+
   li {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       line-height: normal;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -18,6 +18,7 @@ background-color: #f0f0f0;
 
 #footer {
   float: inherit;
+  border-top: 1px #ddd solid;
 }
 
 #footer_inner {
@@ -75,10 +76,6 @@ background-color:#00DCF0;
 -moz-box-shadow: 0 0 10px;
 -webkit-box-shadow: 0 0 10px;
 box-shadow: 0 0 10px;
-}
-
-#footer {
-  border-top: 1px #ddd solid;
 }
 
 #logo img {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -820,6 +820,10 @@ background-color:inherit;
 // padding:0px 6px;
 // }
 
+form input[type="text"] {
+  width: 212px;
+}
+
 input::-moz-focus-inner
 {
     border: 0;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -802,7 +802,7 @@ form input[type=text], form input[type=password] {
 }
 
 form#signin_form input[type=text], form#signin_form input[type=password], form#signup_form input[type=text], form#signup_form input[type=password] {
-width:270px;
+width:282px;
 }
 
 form#set_draft_profile_photo_form label.form_label {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -840,11 +840,15 @@ div.correspondence p.preview_subject {
 }
 
 #notice {
-  padding: 0 1em;
+  padding: .75em 1em;
   font-size: 1.4em;
   background: #E9FDD3;
   color: #517704;
   border: #B0CA86 1px solid;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    padding: 0 1em;
+  }
 }
 
 .request_icon_line {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1,3 +1,4 @@
+$righttoknow-primary-color: #00DCF0;
 $body-font-family: 'Maven Pro', Arial, sans-serif;
 $heading-font-family: 'Actor', Arial, sans-serif;
 
@@ -20,7 +21,7 @@ background-color: #f0f0f0;
 // Site Header
 
 #banner {
-background-color:#00DCF0;
+background-color: $righttoknow-primary-color;
 -moz-box-shadow: 0 0 10px;
 -webkit-box-shadow: 0 0 10px;
 box-shadow: 0 0 10px;
@@ -408,7 +409,7 @@ font-family:'Maven Pro';
 }
 
 #ui-datepicker-div .ui-state-default:hover {
-background:#00dcf0;
+background: $righttoknow-primary-color;
 color:#FFF;
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -52,6 +52,12 @@ font-weight:400;
   }
 }
 
+h4 {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    font-size: 1em;
+  }
+}
+
 dl {
   line-height: 160%;
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -74,6 +74,12 @@ background: #d0ffff;
 
 #logged_in_bar {
 color:#444;
+
+  #logged_in_links {
+    a, .greeting {
+      font-weight: normal;
+    }
+  }
 }
 
 #logged_in_bar a,#logged_in_bar a:visited {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -30,6 +30,13 @@ box-shadow: 0 0 10px;
     width: 53.66667%;
     padding: .5em 1em;
   }
+
+  .rsp_menu_button {
+    background: #fff;
+    width: auto;
+    margin: 1.5em 1em 0 0;
+    padding: .5em 1em;
+  }
 }
 
 #banner_inner a#logo {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -961,6 +961,18 @@ padding-right: 0;
 
 #request_header {
   background-color: #FFFFE0;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-left: 1em;
+  }
+
+  #request_header_body,
+  #request_header_subject {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      padding-right: 0;
+      padding-left: 0;
+    }
+  }
 }
 
 #request_header_text, #request_search_ahead_results {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -382,12 +382,6 @@ color:#005068;
   font-size: 1.1em;
 }
 
-#request_form textarea {
-  font-family: $body-font-family;
-  font-size: 15px;
-  width: 33em;
-}
-
 .request_listing, .body_listing, .user_listing {
   margin-top: 0;
   margin-bottom: -1px;
@@ -717,6 +711,59 @@ padding-right: 0;
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     width: 405px;
     vertical-align: top;
+  }
+}
+
+#request_new {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    @include clearfix;
+  }
+
+  label {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      display: block;
+      float: left;
+      clear: none;
+      width: 110px;
+      text-align: left;
+      margin: 2px 0 0;
+      padding: 0 10px 0 0;
+    }
+  }
+
+  .form_item_note,
+  #request_header_text,
+  #request_form .form_note {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      width: 34em;
+      margin-left: 110px;
+    }
+  }
+
+  #request_advice {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      @include grid-column($columns:3, $float:right);
+      position: static;
+    }
+  }
+
+  #request_form {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      @include grid-column($columns:9, $float:left);
+      position: static;
+    }
+
+    .form_button {
+      @include respond-min( $main_menu-mobile_menu_cutoff ) {
+        margin: 0 0 0 9em;
+      }
+    }
+  }
+
+  #outgoing_message_body {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      width: 34em;
+    }
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -9,6 +9,10 @@ body {
 color:#444;
 font-family: $body-font-family;
 background-color: #f0f0f0;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    line-height: normal;
+  }
 }
 
 h1,h2,h3,dt {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1118,6 +1118,9 @@ padding-top:1em;
   margin-top: 0px;
 }
 
+.front h3 {
+    font-size: 28px;
+}
 
 // Front Page Supporting Orgs section
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -794,6 +794,12 @@ padding-right: 0;
   background-color: #FFFFE0;
 }
 
+#request_header_text {
+  background-color: #D5FFD8;
+  border: #1EFF38 solid 1px;
+  font-style: italic;
+}
+
 // Date Picker
 
 #ui-datepicker-div {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -535,6 +535,11 @@ form input[type=submit],a.link_button_green, a.link_button_green_large {
   }
 }
 
+form input[type=submit] {
+  padding-top: 3px;
+  padding-bottom: 4px;
+}
+
 a.link_button_green_large {
 // background-image: image-url('button-gradient-large.png');
 display: inline-block;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -818,6 +818,14 @@ padding-right: 0;
   font-style: italic;
 }
 
+#request_search_ahead_results {
+  margin-left: 11em;
+
+  h3:first-child {
+    margin-top: 0;
+  }
+}
+
 .form_item_note, .form_note {
   font-size: 1em;
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -16,7 +16,7 @@ background-color: #f0f0f0;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  text-rendering: optimizeLegibility;
+  text-rendering: auto;
 }
 
 h1,h2,h3,dt {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -841,13 +841,13 @@ div.correspondence p.preview_subject {
 
 #notice {
   padding: .75em 1em;
-  font-size: 1.4em;
   background: #E9FDD3;
   color: #517704;
   border: #B0CA86 1px solid;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     padding: 0 1em;
+    font-size: 1.4em;
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -11,7 +11,7 @@ font-family: $body-font-family;
 background-color: #f0f0f0;
 }
 
-h1,h2,h3 {
+h1,h2,h3,dt {
 font-family: $heading-font-family;
  color:#005068;
 }
@@ -23,17 +23,16 @@ font-size:42px;
 
 h2 {
 font-size:1.4em;
-}
-
-h2,dt {
-color:#005068;
-font-family: $heading-font-family;
 font-weight:400;
 }
 
 h3 {
 color:#005068;
 font-weight:400;
+}
+
+dt {
+  font-size: 1.8em;
 }
 
 p {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -15,6 +15,10 @@ background-color: #f0f0f0;
   }
 }
 
+h1, h2, h3, h4, h5, h6 {
+  text-rendering: optimizeLegibility;
+}
+
 h1,h2,h3,dt {
   font-family: $heading-font-family;
   color:#005068;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -25,10 +25,11 @@ background-color: $righttoknow-primary-color;
 -moz-box-shadow: 0 0 10px;
 -webkit-box-shadow: 0 0 10px;
 box-shadow: 0 0 10px;
-}
 
-#logo img {
-  width: 250px;
+  #logo_wrapper {
+    width: 53.66667%;
+    padding: .5em 1em;
+  }
 }
 
 #banner_inner a#logo {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -93,10 +93,11 @@ color:#444;
       }
     }
   }
-}
 
-#logged_in_bar a,#logged_in_bar a:visited {
-color:#ffffff;
+  a,
+  a:visited {
+    color:#ffffff;
+  }
 }
 
 #navigation_search {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -336,6 +336,13 @@ float: none;
     width: 56.125em;
   }
 
+  // TODO: remove this to set footer inline with
+  //       site margin
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    padding-right: .3em;
+    padding-left: .3em;
+  }
+
   > div {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       font-size: .85em;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -79,10 +79,9 @@ background-color: $righttoknow-primary-color;
 -webkit-box-shadow: 0 0 10px;
 box-shadow: 0 0 10px;
 
-  #logo_wrapper {
-    width: 53.66667%;
-    padding: .5em 1em;
-  }
+@include respond-min( $main_menu-mobile_menu_cutoff ) {
+  height: 160px;
+}
 
   .rsp_menu_button {
     background: #fff;
@@ -95,24 +94,43 @@ box-shadow: 0 0 10px;
 #banner_inner {
   max-width:$row-width;
   margin: auto;
-  position: relative;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    @include clearfix;
+    position: relative;
+  }
 }
 
 a#logo {
-  left: 9px;
-  top:75px;
-  z-index: 90;
+  width: 53.66667%;
+  padding: .5em 1em;
+  display: inline-block;
+  float: left;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    padding: 0;
+    width: auto;
+    position: relative;
+    left: 14px;
+    top:75px;
+    z-index: 90;
+  }
 }
 
 #topnav {
 font-family: $body-font-family;
-float: right;
-margin-left: 0;
-top: 100px;
 background: $righttoknow-primary-color-lighter;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin: 0 5px 0 0;
+    float: right;
+    font-size: 1.2em;
+  }
 }
+
 #topnav li a{
   padding: 10px 13px;
+  color: #444;
 }
 #topnav li a:hover {
   color:#005068;
@@ -140,13 +158,13 @@ color:#444;
 
   #logged_in_links {
     @include respond-min( $main_menu-mobile_menu_cutoff ){
-      top: .875em;
-      right: 22em;
+      top: .9em;
+      right: 20.8em;
     }
 
     a, .greeting {
       @include respond-min( $main_menu-mobile_menu_cutoff ){
-        font-size: 14px;
+        font-size: 13.5px;
         font-weight: normal;
         padding: 0;
       }
@@ -173,6 +191,7 @@ color:#444;
   }
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    padding: 0 5px;
     display: block;
     position: absolute;
     z-index: 150;
@@ -217,8 +236,8 @@ color:#444;
   @include respond-min( $main_menu-mobile_menu_cutoff ){
     margin: 5px -1px 0 0;
     padding: 5px 0 5px 2em;
-    width: 20.25em;
-    height: 24px;
+    width: 22.8em;
+    height: 26px;
     font-size: 0.8em;
   }
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -803,6 +803,18 @@ div.correspondence p.preview_subject {
       line-height: normal;
     }
   }
+
+  #search_form {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin-bottom: 0;
+    }
+  }
+}
+
+h2.publicbody_results {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-top: .15em;
+  }
 }
 
 // Forms

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -107,6 +107,12 @@ box-shadow: 0 0 10px;
   }
 }
 
+#banner_content {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    height: 97px;
+  }
+}
+
 a#logo {
   width: 53.66667%;
   padding: .5em 1em;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -656,6 +656,12 @@ div.correspondence p.preview_subject {
 
 // Forms
 
+form input[type=text], form input[type=password] {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    height: 30px;
+  }
+}
+
 form#signin_form input[type=text], form#signin_form input[type=password], form#signup_form input[type=text], form#signup_form input[type=password] {
 width:270px;
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -592,6 +592,10 @@ font-family: $heading-font-family;
 
 // Date Picker
 
+#ui-datepicker-div {
+  box-sizing: normal;
+}
+
 #ui-datepicker-div.ui-widget {
 font-family: $body-font-family;
 color:#005068;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -593,6 +593,12 @@ background-image: image-url('button-gradient.png');
 }
 
 form input[type=submit],a.link_button_green, a.link_button_green_large {
+  color: #fff;
+  font-size: 18px;
+  border: solid 1px #69952f;
+  border-radius: 2px;
+  text-shadow: 1px 1px 0 #5b841d;
+  cursor: pointer;
   background: -moz-linear-gradient(top,  #b2ef40 0%, #7cae36 100%);
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#b2ef40), color-stop(100%,#7cae36));
   background: -webkit-linear-gradient(top,  #b2ef40 0%,#7cae36 100%);

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1203,12 +1203,6 @@ label.form_label {
     }
   }
 
-  form p {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      margin-top: 0;
-    }
-  }
-
   .form_button {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       margin-left: 10.5em;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -76,16 +76,12 @@ color:#ffffff;
   margin-right: inherit;
 }
 
-#navigation_search input#navigation_search_query {
-  border-color: #888;
-  background-image: image-url('search-icon.png') no-repeat left center;
-  background-color: white;
+// TODO: This id is wong on the template,
+//       we're targeting the text-input not
+//       the button. This should be fixed upstream.
+#navigation_search input#navigation_search_button {
   padding-left: 2em;
   border-radius: 5px;
-}
-
-#navigation_search input#navigation_search_button {
-  display: none;
 }
 
 // Site Footer

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1,0 +1,668 @@
+body {
+color:#444;
+font-family:'Maven Pro', Arial, sans-serif;
+background-color: #f0f0f0;
+}
+
+.entirebody {
+  background-color: white;
+}
+
+.after-footer {
+  background-color: #f0f0f0;
+}
+
+#footer {
+  float: inherit;
+}
+
+#footer_inner {
+width:890px;
+position:relative;
+margin:auto;
+}
+
+#oaf_logo {
+  border: 1px #bbb solid;
+  vertical-align: middle;
+  margin-left: 5px;
+}
+
+#oaf {
+  margin-top: 1em;
+  margin-bottom: 50px;
+  float: left;
+  text-align: left;
+}
+
+#footer img {
+  border: 1px #ddd solid;
+  vertical-align: middle;
+}
+
+#oaf ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+#footer ul li {
+  margin-top: 5px;
+}
+
+#footer p {
+  margin-top: 0;
+}
+
+#footer .right {
+  margin-top: 22px;
+  float: right;
+  text-align: left;
+}
+
+#footer .right ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+#banner {
+background-color:#00DCF0;
+-moz-box-shadow: 0 0 10px;
+-webkit-box-shadow: 0 0 10px;
+box-shadow: 0 0 10px;
+}
+
+#footer {
+  border-top: 1px #ddd solid;
+}
+
+#logo img {
+  width: 250px;
+}
+
+#banner_inner a#logo {
+left: 9px;
+top:75px;
+z-index: 90;
+}
+
+#topnav {
+font-family:'Maven Pro', Arial, sans-serif;
+float: right;
+margin-left: 0;
+top: 100px;
+background: #d0ffff;
+}
+#topnav li a{
+  padding: 10px 13px;
+}
+#topnav li a:hover {
+  color:#005068;
+}
+
+#topnav ul li {
+  padding: 0;
+  margin: 0;
+}
+
+#topnav ul li.selected, #topnav ul li:hover {
+ background:#fff;
+}
+
+#logged_in_bar {
+color:#444;
+}
+
+#logged_in_bar a,#logged_in_bar a:visited {
+color:#ffffff;
+}
+
+#content {
+  padding-top: 2em;
+}
+
+h1,h2,h3 {
+ font-family: 'Actor', Arial, sans-serif;
+ color:#005068;
+}
+
+h1 {
+color:#005068;
+font-size:42px;
+}
+
+h2 {
+font-size:1.4em;
+}
+
+
+h2,dt {
+color:#005068;
+font-family:'Actor', Arial, sans-serif;
+font-weight:400;
+}
+
+h3 {
+color:#005068;
+font-weight:400;
+}
+
+a, a:hover {
+  color:#A60201;
+}
+
+a, .request_listing .requester a {
+  text-decoration: none;
+}
+
+a:hover, .request_listing .requester a:hover {
+  text-decoration: underline;
+}
+
+p.subtitle {
+color:#005068;
+}
+
+.request_listing span.head a,.user_listing span.head a,.body_listing span.head a {
+color:#A60201;
+font-family:'Maven Pro', Arial, sans-serif;
+font-weight:400;
+}
+
+.request_listing span.desc {
+background-image: image-url('quote-marks.png') no-repeat;
+color:#444;
+}
+
+span#to_public_body {
+font-family:'Maven Pro', Arial, sans-serif;
+}
+
+#middle_strip {
+color:#005068;
+}
+
+#stepwise_make_request {
+  text-align: center;
+}
+
+#stepwise_make_request a {
+  margin: 15px auto 0 auto;
+}
+
+#request_header_subject input {
+  width: 409px;
+}
+
+#request_form label,label.form_label {
+font-family:'Maven Pro', Arial, sans-serif;
+color:#005068;
+}
+
+.list-filter-item h3 {
+  font-size: 1.1em;
+}
+
+#request_form textarea {
+  font-family:'Maven Pro', Arial, sans-serif;
+  font-size: 15px;
+  width: 33em;
+}
+
+#navigation_search {
+  opacity: inherit;
+}
+
+#navigation_search p {
+  margin-right: inherit;
+}
+
+#navigation_search input#navigation_search_query {
+  border-color: #888;
+  background-image: image-url('search-icon.png') no-repeat left center;
+  background-color: white;
+  padding-left: 2em;
+  border-radius: 5px;
+}
+
+#navigation_search input#navigation_search_button {
+  display: none;
+}
+
+form input[type=submit],a.link_button_green,a.link_button_green_large {
+font-family:'Maven Pro', Arial, sans-serif;
+}
+
+a.link_button_green:hover,a.link_button_green_large:hover {
+  text-decoration: none;
+  color: white;
+}
+
+/* Mostly magic for adding page curls */
+
+div#request_show {
+  position: relative;
+  z-index: 10;
+}
+div.correspondence {
+  margin-bottom: 2em;
+  /* Setting overflow: auto breaks the page-curl */
+  overflow: inherit;
+
+  background: #F9F9F9;
+  /*background: -moz-linear-gradient(0deg, #FCFCFC 0%, #FFF 25%, #FFF 75%, #FCFCFC 100%);
+  background: -ms-linear-gradient(0deg, #FCFCFC 0%, #FFF 25%, #FFF 75%, #FCFCFC 100%);
+  background: -webkit-linear-gradient(0deg, #FCFCFC 0%, #FFF 25%, #FFF 75%, #FCFCFC 100%);
+  background: linear-gradient(0deg, #FCFCFC 0%, #FFF 25%, #FFF 75%, #FCFCFC 100%);*/
+  border: 1px solid #777777;
+  -moz-border-radius: 6px 6px 6px 6px;
+  -webkit-border-radius: 6px 6px 6px 6px;
+  border-radius: 6px 6px 6px 6px;
+  -moz-box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);
+  -webkit-box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);
+  position: relative;
+}
+
+div.outgoing.correspondence {
+  background: #ffffd2;
+  /*background: -moz-linear-gradient(0deg, #F5F5C7 0%, #FFFFD2 25%, #FFFFD2 75%, #F5F5C7 100%);
+  background: -ms-linear-gradient(0deg, #F5F5C7 0%, #FFFFD2 25%, #FFFFD2 75%, #F5F5C7 100%);
+  background: -webkit-linear-gradient(0deg, #F5F5C7 0%, #FFFFD2 25%, #FFFFD2 75%, #F5F5C7 100%);
+  background: linear-gradient(0deg, #F5F5C7 0%, #FFFFD2 25%, #FFFFD2 75%, #F5F5C7 100%);*/
+}
+
+div.correspondence:before, div.correspondence:after {
+  background: none;
+  bottom: 12px;
+  -moz-box-shadow: 0 10px 12px rgba(0, 0, 0, 0.5);
+  -webkit-box-shadow: 0 10px 12px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 10px 12px rgba(0, 0, 0, 0.5);
+  content: "";
+  height: 10px;
+  left: 12px;
+  position: absolute;
+  width: 40%;
+  z-index: -1;
+  -moz-transform: skew(-4deg) rotate(-4deg);
+  -webkit-transform: skew(-4deg) rotate(-4deg);
+  transform: skew(-4deg) rotate(-4deg);
+  top: auto;
+  bottom: 12px;
+  -moz-box-shadow: 0 10px 12px rgba(0, 0, 0, 0.5);
+  -webkit-box-shadow: 0 10px 12px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 10px 12px rgba(0, 0, 0, 0.5);
+}
+
+div.correspondence:after {
+  -moz-transform: skew(4deg) rotate(4deg);
+  -webkit-transform: skew(4deg) rotate(4deg);
+  transform: skew(4deg) rotate(4deg);
+  left: auto;
+  right: 12px;
+}
+
+#frontpage_splash {
+background: none;
+}
+
+#frontpage_splash h1 {
+font-family:'Actor', Arial, sans-serif;
+font-size:39px;
+color:#005068;
+font-weight:400;
+margin:0 0 20px;
+}
+
+#frontpage_splash h1 strong {
+font-family:'Actor', Arial, sans-serif;
+font-size:54px;
+line-height: 1em;
+color:#005068;
+font-weight:400;
+}
+
+#frontpage_splash h1 span {
+font-family:'Actor', Arial, sans-serif;
+font-style:inherit;
+font-size:39px;
+color:#005068;
+}
+
+#frontpage_splash h2 {
+font-size:26px;
+font-weight:400;
+color:#005068;
+font-family:'Actor', Arial, sans-serif;
+}
+
+#frontpage_splash h2 strong {
+font-size:31px;
+color:#005068;
+font-family:'Actor', Arial, sans-serif;
+}
+
+#frontpage_splash h2 span {
+color:#005068;
+font-style:inherit;
+font-size:19px;
+font-family: 'Actor', Arial, sans-serif;
+}
+
+#frontpage_splash #frontpage_right_to_know {
+  margin-top: 80px;
+  width: 221px;
+  float: left;
+}
+
+#frontpage_right_to_know h2, #frontpage_search_box h2 {
+  margin-top: 0px;
+}
+
+#frontpage_splash #frontpage_start_request {
+  margin-top: 50px;
+  margin-left: 70px;
+  margin-right: 70px;
+  width: 291px;
+  float: left;
+}
+
+#frontpage_splash #frontpage_search_box {
+  margin-top: 80px;
+  width: 221px;
+  float: left;
+  margin-bottom: 0px;
+}
+
+#ui-datepicker-div.ui-widget {
+font-family:'Maven Pro', Arial, sans-serif;
+color:#005068;
+}
+
+#ui-datepicker-div .ui-datepicker-header,#ui-datepicker-div .ui-widget-header {
+color:#005068;
+font-family:'Maven Pro';
+}
+
+#ui-datepicker-div .ui-state-default:hover {
+background:#00dcf0;
+color:#FFF;
+}
+
+#ui-datepicker-div .ui-state-active {
+background:#005068;
+color:#FFF;
+}
+
+p.public-body-name-prefix {
+font-family: 'Actor', Arial, sans-serif;
+color:#005068;
+margin-bottom: 0px;
+}
+
+#other-country-notice a {
+color:#FFF;
+}
+
+
+#link_box {
+position:absolute;
+text-align:left;
+background-color:#fff;
+z-index:999;
+opacity:1.0;
+border-radius:6px;
+-moz-border-radius:6px;
+border:1px solid #005068;
+display:none;
+padding:10px;
+}
+
+#link_box .close-button {
+margin-left:15px;
+padding:0;
+}
+
+#follow_count {
+ font-family: 'Actor', Arial, sans-serif;
+ color:#005068;
+}
+
+div.controller_help dt:hover > a, div.controller_help h1:hover > a, div#help_unhappy h1:hover > a.hover_a {
+color: #a60201;
+}
+
+form#signin_form input[type=text], form#signin_form input[type=password], form#signup_form input[type=text], form#signup_form input[type=password] {
+width:270px;
+}
+
+form#set_draft_profile_photo_form label.form_label {
+  width: inherit;
+}
+
+.fieldWithErrors {
+background-color:#fee;
+border: none;
+padding: 0;
+}
+
+.correspondence .event_actions, .comment_in_request .event_actions {
+  opacity: 0;
+  transition: opacity .25s ease-in-out;
+  -moz-transition: opacity .25s ease-in-out;
+  -webkit-transition: opacity .25s ease-in-out;
+}
+
+.correspondence:hover .event_actions, .comment_in_request:hover .event_actions {
+  opacity: 1;
+}
+
+div.controller_help dt a,div.controller_help h1 a,div#help_unhappy h1 a.hover_a {
+background-color:inherit;
+}
+
+/* Fix button height in Firefox */
+form input[type=submit] {
+height: 30px;
+padding:0px 6px;
+}
+
+input::-moz-focus-inner
+{
+    border: 0;
+    padding: 0;
+}
+
+a.link_button_green_large {
+background-image: image-url('button-gradient-large.png');
+}
+
+form input[type=submit],a.link_button_green {
+background-image: image-url('button-gradient.png');
+}
+
+form input[type=submit],a.link_button_green, a.link_button_green_large {
+  background: -moz-linear-gradient(top,  #b2ef40 0%, #7cae36 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#b2ef40), color-stop(100%,#7cae36));
+  background: -webkit-linear-gradient(top,  #b2ef40 0%,#7cae36 100%);
+  background: -o-linear-gradient(top,  #b2ef40 0%,#7cae36 100%);
+  background: -ms-linear-gradient(top,  #b2ef40 0%,#7cae36 100%);
+  background: linear-gradient(to bottom,  #b2ef40 0%,#7cae36 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#b2ef40', endColorstr='#7cae36',GradientType=0 );
+}
+
+form input[type=submit]:hover,a.link_button_green:hover, a.link_button_green_large:hover {
+  background: -moz-linear-gradient(top,  #c2ff50 0%, #8cbe46 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c2ff50), color-stop(100%,#8cbe46));
+  background: -webkit-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
+  background: -o-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
+  background: -ms-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
+  background: linear-gradient(to bottom,  #c2ff50 0%,#8cbe46 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c2ff50', endColorstr='#8cbe46',GradientType=0 );
+}
+
+#date_range label.title,#filter_requests_form label.title,h3.title {
+width:120px;
+}
+
+.filter-request-types {
+  width: 445px;
+}
+
+div.pagination {
+padding-top:1em;
+}
+
+#frontpage_supporting {
+  clear: both;
+  padding-top: 1em;
+}
+
+#frontpage_supporting h2 {
+  margin-bottom: 1em;
+}
+
+#frontpage_supporting img {
+  margin-right: 20px;
+  margin-top: 10px;
+  vertical-align: middle;
+}
+
+#frontpage_supporting .logos a:hover {
+  text-decoration: none;
+}
+
+#openforum_logo {
+  opacity: 0.7;
+}
+
+#frontpage_supporting img {
+  transition: opacity .2s ease-in-out;
+  -moz-transition: opacity .2s ease-in-out;
+  -webkit-transition: opacity .2s ease-in-out;
+}
+
+#openforum_logo:hover {
+  opacity: 0.9;
+}
+
+#okfa_logo {
+  opacity: 0.8;
+}
+
+#okfa_logo:hover {
+  opacity: 1.0;
+}
+
+#cpd_logo {
+  opacity: 0.55;
+}
+
+#cpd_logo:hover {
+  opacity: 0.75;
+}
+
+#getup_logo {
+  opacity: 0.5;
+}
+
+#getup_logo:hover {
+  opacity: 0.7;
+}
+
+#crikey_logo {
+  opacity: 0.55;
+}
+
+#crikey_logo:hover {
+  opacity: 0.75;
+}
+
+#newmatilda_logo {
+  opacity: 0.6;
+}
+
+#newmatilda_logo:hover {
+  opacity: 0.8;
+}
+
+#ausgoal_logo {
+  opacity: 0.65;
+}
+
+#ausgoal_logo:hover {
+  opacity: 0.85;
+}
+
+#newdemocracy_logo {
+  opacity: 0.6;
+}
+
+#newdemocracy_logo:hover {
+  opacity: 0.85;
+}
+
+#blueprintforfreespeech_logo {
+  opacity: 0.7;
+}
+
+#blueprintforfreespeech_logo:hover {
+  opacity: 0.9;
+}
+
+#frontpage_supporting img#newmatilda_logo, #frontpage_supporting img#opennz_logo {
+  margin-right: 0;
+}
+
+#frontpage_supporting img#efa_logo {
+  margin-right: 16px;
+  opacity: 0.75;
+  padding-bottom: 6px;
+}
+
+#frontpage_supporting img#efa_logo:hover {
+  opacity: 0.95;
+}
+
+#frontpage_supporting img#tia_logo {
+  margin-right: 16px;
+  opacity: 0.8;
+}
+
+#frontpage_supporting img#tia_logo:hover {
+  opacity: 1.0;
+}
+
+#frontpage_supporting img#mysociety_logo {
+  margin-right: 16px;
+  opacity: 0.8;
+}
+
+#frontpage_supporting img#mysociety_logo:hover {
+  opacity: 1.0;
+}
+
+#frontpage_supporting img#opennorth_logo {
+  margin-right: 16px;
+  opacity: 0.65;
+}
+
+#frontpage_supporting img#opennorth_logo:hover {
+  opacity: 0.85;
+}
+
+#opennz_logo {
+  opacity: 0.6;
+}
+
+#opennz_logo:hover {
+  opacity: 0.8;
+}
+
+#examples_1 ul li:last-child {
+border-bottom:0;
+}
+
+/* For the time being hide the admin bar in the main app */
+.admin.navbar {
+  display: none;
+}

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -821,6 +821,10 @@ div.correspondence p.preview_subject {
     }
   }
 
+  h1 {
+    margin-bottom: 15px;
+  }
+
   #search_form {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       margin-bottom: 0;
@@ -830,7 +834,7 @@ div.correspondence p.preview_subject {
 
 h2.publicbody_results {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin-top: .15em;
+    margin-top: .17em;
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1158,6 +1158,10 @@ padding-top:1em;
   background: none;
   padding-top: 7px;
 
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    min-height: 401px;
+  }
+
   h1 {
     font-family: $heading-font-family;
     color:#005068;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -658,6 +658,19 @@ div.correspondence p.preview_subject {
   line-height: 25px;
 }
 
+.describe_state_form {
+  font-weight: 400;
+  background: #E9FDD3;
+  color: #333;
+  border-radius: 6px;
+  margin: 15px 0 15px 1em;
+  padding: 10px 20px;
+}
+
+#describe_state_form_1 {
+  width: 70%;
+}
+
 #notice {
   padding: 0 1em;
   font-size: 1.4em;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -852,8 +852,7 @@ div.correspondence p.preview_subject {
   }
 }
 
-#search_form,
-#search_form p {
+#search_form {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     margin-bottom: 0;
   }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -85,9 +85,11 @@ box-shadow: 0 0 10px;
 
   .rsp_menu_button {
     background: #fff;
-    width: auto;
-    margin: 1.5em 1em 0 0;
+    width: 4.5em;
+    margin: 1em 1em 0 0;
     padding: .5em 1em;
+    border-radius: .3em;
+    text-align: center;
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -55,6 +55,10 @@ dl {
 dt {
   margin: 36px 0 18px;
   font-size: 1.8em;
+
+  &:first-child {
+    margin-top: 23px;
+  }
 }
 
 dd {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1028,6 +1028,11 @@ padding-right: 0;
 .form_item_note {
   margin-top: -1em;
 
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-left: 110px;
+    width: 510px;
+  }
+
   p + & {
     top: 0;
     position: static;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -128,11 +128,13 @@ box-shadow: 0 0 10px;
 
 a#logo {
   width: 53.66667%;
+  max-width: 228px;
   padding: .5em 1em;
   display: inline-block;
   float: left;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    max-width: none;
     padding: 0;
     width: auto;
     position: relative;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -290,7 +290,7 @@ color:#444;
 // Site Footer
 
 #footer {
-  margin-top: 4.15em;
+  margin-top: 4.95em;
   border-top: 1px #ddd solid;
   background-color: #f0f0f0;
   font-size: 1em;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -719,14 +719,33 @@ div.correspondence p.preview_subject {
     margin: 20px 0;
   }
 
+  div {
+    margin: 0 0 1em;
+
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin: 0;
+    }
+  }
+
   input[type="radio"] {
+    margin: 0;
+    height: 1.6em;
+    float: left;
+    clear: left;
+
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       margin: 3px;
+      float: none;
+      height: auto;
     }
 
     + label {
+      width: 85%;
+      margin-left: .75em;
+
       @include respond-min( $main_menu-mobile_menu_cutoff ) {
         margin: 0;
+        width: auto;
         font-size: 1em;
         line-height: normal;
       }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -352,6 +352,7 @@ float: none;
 
 #right_column {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-top: 35px;
     width: 210px;
     box-sizing: content-box;
   }
@@ -359,6 +360,7 @@ float: none;
 
 #right_column_flip {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-top: 38px;
     width: 225px;
     box-sizing: content-box;
   }
@@ -373,6 +375,7 @@ float: none;
 
 #left_column_flip {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-top: 10px;
     width: 615px;
     box-sizing: content-box;
   }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -304,11 +304,11 @@ color:#005068;
 }
 
 #stepwise_make_request {
-  text-align: center;
-}
+  margin: 2em 0;
 
-#stepwise_make_request a {
-  margin: 15px auto 0 auto;
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    margin: 2em 4em 0;
+  }
 }
 
 #request_header_subject input {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -357,6 +357,13 @@ float: none;
   }
 }
 
+#header_right {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    width: 255px;
+    padding-top: 3em;
+  }
+}
+
 #middle_strip {
 color:#005068;
 font-family: georgia;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1013,6 +1013,7 @@ padding-top:1em;
 
 #frontpage_splash {
   background: none;
+  padding-top: 7px;
 
   h1 {
     font-family: $heading-font-family;
@@ -1088,7 +1089,7 @@ padding-top:1em;
   }
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin-top: 50px;
+    margin-top: 49px;
     margin-left: 70px;
     margin-right: 70px;
     padding: 0;
@@ -1105,7 +1106,7 @@ padding-top:1em;
   }
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin-top: 70px;
+    margin-top: 80px;
     margin-bottom: 0px;
     padding: 0;
     width: 221px;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -882,9 +882,9 @@ padding: 0;
 
 .correspondence .event_actions, .comment_in_request .event_actions {
   opacity: .6;
-  transition: opacity .25s ease-in-out;
   -moz-transition: opacity .25s ease-in-out;
   -webkit-transition: opacity .25s ease-in-out;
+  transition: opacity .25s ease-in-out;
 }
 
 .correspondence:hover .event_actions, .comment_in_request:hover .event_actions {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -695,12 +695,14 @@ div.correspondence p.preview_subject {
   background: #E9FDD3;
   color: #333;
   border-radius: 6px;
-  margin: 15px 0 15px 1em;
-  padding: 10px 20px;
 }
 
 #describe_state_form_1 {
-  width: 70%;
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    @include grid-column($columns:8.33, $float:none);
+    margin: 2.175em 0 0 1em;
+    padding: 10px 20px;
+  }
 }
 
 #notice {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -80,6 +80,11 @@ color:#444;
 }
 
   #logged_in_links {
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      top: .875em;
+      right: 22em;
+    }
+
     a, .greeting {
       @include respond-min( $main_menu-mobile_menu_cutoff ){
         font-size: 14px;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -603,6 +603,47 @@ div.controller_help dt:hover > a, div.controller_help h1:hover > a, div#help_unh
 color: #a60201;
 }
 
+
+#authority_selection {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    float: left;
+    width: 40%;
+  }
+}
+
+#authority_preview {
+  background-color: #FFFFE0;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-top: -67px;
+    padding-left: 1em;
+    padding-right: 1em;
+    overflow: hidden;
+    width: 48%;
+    float: right;
+  }
+
+  h1 {
+    margin-top: 15px;
+    margin-top: 1rem;
+  }
+
+  #stepwise_make_request {
+    margin: 2em 0;
+    text-align: center;
+  }
+
+  .link_button_green {
+    display: inline-block;
+    text-align: center;
+  }
+
+  #public_body_show {
+    margin-right: 0;
+    margin-left: 0;
+  }
+}
+
 // Forms
 
 form#signin_form input[type=text], form#signin_form input[type=password], form#signup_form input[type=text], form#signup_form input[type=password] {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -159,9 +159,12 @@ color:#444;
 }
 
   #logged_in_links {
+    font-weight: bold;
+
     @include respond-min( $main_menu-mobile_menu_cutoff ){
       top: .9em;
       right: 20.8em;
+      font-weight: normal;
     }
 
     a, .greeting {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -337,6 +337,7 @@ color:#005068;
   line-height: normal;
 
   span.head a {
+    font-size: 1.25em;
     font-weight:400;
   }
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -18,6 +18,10 @@ background-color: #f0f0f0;
 h1,h2,h3,dt {
   font-family: $heading-font-family;
   color:#005068;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    line-height: 1em;
+  }
 }
 
 h1 {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -856,7 +856,6 @@ padding-right: 0;
     float: left;
     width: 8%;
     height: 100px;
-    margin-top: 45px;
   }
 }
 
@@ -882,6 +881,7 @@ padding-right: 0;
 }
 
 p#sign_in_reason, p#superuser_message {
+  margin-top: 2em;
   text-align: center;
   font-size: 1.4em;
   font-weight: 700;
@@ -911,8 +911,7 @@ label.form_label {
 #sign_together {
   h1 {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      margin-bottom: 1em;
-      margin-left: 2.4em;
+      margin: .25em 0 1em 2.4em;
     }
   }
 
@@ -922,7 +921,7 @@ label.form_label {
     }
   }
 
-  p {
+  form p {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       margin-top: 0;
     }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -797,6 +797,14 @@ div.correspondence p.preview_subject {
   padding: 8px 0 10px 42px;
 }
 
+#public_body_list {
+  li {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      line-height: normal;
+    }
+  }
+}
+
 // Forms
 
 form input[type=text], form input[type=password] {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -67,6 +67,11 @@ dt {
 
 dd {
   margin-left: 0;
+
+  // override _global_style.scss:84
+  dt + & > p {
+    margin-top: 1em;
+  }
 }
 
 p {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -609,10 +609,10 @@ background-color:inherit;
 }
 
 /* Fix button height in Firefox */
-form input[type=submit] {
-height: 30px;
-padding:0px 6px;
-}
+// form input[type=submit] {
+// height: 30px;
+// padding:0px 6px;
+// }
 
 input::-moz-focus-inner
 {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -854,6 +854,7 @@ padding-right: 0;
 #sign_together {
   h1 {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin-bottom: 1em;
       margin-left: 2.4em;
     }
   }
@@ -919,6 +920,20 @@ label.form_label {
 #sign_together .form_button {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     margin-left: 10.5em;
+  }
+}
+
+#sign_together {
+  input {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin-bottom: 0;
+    }
+  }
+
+  p {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin-top: 0;
+    }
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -837,11 +837,18 @@ div.correspondence p.preview_subject {
   h1 {
     margin-bottom: 15px;
   }
+}
 
-  #search_form {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      margin-bottom: 0;
-    }
+#search_form,
+#search_form p {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-bottom: 0;
+  }
+}
+
+#search_form #query {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-bottom: 7px;
   }
 }
 
@@ -909,15 +916,27 @@ width:125px;
 padding-right: 0;
 }
 
-.list-filter-item {
-  h3.title {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      display: inline-block;
-      vertical-align: middle;
-      margin-top: 11px;
-    }
+h3.title {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    display: inline-block;
+    vertical-align: middle;
+    margin-top: 11px;
   }
 
+  #filter_form & {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin-top: 0;
+      margin-bottom: 5px;
+      width:120px;
+    }
+  }
+}
+
+#general_search h2 {
+  margin-top: 20px;
+}
+
+.list-filter-item {
   input {
     margin-bottom: 0.7em;
     height: auto;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1125,7 +1125,7 @@ h3.title {
     float: left;
     width: 8%;
     height: 100px;
-    padding: 0;
+    padding: 0 0 0 .25em;
     white-space: onwrap;
   }
 }
@@ -1155,6 +1155,7 @@ h3.title {
 
 p#sign_in_reason, p#superuser_message {
   margin-top: 1.85em;
+  padding-left: .95em;
   text-align: center;
   font-size: 1.4em;
   font-weight: 700;
@@ -1185,14 +1186,14 @@ label.form_label {
 #sign_together {
   h1 {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      margin: .25em 0 1em 2.375em;
+      margin: .25em 0 1.175em 2.4em;
     }
   }
 
   #right_half {
     h1 {
       @include respond-min( $main_menu-mobile_menu_cutoff ) {
-        margin: .25em 0 1em 2.125em;
+        margin: .25em 0 1.175em 2.23em;
       }
     }
   }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -60,6 +60,10 @@ background: #d0ffff;
  background:#fff;
 }
 
+#navigation {
+  border: 0;
+}
+
 #logged_in_bar {
 color:#444;
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -100,6 +100,7 @@ box-shadow: 0 0 10px;
 #banner_inner {
   max-width:$row-width;
   margin: auto;
+  min-height: 69px;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     @include clearfix;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -25,7 +25,7 @@ background-color: #f0f0f0;
 }
 
 #footer_inner {
-width:890px;
+max-width:$row-width;
 position:relative;
 margin:auto;
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -713,6 +713,20 @@ div.correspondence p.preview_subject {
     border-color: #b0ca86;
     margin: 20px 0;
   }
+
+  input[type="radio"] {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin: 3px;
+    }
+
+    + label {
+      @include respond-min( $main_menu-mobile_menu_cutoff ) {
+        margin: 0;
+        font-size: 1em;
+        line-height: normal;
+      }
+    }
+  }
 }
 
 #describe_state_form_1 {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -964,6 +964,8 @@ padding-right: 0;
   background-color: #FFFFE0;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    width: auto;
+    margin-right: .7em;
     margin-left: 1em;
   }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -345,7 +345,6 @@ color:#005068;
 .request_listing {
   span.desc {
     background: image-url('quote-marks.png') no-repeat;
-    color:#444;
   }
 
   span.bottomline {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -663,7 +663,7 @@ color: #a60201;
 #authority_selection {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     float: left;
-    width: 40%;
+    width: 350px;
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -291,7 +291,7 @@ font-weight:400;
 }
 
 .request_listing span.desc {
-background-image: image-url('quote-marks.png') no-repeat;
+background: image-url('quote-marks.png') no-repeat;
 color:#444;
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -929,7 +929,7 @@ padding-right: 0;
 
   #request_advice {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      @include grid-column($columns:3, $float:right);
+      @include grid-column($columns:3.2, $float:right);
       position: static;
     }
 
@@ -944,7 +944,7 @@ padding-right: 0;
 
   #request_form {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      @include grid-column($columns:9, $float:left);
+      @include grid-column($columns:8.6, $float:left);
       position: static;
     }
 
@@ -957,7 +957,7 @@ padding-right: 0;
 
   #outgoing_message_body {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      width: 34em;
+      width: 33.3em;
     }
   }
 
@@ -1002,7 +1002,7 @@ padding-right: 0;
   width: 100%;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    width: 409px;
+    width: 420px;
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -996,6 +996,7 @@ padding-right: 0;
 
 #middle_strip {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-top: -.5em;
     float: left;
     width: 8%;
     height: 100px;
@@ -1084,6 +1085,12 @@ label.form_label {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       margin-left: 10.5em;
     }
+  }
+}
+
+#signup, #signin {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-top: 47px;
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -720,27 +720,27 @@ padding-top:1em;
       font-family: $heading-font-family;
     }
   }
+}
 
-  #frontpage_right_to_know {
-    margin-top: 80px;
-    width: 221px;
-    float: left;
-  }
+#frontpage_right_to_know {
+  margin-top: 80px;
+  width: 221px;
+  float: left;
+}
 
-  #frontpage_start_request {
-    margin-top: 50px;
-    margin-left: 70px;
-    margin-right: 70px;
-    width: 291px;
-    float: left;
-  }
+#frontpage_start_request {
+  margin-top: 50px;
+  margin-left: 70px;
+  margin-right: 70px;
+  width: 291px;
+  float: left;
+}
 
-  #frontpage_search_box {
-    margin-top: 80px;
-    width: 221px;
-    float: left;
-    margin-bottom: 0px;
-  }
+#frontpage_search_box {
+  margin-top: 80px;
+  width: 221px;
+  float: left;
+  margin-bottom: 0px;
 }
 
 #frontpage_right_to_know h2, #frontpage_search_box h2 {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -807,7 +807,8 @@ div.correspondence p.preview_subject {
 
   input[type="radio"] {
     margin: 0;
-    height: 1.6em;
+    height: 1.2em;
+    width: 1.2em;
     float: left;
     clear: left;
 
@@ -818,8 +819,10 @@ div.correspondence p.preview_subject {
     }
 
     + label {
-      width: 85%;
+      width: 84%;
+      margin-top: -.25em;
       margin-left: .75em;
+      vertical-align: top;
 
       @include respond-min( $main_menu-mobile_menu_cutoff ) {
         margin: 0;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -666,6 +666,14 @@ div.correspondence p.preview_subject {
   border: #B0CA86 1px solid;
 }
 
+.request_icon_line {
+  background-repeat: no-repeat;
+  background-position: left center;
+  min-height: 24px;
+  clear: left;
+  padding: 8px 0 10px 42px;
+}
+
 // Forms
 
 form input[type=text], form input[type=password] {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -808,10 +808,18 @@ padding-right: 0;
   background-color: #FFFFE0;
 }
 
+#request_header_text, #request_search_ahead_results {
+  font-size: 0.9em;
+}
+
 #request_header_text {
   background-color: #D5FFD8;
   border: #1EFF38 solid 1px;
   font-style: italic;
+}
+
+.form_item_note, .form_note {
+  font-size: 1em;
 }
 
 // Date Picker

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -481,6 +481,7 @@ color:#005068;
 
 .feed_link {
   padding: 4px 0;
+  clear: left;
 }
 
 // Buttons
@@ -630,6 +631,12 @@ padding:0;
 #follow_count {
  font-family: 'Actor', Arial, sans-serif;
  color:#005068;
+ font-size: 60px;
+ line-height: 60px;
+ float: left;
+ margin-top: -15px;
+ margin-right: 5px;
+ position: static;
 }
 
 div.controller_help dt:hover > a, div.controller_help h1:hover > a, div#help_unhappy h1:hover > a.hover_a {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -851,15 +851,6 @@ padding-right: 0;
   font-size: 1em;
 }
 
-#sign_together {
-  h1 {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      margin-bottom: 1em;
-      margin-left: 2.4em;
-    }
-  }
-}
-
 #middle_strip {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     float: left;
@@ -917,13 +908,14 @@ label.form_label {
   }
 }
 
-#sign_together .form_button {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin-left: 10.5em;
-  }
-}
-
 #sign_together {
+  h1 {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin-bottom: 1em;
+      margin-left: 2.4em;
+    }
+  }
+
   input {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       margin-bottom: 0;
@@ -933,6 +925,12 @@ label.form_label {
   p {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       margin-top: 0;
+    }
+  }
+
+  .form_button {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin-left: 10.5em;
     }
   }
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -932,6 +932,14 @@ padding-right: 0;
       @include grid-column($columns:3, $float:right);
       position: static;
     }
+
+    ul {
+      margin-top: 1em;
+
+      @include respond-min( $main_menu-mobile_menu_cutoff ) {
+        padding: 0;
+      }
+    }
   }
 
   #request_form {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -345,6 +345,7 @@ color:#005068;
 .request_listing {
   span.desc {
     background: image-url('quote-marks.png') no-repeat;
+    min-height: 2em;
   }
 
   span.bottomline {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -22,6 +22,7 @@ background-color: #f0f0f0;
 #footer {
   border-top: 1px #ddd solid;
   background-color: #f0f0f0;
+  text-align: left;
 
   img {
     border: 1px #ddd solid;
@@ -41,10 +42,13 @@ background-color: #f0f0f0;
     margin-top: 0;
   }
 
-  .right {
+  .footer_right {
     margin-top: 22px;
-    float: right;
-    text-align: left;
+
+    @include respond-min(51em) {
+      float: right;
+      text-align: left;
+    }
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -247,6 +247,7 @@ color:#444;
 #footer {
   border-top: 1px #ddd solid;
   background-color: #f0f0f0;
+  font-size: 1em;
   text-align: left;
 
   img {
@@ -291,6 +292,12 @@ float: none;
 
   @include lte-ie7 {
     width: 56.125em;
+  }
+
+  > div {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      font-size: .85em;
+    }
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -903,6 +903,7 @@ padding-right: 0;
 
   span#to_public_body {
     margin-bottom: 0;
+    font-size: 1.1em;
   }
 
   label {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -606,16 +606,16 @@ form input[type=submit],a.link_button_green, a.link_button_green_large {
   background: -ms-linear-gradient(top,  #b2ef40 0%,#7cae36 100%);
   background: linear-gradient(to bottom,  #b2ef40 0%,#7cae36 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#b2ef40', endColorstr='#7cae36',GradientType=0 );
-}
 
-form input[type=submit]:hover,a.link_button_green:hover, a.link_button_green_large:hover {
-  background: -moz-linear-gradient(top,  #c2ff50 0%, #8cbe46 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c2ff50), color-stop(100%,#8cbe46));
-  background: -webkit-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
-  background: -o-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
-  background: -ms-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
-  background: linear-gradient(to bottom,  #c2ff50 0%,#8cbe46 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c2ff50', endColorstr='#8cbe46',GradientType=0 );
+  &:hover {
+    background: -moz-linear-gradient(top,  #c2ff50 0%, #8cbe46 100%);
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c2ff50), color-stop(100%,#8cbe46));
+    background: -webkit-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
+    background: -o-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
+    background: -ms-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
+    background: linear-gradient(to bottom,  #c2ff50 0%,#8cbe46 100%);
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c2ff50', endColorstr='#8cbe46',GradientType=0 );    
+  }
 }
 
 #date_range label.title,#filter_requests_form label.title,h3.title {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1024,7 +1024,7 @@ padding-right: 0;
 }
 
 p#sign_in_reason, p#superuser_message {
-  margin-top: 2em;
+  margin-top: 1.85em;
   text-align: center;
   font-size: 1.4em;
   font-weight: 700;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -683,17 +683,25 @@ padding-top:1em;
 
   h1 {
     font-family: $heading-font-family;
-    font-size:39px;
     color:#005068;
     font-weight:400;
+    font-size: 2em;
     margin:0 0 20px;
+
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      font-size:39px;
+    }
 
     strong {
       font-family: $heading-font-family;
-      font-size:54px;
+      font-size: 1.5em;
       line-height: 1em;
       color:#005068;
       font-weight:400;
+
+      @include respond-min( $main_menu-mobile_menu_cutoff ) {
+        font-size:54px;
+      }
     }
 
     span {
@@ -728,9 +736,10 @@ padding-top:1em;
 #frontpage_right_to_know {
   @include grid-column($columns:12);
 
-  // @include respond-min( 30em ) {
+  @include respond-min( 30em ) {
+        margin-bottom: 3em;
   //   @include grid-column($columns:6);
-  // }
+  }
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     margin-top: 80px;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -359,8 +359,11 @@ color:#005068;
   margin-bottom: -1px;
   border-bottom: 1px solid #DDD;
   padding: 12px 0 6px;
-  font-size: 0.9em;
   line-height: normal;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    font-size: 0.9em;
+  }
 
   span.head a {
     font-size: 1.25em;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -322,7 +322,7 @@ float: none;
 // Main Body
 
 #content {
-  padding-top: 2em;
+  padding-top: .8em;
 }
 
 span#to_public_body {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -325,6 +325,34 @@ float: none;
   padding-top: .8em;
 }
 
+#right_column {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    width: 210px;
+    box-sizing: content-box;
+  }
+}
+
+#right_column_flip {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    width: 225px;
+    box-sizing: content-box;
+  }
+}
+
+#left_column {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    width: 630px;
+    box-sizing: content-box;
+  }
+}
+
+#left_column_flip {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    width: 615px;
+    box-sizing: content-box;
+  }
+}
+
 span#to_public_body {
 font-family: $body-font-family;
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -598,6 +598,7 @@ div.correspondence:after {
 // Special components
 
 p.public-body-name-prefix {
+font-size: 1.2em;
 font-family: 'Actor', Arial, sans-serif;
 color:#005068;
 margin-bottom: 0px;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -818,6 +818,15 @@ padding-right: 0;
   font-style: italic;
 }
 
+#request_new #request_header_text,
+#request_new #request_header_subject input {
+  width: 100%;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    width: 409px;
+  }
+}
+
 #request_search_ahead_results {
   margin-left: 11em;
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1009,20 +1009,22 @@ padding-right: 0;
 #right_half {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     width: 46%;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
   }
 }
 
 #left_half {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     float: left;
+    padding-left: 0.9375rem;
+    padding-right: 0;
   }
 }
 
 #right_half {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     float: right;
+    padding-right: .7em;
+    padding-left: .7em;
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -841,6 +841,13 @@ padding-right: 0;
   font-size: 1em;
 }
 
+p#sign_in_reason, p#superuser_message {
+  text-align: center;
+  font-size: 1.4em;
+  font-weight: 700;
+  line-height: 1em;
+}
+
 // Date Picker
 
 #ui-datepicker-div {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -688,6 +688,19 @@ padding:10px;
 #link_box .close-button {
 margin-left:15px;
 padding:0;
+color: #FFF;
+text-decoration: none;
+display: inline-block;
+border-radius: 2px;
+-moz-border-radius: 2px;
+cursor: pointer;
+background: url(/assets/small-white-cross-967f7527d59a4f21507413a91151f598.png) no-repeat #444;
+width: 15px;
+height: 15px;
+border: solid 0 #FFF;
+text-indent: -999px;
+overflow: hidden;
+float: right;
 }
 
 #follow_count {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1,3 +1,5 @@
+// Basic styles
+
 body {
 color:#444;
 font-family:'Maven Pro', Arial, sans-serif;
@@ -11,6 +13,8 @@ background-color: #f0f0f0;
 .after-footer {
   background-color: #f0f0f0;
 }
+
+// Site Footer
 
 #footer {
   float: inherit;
@@ -64,6 +68,8 @@ margin:auto;
   padding-left: 0;
 }
 
+// Site Header
+
 #banner {
 background-color:#00DCF0;
 -moz-box-shadow: 0 0 10px;
@@ -115,6 +121,8 @@ color:#444;
 #logged_in_bar a,#logged_in_bar a:visited {
 color:#ffffff;
 }
+
+// Main Body
 
 #content {
   padding-top: 2em;
@@ -228,6 +236,8 @@ color:#005068;
   display: none;
 }
 
+// Buttons
+
 form input[type=submit],a.link_button_green,a.link_button_green_large {
 font-family:'Maven Pro', Arial, sans-serif;
 }
@@ -301,6 +311,8 @@ div.correspondence:after {
   right: 12px;
 }
 
+// Front Page
+
 #frontpage_splash {
 background: none;
 }
@@ -373,6 +385,8 @@ font-family: 'Actor', Arial, sans-serif;
   margin-bottom: 0px;
 }
 
+// Date Picker
+
 #ui-datepicker-div.ui-widget {
 font-family:'Maven Pro', Arial, sans-serif;
 color:#005068;
@@ -392,6 +406,8 @@ color:#FFF;
 background:#005068;
 color:#FFF;
 }
+
+// Special components
 
 p.public-body-name-prefix {
 font-family: 'Actor', Arial, sans-serif;
@@ -430,6 +446,8 @@ padding:0;
 div.controller_help dt:hover > a, div.controller_help h1:hover > a, div#help_unhappy h1:hover > a.hover_a {
 color: #a60201;
 }
+
+// Forms
 
 form#signin_form input[type=text], form#signin_form input[type=password], form#signup_form input[type=text], form#signup_form input[type=password] {
 width:270px;
@@ -511,6 +529,8 @@ width:120px;
 div.pagination {
 padding-top:1em;
 }
+
+// Front Page Supporting Orgs section
 
 #frontpage_supporting {
   clear: both;
@@ -661,6 +681,8 @@ padding-top:1em;
 #examples_1 ul li:last-child {
 border-bottom:0;
 }
+
+// Overrides
 
 /* For the time being hide the admin bar in the main app */
 .admin.navbar {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -841,6 +841,44 @@ padding-right: 0;
   font-size: 1em;
 }
 
+#sign_together {
+  h1 {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin-left: 2.4em;
+    }
+  }
+}
+
+#middle_strip {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    float: left;
+    width: 8%;
+    height: 100px;
+    margin-top: 45px;
+  }
+}
+
+#left_half,
+#right_half {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    width: 46%;
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+#left_half {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    float: left;
+  }
+}
+
+#right_half {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    float: right;
+  }
+}
+
 p#sign_in_reason, p#superuser_message {
   text-align: center;
   font-size: 1.4em;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -17,71 +17,6 @@ background-color: #f0f0f0;
   background-color: #f0f0f0;
 }
 
-// Site Footer
-
-#footer {
-  border-top: 1px #ddd solid;
-  background-color: #f0f0f0;
-  text-align: left;
-
-  img {
-    border: 1px #ddd solid;
-    vertical-align: middle;
-  }
-
-  ul {
-    list-style: none;
-    padding-left: 0;
-  }
-
-  li {
-    margin-top: 5px;
-  }
-
-  p {
-    margin-top: 0;
-  }
-
-  .footer_right {
-    margin-top: 22px;
-
-    @include respond-min(51em) {
-      float: right;
-      text-align: left;
-    }
-  }
-}
-
-#footer_inner {
-max-width:$row-width;
-margin: auto;
-@include grid-column(12);
-@include clearfix;
-float: none;
-
-  @include ie8{
-    padding-left: 0.9375em;
-    padding-right: 0.9375em;
-  }
-
-  @include lte-ie7 {
-    width: 56.125em;
-  }
-}
-
-#oaf_logo {
-  border: 1px #bbb solid;
-  vertical-align: middle;
-  margin-left: 5px;
-}
-
-#oaf {
-  margin-top: 1em;
-  margin-bottom: 50px;
-  float: left;
-  text-align: left;
-}
-
 // Site Header
 
 #banner {
@@ -150,6 +85,71 @@ color:#ffffff;
 
 #navigation_search input#navigation_search_button {
   display: none;
+}
+
+// Site Footer
+
+#footer {
+  border-top: 1px #ddd solid;
+  background-color: #f0f0f0;
+  text-align: left;
+
+  img {
+    border: 1px #ddd solid;
+    vertical-align: middle;
+  }
+
+  ul {
+    list-style: none;
+    padding-left: 0;
+  }
+
+  li {
+    margin-top: 5px;
+  }
+
+  p {
+    margin-top: 0;
+  }
+
+  .footer_right {
+    margin-top: 22px;
+
+    @include respond-min(51em) {
+      float: right;
+      text-align: left;
+    }
+  }
+}
+
+#footer_inner {
+max-width:$row-width;
+margin: auto;
+@include grid-column(12);
+@include clearfix;
+float: none;
+
+  @include ie8{
+    padding-left: 0.9375em;
+    padding-right: 0.9375em;
+  }
+
+  @include lte-ie7 {
+    width: 56.125em;
+  }
+}
+
+#oaf_logo {
+  border: 1px #bbb solid;
+  vertical-align: middle;
+  margin-left: 5px;
+}
+
+#oaf {
+  margin-top: 1em;
+  margin-bottom: 50px;
+  float: left;
+  text-align: left;
 }
 
 // Main Body

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -368,7 +368,7 @@ font-family: $heading-font-family;
 color:#005068;
 font-style:inherit;
 font-size:19px;
-font-family: 'Actor', Arial, sans-serif;
+font-family: $heading-font-family;
 }
 
 #frontpage_splash #frontpage_right_to_know {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -177,7 +177,7 @@ color:#444;
     font-weight: bold;
 
     @include respond-min( $main_menu-mobile_menu_cutoff ){
-      top: .9em;
+      top: 1.05em;
       right: 20.8em;
       font-weight: normal;
     }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -40,6 +40,12 @@ box-shadow: 0 0 10px;
   }
 }
 
+#banner_inner {
+  max-width:$row-width;
+  margin: auto;
+  position: relative;
+}
+
 a#logo {
   left: 9px;
   top:75px;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -881,7 +881,7 @@ padding: 0;
 }
 
 .correspondence .event_actions, .comment_in_request .event_actions {
-  opacity: 0;
+  opacity: .6;
   transition: opacity .25s ease-in-out;
   -moz-transition: opacity .25s ease-in-out;
   -webkit-transition: opacity .25s ease-in-out;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -45,16 +45,14 @@ p.subtitle {
 color:#005068;
 }
 
-a, a:hover {
+a {
   color:#A60201;
-}
-
-a, .request_listing .requester a {
   text-decoration: none;
-}
 
-a:hover, .request_listing .requester a:hover {
-  text-decoration: underline;
+  &:hover {
+    color:#A60201;
+    text-decoration: underline;
+  }
 }
 
 .entirebody {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -40,10 +40,10 @@ box-shadow: 0 0 10px;
   }
 }
 
-#banner_inner a#logo {
-left: 9px;
-top:75px;
-z-index: 90;
+a#logo {
+  left: 9px;
+  top:75px;
+  z-index: 90;
 }
 
 #topnav {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -413,6 +413,42 @@ a.link_button_green:hover,a.link_button_green_large:hover {
   color: white;
 }
 
+
+a.link_button_green_large {
+background-image: image-url('button-gradient-large.png');
+}
+
+form input[type=submit],a.link_button_green {
+background-image: image-url('button-gradient.png');
+}
+
+form input[type=submit],a.link_button_green, a.link_button_green_large {
+  padding: 5px 6px;
+  color: #fff;
+  font-size: 18px;
+  border: solid 1px #69952f;
+  border-radius: 2px;
+  text-shadow: 1px 1px 0 #5b841d;
+  cursor: pointer;
+  background: -moz-linear-gradient(top,  #b2ef40 0%, #7cae36 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#b2ef40), color-stop(100%,#7cae36));
+  background: -webkit-linear-gradient(top,  #b2ef40 0%,#7cae36 100%);
+  background: -o-linear-gradient(top,  #b2ef40 0%,#7cae36 100%);
+  background: -ms-linear-gradient(top,  #b2ef40 0%,#7cae36 100%);
+  background: linear-gradient(to bottom,  #b2ef40 0%,#7cae36 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#b2ef40', endColorstr='#7cae36',GradientType=0 );
+
+  &:hover {
+    background: -moz-linear-gradient(top,  #c2ff50 0%, #8cbe46 100%);
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c2ff50), color-stop(100%,#8cbe46));
+    background: -webkit-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
+    background: -o-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
+    background: -ms-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
+    background: linear-gradient(to bottom,  #c2ff50 0%,#8cbe46 100%);
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c2ff50', endColorstr='#8cbe46',GradientType=0 );
+  }
+}
+
 /* Mostly magic for adding page curls */
 
 div#request_show {
@@ -654,41 +690,6 @@ input::-moz-focus-inner
 {
     border: 0;
     padding: 0;
-}
-
-a.link_button_green_large {
-background-image: image-url('button-gradient-large.png');
-}
-
-form input[type=submit],a.link_button_green {
-background-image: image-url('button-gradient.png');
-}
-
-form input[type=submit],a.link_button_green, a.link_button_green_large {
-  padding: 5px 6px;
-  color: #fff;
-  font-size: 18px;
-  border: solid 1px #69952f;
-  border-radius: 2px;
-  text-shadow: 1px 1px 0 #5b841d;
-  cursor: pointer;
-  background: -moz-linear-gradient(top,  #b2ef40 0%, #7cae36 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#b2ef40), color-stop(100%,#7cae36));
-  background: -webkit-linear-gradient(top,  #b2ef40 0%,#7cae36 100%);
-  background: -o-linear-gradient(top,  #b2ef40 0%,#7cae36 100%);
-  background: -ms-linear-gradient(top,  #b2ef40 0%,#7cae36 100%);
-  background: linear-gradient(to bottom,  #b2ef40 0%,#7cae36 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#b2ef40', endColorstr='#7cae36',GradientType=0 );
-
-  &:hover {
-    background: -moz-linear-gradient(top,  #c2ff50 0%, #8cbe46 100%);
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#c2ff50), color-stop(100%,#8cbe46));
-    background: -webkit-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
-    background: -o-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
-    background: -ms-linear-gradient(top,  #c2ff50 0%,#8cbe46 100%);
-    background: linear-gradient(to bottom,  #c2ff50 0%,#8cbe46 100%);
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#c2ff50', endColorstr='#8cbe46',GradientType=0 );    
-  }
 }
 
 #date_range label.title,#filter_requests_form label.title,h3.title {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1209,6 +1209,19 @@ label.form_label {
       margin-left: 10.5em;
     }
   }
+
+  input[type="checkbox"] {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin: .2em;
+    }
+
+    + label {
+      @include respond-min( $main_menu-mobile_menu_cutoff ) {
+        margin: 0;
+        line-height: normal;
+      }
+    }
+  }
 }
 
 #signup, #signin {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -790,6 +790,10 @@ padding-right: 0;
   }
 }
 
+#request_header {
+  background-color: #FFFFE0;
+}
+
 // Date Picker
 
 #ui-datepicker-div {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1071,12 +1071,12 @@ padding-top:1em;
 
   @include respond-min( 30em ) {
         margin-bottom: 3em;
-  //   @include grid-column($columns:6);
   }
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     margin-top: 80px;
-    @include grid-column($columns:4, $float:left);
+    padding-right: 0;
+    width: 236px;
   }
 }
 
@@ -1089,11 +1089,10 @@ padding-top:1em;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     margin-top: 50px;
-    // margin-left: 70px;
-    // margin-right: 70px;
-    // width: 291px;
-    // float: left;
-    @include grid-column($columns:4.5, $float:left);
+    margin-left: 70px;
+    margin-right: 70px;
+    padding: 0;
+    width: 291px;
   }
 }
 
@@ -1106,14 +1105,14 @@ padding-top:1em;
   }
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    // width: 221px;
-    // float: left;
     margin-top: 70px;
     margin-bottom: 0px;
-    @include grid-column($columns:3.5, $float:left);
+    padding: 0;
+    width: 221px;
 
     input[type="text"] {
       margin-bottom: 0;
+      width: 210px;
     }
   }
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -74,10 +74,12 @@ background: #d0ffff;
 
 #logged_in_bar {
 color:#444;
+font-size: 0.9em;
 
   #logged_in_links {
     a, .greeting {
       font-weight: normal;
+      padding: 0;
     }
   }
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -629,7 +629,7 @@ background-image: image-url('button-gradient.png');
 }
 
 form input[type=submit],a.link_button_green, a.link_button_green_large {
-  padding: 0 6px;
+  padding: 5px 6px;
   color: #fff;
   font-size: 18px;
   border: solid 1px #69952f;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1,4 +1,5 @@
 $righttoknow-primary-color: #00DCF0;
+$righttoknow-primary-color-lighter: #d0ffff;
 $body-font-family: 'Maven Pro', Arial, sans-serif;
 $heading-font-family: 'Actor', Arial, sans-serif;
 
@@ -50,7 +51,7 @@ font-family: $body-font-family;
 float: right;
 margin-left: 0;
 top: 100px;
-background: #d0ffff;
+background: $righttoknow-primary-color-lighter;
 }
 #topnav li a{
   padding: 10px 13px;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -404,10 +404,6 @@ color:#005068;
 
 // Buttons
 
-form input[type=submit],a.link_button_green,a.link_button_green_large {
-font-family: $body-font-family;
-}
-
 a.link_button_green:hover,a.link_button_green_large:hover {
   text-decoration: none;
   color: white;
@@ -426,6 +422,7 @@ form input[type=submit],a.link_button_green, a.link_button_green_large {
   padding: 5px 6px;
   color: #fff;
   font-size: 18px;
+  font-family: $body-font-family;
   border: solid 1px #69952f;
   border-radius: 2px;
   text-shadow: 1px 1px 0 #5b841d;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -122,7 +122,7 @@ font-family: $body-font-family;
 background: $righttoknow-primary-color-lighter;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin: 0 5px 0 0;
+    margin: 3px 5px 0 0;
     float: right;
     font-size: 1.2em;
   }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -31,8 +31,17 @@ color:#005068;
 font-weight:400;
 }
 
+dl {
+  line-height: 160%;
+}
+
 dt {
+  margin: 36px 0 18px;
   font-size: 1.8em;
+}
+
+dd {
+  margin-left: 0;
 }
 
 p {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -329,8 +329,6 @@ color:#005068;
   line-height: normal;
 
   span.head a {
-    color:#A60201;
-    font-family: $body-font-family;
     font-weight:400;
   }
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -16,8 +16,8 @@ background-color: #f0f0f0;
 }
 
 h1,h2,h3,dt {
-font-family: $heading-font-family;
- color:#005068;
+  font-family: $heading-font-family;
+  color:#005068;
 }
 
 h1 {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -714,6 +714,23 @@ padding-right: 0;
   }
 }
 
+.errorExplanation {
+  border-radius: 6px;
+  -moz-border-radius: 6px;
+  font-weight: 400;
+  width: 554px;
+  margin: 20px 0 30px;
+}
+
+#error, .errorExplanation, #hidden_request {
+  color: #FF0606;
+  background-color: #FEE;
+  border-color: #FF0C11;
+  border-style: solid;
+  border-width: 1px;
+}
+
+
 #request_new {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     @include clearfix;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -76,12 +76,13 @@ background: #d0ffff;
 color:#444;
 
 @include respond-min( $main_menu-mobile_menu_cutoff ){
-  font-size: 0.9em;
+
 }
 
   #logged_in_links {
     a, .greeting {
       @include respond-min( $main_menu-mobile_menu_cutoff ){
+        font-size: 14px;
         font-weight: normal;
         padding: 0;
       }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -355,6 +355,8 @@ float: none;
 
 #middle_strip {
 color:#005068;
+font-family: georgia;
+font-style: italic;
 }
 
 #stepwise_make_request {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1128,6 +1128,22 @@ label.form_label {
   }
 }
 
+.new_public_body_change_request {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    margin-top: -1px;
+  }
+
+  input[type="text"] {
+    margin-bottom: 0;
+  }
+
+  .form_button {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin-left: 135px;
+    }
+  }
+}
+
 // Date Picker
 
 #ui-datepicker-div {

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -1,0 +1,34 @@
+<div id="footer">
+  <div id="footer_inner">
+    <div id="oaf">
+      <p><%= AlaveteliConfiguration::site_name %> is another project from the
+        <%= link_to "https://www.openaustraliafoundation.org.au" do %>
+          <%= image_tag "openaustralia_foundation.png", :width => "200", :id => "oaf_logo", :alt => "OpenAustralia Foundation logo" %>
+        <% end %>
+      </p>
+      <p>Like it? Then also take a look at</p>
+      <ul>
+        <li><%= image_tag "oa_logo.png"%> <%= link_to "OpenAustralia.org", "https://www.openaustralia.org.au" %></li>
+        <li><%= image_tag "el_logo.png"%> <%= link_to "Election Leaflets", "http://www.electionleaflets.org.au" %></li>
+        <li><%= image_tag "pa_logo.png"%> <%= link_to "PlanningAlerts", "http://www.planningalerts.org.au" %></li>
+        <li><%= image_tag "tvfy_logo.png"%> <%= link_to "They Vote For You", "https://theyvoteforyou.org.au/" %></li>
+      </ul>
+    </div>
+    <div class="right">
+      <div id="powered">
+        <%= _('Powered by <a href="http://alaveteli.org/">Alaveteli</a>') %>
+      </div>
+      <div id="contact_footer">
+        <ul>
+          <li>
+            <%= link_to _("Contact {{site_name}}", :site_name => site_name), help_contact_url %>
+          </li>
+          <li>
+            <%= image_tag "twitter-16.png", :alt => "twitter icon", :class =>"twitter-icon" %> <a href="https://twitter.com/<%= AlaveteliConfiguration::twitter_username %>"><%= _("Follow us on twitter") %></a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="after-footer">&nbsp;</div>

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -1,6 +1,6 @@
 <div class="footer" id="footer">
   <div id="footer_inner">
-    <div class="right" id="contact_footer">
+    <div class="footer_right" id="contact_footer">
         <ul>
           <%= render :partial => 'general/responsive_credits' %>
           <li>

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -21,9 +21,12 @@
           <li>
             <%= link_to _("Contact {{site_name}}", :site_name => site_name), help_contact_url %>
           </li>
-          <li>
-            <%= image_tag "twitter-16.png", :alt => "twitter icon", :class =>"twitter-icon" %> <a href="https://twitter.com/<%= AlaveteliConfiguration::twitter_username %>"><%= _("Follow us on twitter") %></a>
-          </li>
+          <% unless AlaveteliConfiguration::twitter_username.blank? %>
+            <li>
+              <%= image_tag "twitter-16.png", :alt => "twitter icon", :class =>"twitter-icon" %>
+              <a href="https://twitter.com/<%= AlaveteliConfiguration::twitter_username %>"><%= _("Follow us on twitter") %></a>
+            </li>
+          <% end %>
         </ul>
       </div>
     </div>

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -1,19 +1,5 @@
 <div class="footer" id="footer">
   <div id="footer_inner">
-    <div id="oaf">
-      <p><%= AlaveteliConfiguration::site_name %> is another project from the
-        <%= link_to "https://www.openaustraliafoundation.org.au" do %>
-          <%= image_tag "openaustralia_foundation.png", :width => "200", :id => "oaf_logo", :alt => "OpenAustralia Foundation logo" %>
-        <% end %>
-      </p>
-      <p>Like it? Then also take a look at</p>
-      <ul>
-        <li><%= image_tag "oa_logo.png"%> <%= link_to "OpenAustralia.org", "https://www.openaustralia.org.au" %></li>
-        <li><%= image_tag "el_logo.png"%> <%= link_to "Election Leaflets", "http://www.electionleaflets.org.au" %></li>
-        <li><%= image_tag "pa_logo.png"%> <%= link_to "PlanningAlerts", "http://www.planningalerts.org.au" %></li>
-        <li><%= image_tag "tvfy_logo.png"%> <%= link_to "They Vote For You", "https://theyvoteforyou.org.au/" %></li>
-      </ul>
-    </div>
     <div class="right">
       <%= render :partial => 'general/responsive_credits' %>
       <div id="contact_footer">
@@ -29,6 +15,20 @@
           <% end %>
         </ul>
       </div>
+    </div>
+    <div id="oaf">
+      <p><%= AlaveteliConfiguration::site_name %> is another project from the
+        <%= link_to "https://www.openaustraliafoundation.org.au" do %>
+          <%= image_tag "openaustralia_foundation.png", :width => "200", :id => "oaf_logo", :alt => "OpenAustralia Foundation logo" %>
+        <% end %>
+      </p>
+      <p>Like it? Then also take a look at</p>
+      <ul>
+        <li><%= image_tag "oa_logo.png"%> <%= link_to "OpenAustralia.org", "https://www.openaustralia.org.au" %></li>
+        <li><%= image_tag "el_logo.png"%> <%= link_to "Election Leaflets", "http://www.electionleaflets.org.au" %></li>
+        <li><%= image_tag "pa_logo.png"%> <%= link_to "PlanningAlerts", "http://www.planningalerts.org.au" %></li>
+        <li><%= image_tag "tvfy_logo.png"%> <%= link_to "They Vote For You", "https://theyvoteforyou.org.au/" %></li>
+      </ul>
     </div>
   </div>
 </div>

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -15,9 +15,7 @@
       </ul>
     </div>
     <div class="right">
-      <div id="powered">
-        <%= _('Powered by <a href="http://alaveteli.org/">Alaveteli</a>') %>
-      </div>
+      <%= render :partial => 'general/responsive_credits' %>
       <div id="contact_footer">
         <ul>
           <li>

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -1,9 +1,8 @@
 <div class="footer" id="footer">
   <div id="footer_inner">
-    <div class="right">
-      <%= render :partial => 'general/responsive_credits' %>
-      <div id="contact_footer">
+    <div class="right" id="contact_footer">
         <ul>
+          <%= render :partial => 'general/responsive_credits' %>
           <li>
             <%= link_to _("Contact {{site_name}}", :site_name => site_name), help_contact_url %>
           </li>
@@ -14,7 +13,6 @@
             </li>
           <% end %>
         </ul>
-      </div>
     </div>
     <div id="oaf">
       <p><%= AlaveteliConfiguration::site_name %> is another project from the

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -32,4 +32,3 @@
     </div>
   </div>
 </div>
-<div class="after-footer">&nbsp;</div>

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -1,4 +1,4 @@
-<div id="footer">
+<div class="footer" id="footer">
   <div id="footer_inner">
     <div id="oaf">
       <p><%= AlaveteliConfiguration::site_name %> is another project from the

--- a/lib/views/general/_responsive_header.html.erb
+++ b/lib/views/general/_responsive_header.html.erb
@@ -29,7 +29,7 @@
     <div id="navigation_search">
       <form id="navigation_search_form" method="post" action="<%= search_redirect_path %>">
         <label for="navigation_search_button">
-          <img src="/assets/search.png" alt="Search:">
+          Search
         </label>
         <%= text_field_tag 'query', params[:query], { :id => "navigation_search_button", :title => "type your search term here" } %>
       </form>

--- a/lib/views/general/_responsive_header.html.erb
+++ b/lib/views/general/_responsive_header.html.erb
@@ -1,0 +1,38 @@
+<div id="banner">
+  <div id="banner_inner">
+    <div id="banner_content">
+      <div id="logo_wrapper">
+        <%= link_to image_tag('logo.png'), frontpage_path, :id => 'logo' %>
+      </div>
+      <div class="rsp_menu_button">
+        <a href="#banner" class="open"> <i class="icon-menu"></i> Menu </a>
+        <a href="#" class="close"> <i class="icon-menu"></i> Close </a>
+      </div>
+      <%= render :partial => 'general/locale_switcher' %>
+      <% if ! (controller.action_name == 'signin' or controller.action_name == 'signup') %>
+        <div id="logged_in_bar">
+          <div id="logged_in_links">
+          <% if @user %>
+            <span class="greeting"><%= _('Hello, {{username}}!', :username => @user.name) %></span>
+            <%=link_to _("My requests"), show_user_requests_path(:url_name => @user.url_name) %>
+            <%=link_to _("My profile"), show_user_profile_path(:url_name => @user.url_name) %>
+            <%=link_to _("My wall"), show_user_wall_path(:url_name => @user.url_name) %>
+            <%= link_to _("Sign out"), signout_path(:r => request.fullpath) %>
+          <% else %>
+               <%= link_to _("Sign in or sign up"), signin_path(:r => request.fullpath) %>
+          <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <%= render :partial => 'general/responsive_topnav' %>
+    <div id="navigation_search">
+      <form id="navigation_search_form" method="post" action="<%= search_redirect_path %>">
+        <label for="navigation_search_button">
+          <img src="/assets/search.png" alt="Search:">
+        </label>
+        <%= text_field_tag 'query', params[:query], { :id => "navigation_search_button", :title => "type your search term here" } %>
+      </form>
+    </div>
+  </div>
+</div>

--- a/lib/views/general/_responsive_header.html.erb
+++ b/lib/views/general/_responsive_header.html.erb
@@ -1,9 +1,7 @@
 <div id="banner">
   <div id="banner_inner">
     <div id="banner_content">
-      <div id="logo_wrapper">
-        <%= link_to image_tag('logo.png'), frontpage_path, :id => 'logo' %>
-      </div>
+      <%= link_to image_tag('logo.png'), frontpage_path, :id => 'logo' %>
       <div class="rsp_menu_button">
         <a href="#banner" class="open"> <i class="icon-menu"></i> Menu </a>
         <a href="#" class="close"> <i class="icon-menu"></i> Close </a>

--- a/lib/views/general/_responsive_topnav.html.erb
+++ b/lib/views/general/_responsive_topnav.html.erb
@@ -1,0 +1,32 @@
+<div id="topnav">
+    <ul id="navigation">
+
+        <li class="<%= 'selected' if params[:controller] == 'request' and ['new', 'select_authority'].include?(params[:action]) %>">
+          <%= link_to _("Make a request"), select_authority_path, :id => 'make-request-link' %>
+        </li>
+
+        <li class="<%= 'selected' if params[:controller] == 'request' and !['new', 'select_authority'].include?(params[:action]) %>">
+          <%= link_to _("View requests"), request_list_successful_path %>
+        </li>
+
+        <li class="<%= 'selected' if params[:controller] == 'public_body' %>">
+          <%= link_to _("View authorities"), list_public_bodies_default_path %>
+        </li>
+
+        <% unless AlaveteliConfiguration::blog_feed.empty? %>
+          <li class="<%= 'selected' if params[:controller] == 'general' and params[:action] == 'blog' %>"><%= link_to _("Read blog"), blog_path %></li>
+        <% end %>
+        <li class="<%= 'selected' if params[:controller] == 'help' %>">
+          <%= link_to _("Help"), help_about_path %>
+        </li>
+
+        <li id="navigation_search">
+          <form id="navigation_search_form" method="post" action="<%= search_redirect_path %>">
+            <label for="navigation_search_button">
+              <img src="/assets/search.png" alt="Search:">
+            </label>
+              <%= text_field_tag 'query', params[:query], { :id => "navigation_search_button", :title => "type your search term here" } %>
+          </form>
+        </li>
+    </ul>
+</div>

--- a/lib/views/general/_responsive_topnav.html.erb
+++ b/lib/views/general/_responsive_topnav.html.erb
@@ -14,7 +14,7 @@
         </li>
 
         <% unless AlaveteliConfiguration::blog_feed.empty? %>
-          <li class="<%= 'selected' if params[:controller] == 'general' and params[:action] == 'blog' %>"><%= link_to _("Read blog"), blog_path %></li>
+          <li class="<%= 'selected' if params[:controller] == 'general' and params[:action] == 'blog' %>"><%= link_to _("Read blog"), "https://www.openaustraliafoundation.org.au/category/projects/righttoknow-org-au/" %></li>
         <% end %>
         <li class="<%= 'selected' if params[:controller] == 'help' %>">
           <%= link_to _("Help"), help_about_path %>

--- a/lib/views/general/_responsive_topnav.html.erb
+++ b/lib/views/general/_responsive_topnav.html.erb
@@ -25,7 +25,7 @@
             <label for="navigation_search_button">
               <img src="/assets/search.png" alt="Search:">
             </label>
-              <%= text_field_tag 'query', params[:query], { :id => "navigation_search_button", :title => "type your search term here" } %>
+            <%= text_field_tag 'query', params[:query], { :id => "navigation_search_button", :title => "type your search term here" } %>
           </form>
         </li>
     </ul>

--- a/lib/views/general/_responsive_topnav.html.erb
+++ b/lib/views/general/_responsive_topnav.html.erb
@@ -19,14 +19,5 @@
         <li class="<%= 'selected' if params[:controller] == 'help' %>">
           <%= link_to _("Help"), help_about_path %>
         </li>
-
-        <li id="navigation_search">
-          <form id="navigation_search_form" method="post" action="<%= search_redirect_path %>">
-            <label for="navigation_search_button">
-              <img src="/assets/search.png" alt="Search:">
-            </label>
-            <%= text_field_tag 'query', params[:query], { :id => "navigation_search_button", :title => "type your search term here" } %>
-          </form>
-        </li>
     </ul>
 </div>

--- a/lib/views/general/_responsive_topnav.html.erb
+++ b/lib/views/general/_responsive_topnav.html.erb
@@ -6,7 +6,7 @@
         </li>
 
         <li class="<%= 'selected' if params[:controller] == 'request' and !['new', 'select_authority'].include?(params[:action]) %>">
-          <%= link_to _("View requests"), request_list_successful_path %>
+          <%= link_to _("View requests"), request_list_all_path %>
         </li>
 
         <li class="<%= 'selected' if params[:controller] == 'public_body' %>">


### PR DESCRIPTION
This enables us to activate the 'responsive' theme and get a more small screen and touch friendly design than the current Right To Know theme, _without_ changing the current widescreen design.

This comes from issue: https://github.com/openaustralia/righttoknow/issues/396

This has involved a lot of changes, big and small to get working. There are still subtle layout differences between the current wide screen version and this version—where there is a few pixels difference in spacing in some places. Some of those are unavoidable as far as I can tell (such as #440), but others could be made to match pixel perfect with more work/time—it's just deciding if it's worth it. Examples: there is a few pixels more space between headings in the helps sections, and the sidebar column on the request page is a few pixels thinner and a consistent width.

Apart from any major bugs we discover, really useful feedback would be which small differences are worth fixing and which aren't. There are so many moving parts in this css, some of those small differences take quite a while to track down and fix—though through this process I've gotten a pretty good idea of how most of it works.

Could a few people please test this on their phones/tablets and report bugs onto the Responsive styling milestone (and link back here).

This scss could be refactored to be simpler and make better use of variables etc. Should I make those changes and make it part of this PR?
