### PR TITLE
bug fix to document 'view as html' header, make logo readable

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -907,6 +907,7 @@ h2.publicbody_results {
 
 // header of the 'View as HTML' screen for viewing documents
 .view_html_prefix {
+  min-height: 4em;
   background-color: $righttoknow-primary-color;
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -905,6 +905,11 @@ h2.publicbody_results {
   margin-right: 0;
 }
 
+// header of the 'View as HTML' screen for viewing documents
+.view_html_prefix {
+  background-color: $righttoknow-primary-color;
+}
+
 // Forms
 
 form input[type=text], form input[type=password] {


### PR DESCRIPTION
As pointed out by @brfairless in #407 and #354 the background colour of the header on the 'view as html' page makes the logo difficult to read. The logo also hangs outside of the header.

This makes the minimum changes to fix this bug.
## Before

![screen shot 2015-04-07 at 11 44 46 am](https://cloud.githubusercontent.com/assets/1239550/7015904/b3d10246-dd1e-11e4-840e-f9612fd74654.png)
## After

![screen shot 2015-04-07 at 11 44 38 am](https://cloud.githubusercontent.com/assets/1239550/7015905/bad44f76-dd1e-11e4-8d96-a154370c0352.png)

There appear to be changes to make this page responsive in upstream v0.21 https://github.com/mysociety/alaveteli/commit/2c29fdd40daa0cd809729ef3907767792c9b3274

@brfairless I redid this on a new branch as it had to be re-done for the responsive theme anyone and it seemed a bit cleaner.
