### PR TITLE
Fees and timeframes help updates

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1607,6 +1607,12 @@ padding-top:1em;
 border-bottom:0;
 }
 
+table, th, tr, td {
+  border: 1px solid #ddd;
+  padding: 5px 20px 5px 5px;
+  text-align: left;
+}
+
 // Overrides
 
 /* For the time being hide the admin bar in the main app */

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -189,16 +189,7 @@ spent on marshmallows in the past year than in the past ten years.
 <dd>
 <p>
   By law, the public authority must keep you informed about the progress of your Freedom of Information request.
-</p>
-
-<p>
-  Within <strong>14 days</strong> after they receive your request they must give you
-  <strong>written acknowledgement</strong> and within <strong>30 days</strong> they
-  must provide you with either <strong>the documents you have asked for or a written
-  decision on your request</strong>.
-</p>
-
-<p>
+  It should take no longer than <strong>about a month</strong> for you to get a response to your request.
   For various reasons, this timeframe can be extended.
 </p>
 

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -153,8 +153,55 @@ keep your request focused</a> and ask for specific existing documents.
 
 <p>
   Making a Freedom of Information request to a Federal or ACT authority is always free.
-  For other states and territories there is an application fee around $30.
+  For other states and territories there is an application fee around $30:
 </p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Jurisdiction</th>
+      <th>Application Fee</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Federal</td>
+      <td>Free</td>
+    </tr>
+    <tr>
+      <td>ACT</td>
+      <td>Free</td>
+    </tr>
+    <tr>
+      <td>NSW</td>
+      <td>$30.00</td>
+    </tr>
+    <tr>
+      <td>NT</td>
+      <td>$30.00</td>
+    </tr>
+    <tr>
+      <td>QLD</td>
+      <td>$43.35</td>
+    </tr>
+    <tr>
+      <td>SA</td>
+      <td>$30.50</td>
+    </tr>
+    <tr>
+      <td>TAS</td>
+      <td>$37.00</td>
+    </tr>
+    <tr>
+      <td>VIC</td>
+      <td>$26.50</td>
+    </tr>
+    <tr>
+      <td>WA</td>
+      <td>$30.00</td>
+    </tr>
+  </tbody>
+</table>
 
 <p>
   A public authority may choose to impose certain charges to provide the

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -152,9 +152,14 @@ keep your request focused</a> and ask for specific existing documents.
 <dd>
 
 <p>
-  Making a Freedom of Information request is always free. A public authority may choose to impose
-  certain charges to provide the information but they can only charge you if
-  you have specifically agreed in advance to pay.
+  Making a Freedom of Information request to a Federal or ACT authority is always free.
+  For other states and territories there is an application fee around $30.
+</p>
+
+<p>
+  A public authority may choose to impose certain charges to provide the
+  information but they can only charge you if you have specifically agreed in
+  advance to pay.
 </p>
 
 <p>


### PR DESCRIPTION
This is a much simpler approach than #509 to updating the help about application fees and response timeframes.

![8108940](https://cloud.githubusercontent.com/assets/48945/7175050/80b596e2-e453-11e4-8321-55f4d416c32d.png)

Closes #506, closes #507.
