### PR TITLE
prevent attachements from cascading diagonally

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -910,6 +910,11 @@ h2.publicbody_results {
   background-color: $righttoknow-primary-color;
 }
 
+// fix for cascading document <p>s
+.correspondence p.attachment {
+  clear: both;
+}
+
 // Forms
 
 form input[type=text], form input[type=password] {


### PR DESCRIPTION
minimum change to fix #465 . When multiple attachments are listed they cascade to the right on wide screens.
