### PR TITLE
fix broken layout of 'What are you doing?' form for replies

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -842,6 +842,39 @@ div.correspondence p.preview_subject {
   }
 }
 
+.new_outgoing_message .fieldWithErrors {
+  padding: 1em 1em .25em;
+
+  input[type="radio"] {
+    margin: 0;
+    height: 1.2em;
+    width: 1.2em;
+    float: left;
+    clear: left;
+
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      margin: 3px;
+      float: none;
+      height: auto;
+    }
+
+    + label {
+      width: 84%;
+      margin-top: -.25em;
+      margin-bottom: .75em;
+      margin-left: .75em;
+      vertical-align: top;
+
+      @include respond-min( $main_menu-mobile_menu_cutoff ) {
+        margin: 0 0 .75em;
+        width: auto;
+        font-size: 1em;
+        line-height: normal;
+      }
+    }
+  }
+}
+
 #notice {
   padding: .75em 1em;
   background: #E9FDD3;


### PR DESCRIPTION
Fixes broken layout documented in #466 .
Adds styles to match the layout these radio buttons with the .describe_state_form
## Before

![rtk-radiobuttons](https://cloud.githubusercontent.com/assets/6841582/6963349/f8c52af0-d989-11e4-8005-03faa25ef5bc.png)
![ios simulator screen shot 2 apr 2015 10 48 00 pm](https://cloud.githubusercontent.com/assets/6841582/6963373/59cf4df8-d98a-11e4-8a71-1e4358078886.png)
## After

![screen shot 2015-04-09 at 9 06 31 am](https://cloud.githubusercontent.com/assets/1239550/7057379/5b680db8-de98-11e4-87f7-26704e9c2ab9.png)

![screen shot 2015-04-09 at 9 06 38 am](https://cloud.githubusercontent.com/assets/1239550/7057382/5d7a0ba6-de98-11e4-928d-c456163a6a80.png)

fixes #466
