### PR TITLE
[WIP] Fee and timeframe help changes

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1607,6 +1607,11 @@ padding-top:1em;
 border-bottom:0;
 }
 
+table, th, tr, td {
+  border: 1px solid #ddd;
+  padding: 5px 20px 5px 5px;
+}
+
 // Overrides
 
 /* For the time being hide the admin bar in the main app */

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1610,6 +1610,7 @@ border-bottom:0;
 table, th, tr, td {
   border: 1px solid #ddd;
   padding: 5px 20px 5px 5px;
+  text-align: left;
 }
 
 // Overrides

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -270,6 +270,72 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
     and information below.
   </p>
 
+  <p>
+    There are 9 different laws governing Freedom of Information in Australia.
+    There's a Federal law and a different law for each state or territory.
+    We've created a detailed spreadsheet of all the
+    <%= link_to "key differences", "https://docs.google.com/spreadsheets/d/1KP2efKvCP3jAknTGYUOq8EYpjNElcWDhb0qUX2Rm4lg/edit#gid=0" %>.
+    Two of the differences most relevant to requesters are applications fees
+    and required response times:
+  </p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Jurisdiction</th>
+        <th>Response Timeframe</th>
+        <th>Application Fee</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Federal</td>
+        <td>30 calendar days</td>
+        <td>Free</td>
+      </tr>
+      <tr>
+        <td>ACT</td>
+        <td>30 days</td>
+        <td>Free</td>
+      </tr>
+      <tr>
+        <td>NSW</td>
+        <td>20 working days</td>
+        <td>$30.00</td>
+      </tr>
+      <tr>
+        <td>NT</td>
+        <td>30 days</td>
+        <td>$30.00</td>
+      </tr>
+      <tr>
+        <td>QLD</td>
+        <td>25 business days</td>
+        <td>$43.35</td>
+      </tr>
+      <tr>
+        <td>SA</td>
+        <td>30 calendar days</td>
+        <td>$30.50</td>
+      </tr>
+      <tr>
+        <td>TAS</td>
+        <td>20 working days</td>
+        <td>$37.00</td>
+      </tr>
+      <tr>
+        <td>VIC</td>
+        <td>45 days</td>
+        <td>$26.50</td>
+      </tr>
+      <tr>
+        <td>WA</td>
+        <td>45 days</td>
+        <td>$30.00</td>
+      </tr>
+    </tbody>
+  </table>
+
   <p>Each jurisdiction has a body that oversees FOI, which generally has useful resources too:</p>
   <ul>
     <li>
@@ -283,110 +349,6 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
       in charge of <a href="http://www.cmd.act.gov.au/functions/foi">Freedom of Information</a>.
     </li>
   </ul>
-
-  <p>
-    There are 9 different laws governing Freedom of Information in Australia.
-    There's a Federal law and a different one for each state or territory.
-    We've got a handy spreadsheet that details all the
-    <%= link_to "key differences", "https://docs.google.com/spreadsheets/d/1KP2efKvCP3jAknTGYUOq8EYpjNElcWDhb0qUX2Rm4lg/edit#gid=0" %>
-    and there are tables below showing the differences in fees and required response times.
-  </p>
-
-  <h3>Response Times</h3>
-  <table>
-    <thead>
-      <tr>
-        <th>Jurisdiction</th>
-        <th>Timeframe</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Federal</td>
-        <td>30 calendar days</td>
-      </tr>
-      <tr>
-        <td>ACT</td>
-        <td>30 days</td>
-      </tr>
-      <tr>
-        <td>NSW</td>
-        <td>20 working days</td>
-      </tr>
-      <tr>
-        <td>NT</td>
-        <td>30 days</td>
-      </tr>
-      <tr>
-        <td>QLD</td>
-        <td>25 business days</td>
-      </tr>
-      <tr>
-        <td>SA</td>
-        <td>30 calendar days</td>
-      </tr>
-      <tr>
-        <td>TAS</td>
-        <td>20 working days</td>
-      </tr>
-      <tr>
-        <td>VIC</td>
-        <td>45 days</td>
-      </tr>
-      <tr>
-        <td>WA</td>
-        <td>45 days</td>
-      </tr>
-    </tbody>
-  </table>
-
-  <h3>Application Fees</h3>
-  <table>
-    <thead>
-      <tr>
-        <th>Jurisdiction</th>
-        <th>Application Fee</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Federal</td>
-        <td>Free</td>
-      </tr>
-      <tr>
-        <td>ACT</td>
-        <td>Free</td>
-      </tr>
-      <tr>
-        <td>NSW</td>
-        <td>$30.00</td>
-      </tr>
-      <tr>
-        <td>NT</td>
-        <td>$30.00</td>
-      </tr>
-      <tr>
-        <td>QLD</td>
-        <td>$43.35</td>
-      </tr>
-      <tr>
-        <td>SA</td>
-        <td>$30.50</td>
-      </tr>
-      <tr>
-        <td>TAS</td>
-        <td>$37.00</td>
-      </tr>
-      <tr>
-        <td>VIC</td>
-        <td>$26.50</td>
-      </tr>
-      <tr>
-        <td>WA</td>
-        <td>$30.00</td>
-      </tr>
-    </tbody>
-  </table>
 </dd>
 
 <dt id="data_protection">Can I request information about myself? <a href="#data_protection">#</a> </dt>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -264,12 +264,13 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
 
 <dd>
   <p>
