### PR TITLE
Make notice/fash message layout more consistent on widescreens

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -849,7 +849,6 @@ div.correspondence p.preview_subject {
   border: #B0CA86 1px solid;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    padding: 0 1em;
     font-size: 1.4em;
   }
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -849,7 +849,7 @@ div.correspondence p.preview_subject {
   border: #B0CA86 1px solid;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    font-size: 1.4em;
+    font-size: 1.2em;
   }
 }
 


### PR DESCRIPTION
The layout of notices is a bit squashed and inconsistent with the general style on wide screens. This adds consistent padding to the top and bottom of the notice box and slightly decreases the font size to make it fit better.

fixes #467
## Before

![screen shot 2015-04-07 at 10 31 43 am](https://cloud.githubusercontent.com/assets/1239550/7015199/541198c6-dd13-11e4-9704-11b4fcad1201.png)
## After

![screen shot 2015-04-07 at 10 30 24 am](https://cloud.githubusercontent.com/assets/1239550/7015200/58647164-dd13-11e4-80e0-f046ecc0df7e.png)