-    Right To Know will guide you through each step of the way, giving you just
-    enough information at just the right time. However if you're still keen to get your
-    hands dirty, you'll want to check out information that relates to the jurisdiction
-    you're making a request in:
+    When you use Right To Know we guide you through each step of the request
+    process, giving you just enough information at just the right time. However
+    if you're still keen to get your hands dirty you'll find some useful links
+    and information below.
   </p>
 
+  <p>Each jurisdiction has a body that oversees FOI, which generally has useful resources too:</p>
   <ul>
     <li>
       For <%= link_to "Federal Authorities", list_public_bodies_path(:tag => "federal") %>, have a look at the Freedom of Information
@@ -282,6 +283,110 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
       in charge of <a href="http://www.cmd.act.gov.au/functions/foi">Freedom of Information</a>.
     </li>
   </ul>
+
+  <p>
+    There are 9 different laws governing Freedom of Information in Australia.
+    There's a Federal law and a different one for each state or territory.
+    We've got a handy spreadsheet that details all the
+    <%= link_to "key differences", "https://docs.google.com/spreadsheets/d/1KP2efKvCP3jAknTGYUOq8EYpjNElcWDhb0qUX2Rm4lg/edit#gid=0" %>
+    and there are tables below showing the differences in fees and required response times.
+  </p>
+
+  <h3>Response Times</h3>
+  <table>
+    <thead>
+      <tr>
+        <th>Jurisdiction</th>
+        <th>Timeframe</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Federal</td>
+        <td>30 calendar days</td>
+      </tr>
+      <tr>
+        <td>ACT</td>
+        <td>30 days</td>
+      </tr>
+      <tr>
+        <td>NSW</td>
+        <td>20 working days</td>
+      </tr>
+      <tr>
+        <td>NT</td>
+        <td>30 days</td>
+      </tr>
+      <tr>
+        <td>QLD</td>
+        <td>25 business days</td>
+      </tr>
+      <tr>
+        <td>SA</td>
+        <td>30 calendar days</td>
+      </tr>
+      <tr>
+        <td>TAS</td>
+        <td>20 working days</td>
+      </tr>
+      <tr>
+        <td>VIC</td>
+        <td>45 days</td>
+      </tr>
+      <tr>
+        <td>WA</td>
+        <td>45 days</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Application Fees</h3>
+  <table>
+    <thead>
+      <tr>
+        <th>Jurisdiction</th>
+        <th>Application Fee</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Federal</td>
+        <td>Free</td>
+      </tr>
+      <tr>
+        <td>ACT</td>
+        <td>Free</td>
+      </tr>
+      <tr>
+        <td>NSW</td>
+        <td>$30.00</td>
+      </tr>
+      <tr>
+        <td>NT</td>
+        <td>$30.00</td>
+      </tr>
+      <tr>
+        <td>QLD</td>
+        <td>$43.35</td>
+      </tr>
+      <tr>
+        <td>SA</td>
+        <td>$30.50</td>
+      </tr>
+      <tr>
+        <td>TAS</td>
+        <td>$37.00</td>
+      </tr>
+      <tr>
+        <td>VIC</td>
+        <td>$26.50</td>
+      </tr>
+      <tr>
+        <td>WA</td>
+        <td>$30.00</td>
+      </tr>
+    </tbody>
+  </table>
 </dd>
 
 <dt id="data_protection">Can I request information about myself? <a href="#data_protection">#</a> </dt>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -272,13 +272,13 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
 
   <ul>
     <li>
-      For <strong>Federal Authorities</strong>, have a look at the Freedom of Information
+      For <%= link_to "Federal Authorities", list_public_bodies_path(:tag => "federal") %>, have a look at the Freedom of Information
       <a href="http://www.oaic.gov.au/freedom-of-information/applying-the-foi-act/foi-guidelines/">guidelines</a>
       and <a href="http://www.oaic.gov.au/freedom-of-information/foi-resources/freedom-of-information-fact-sheets/">fact sheets</a>
       on the Information Commissioner's website.
     </li>
     <li>
-      For <strong>ACT Authorities</strong>, see the website for the Directorate
+      For <%= link_to "ACT Authorities", list_public_bodies_path(:tag => "ACT") %>, see the website for the Directorate
       in charge of <a href="http://www.cmd.act.gov.au/functions/foi">Freedom of Information</a>.
     </li>
   </ul>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -192,10 +192,8 @@ spent on marshmallows in the past year than in the past ten years.
 </p>
 
 <p>
-  Within <strong>14 days</strong> after they receive your request they must give you
-  <strong>written acknowledgement</strong> and within <strong>30 days</strong> they
-  must provide you with either <strong>the documents you have asked for or a written
-  decision on your request</strong>.
+  They must provide you with a decision within a certain timeframe, depending
+  on the law that applies to that authority. It's between <%= link_to "20 to 45 days", :anchor => "ico_help" %>.
 </p>
 
 <p>


### PR DESCRIPTION
There are two sections in our help files that need updating relating to [fees](https://www.righttoknow.org.au/help/requesting#fees) and [response timeframes](https://www.righttoknow.org.au/help/requesting#quickly_response).

So far I've tried to keep the complexity out of those answers and give a simple explanation with a link to the [nitty-gritty answer](https://www.righttoknow.org.au/help/requesting#ico_help) that has more details (which I've also added).

I'm interested in feedback about the wording.

If @equivalentideas has modifications to the table layout that would be good too. I've noticed it doesn't resize down all the way on very small screens.

TODO: The fees question.

Closes #506, closes #507.
