### PR TITLE
Document html view header fix

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -917,6 +917,10 @@ div.comment_in_request {
 .view_html_prefix {
   min-height: 4em;
   background-color: $righttoknow-primary-color;
+
+  p {
+    margin-top: 0;
+  }
 }
 
 // fix for cascading document <p>s

--- a/lib/views/request/_view_html_prefix.html.erb
+++ b/lib/views/request/_view_html_prefix.html.erb
@@ -1,13 +1,13 @@
 <div class="view_html_prefix">
     <div class="view_html_logo">
         <%= link_to "/" do %>
-          <%= image_tag "logo.png", :id => "#{site_name}", :width => "150" %>
+          <%= image_tag "logo.png", :alt => "#{site_name}", :width => "150" %>
         <% end %>
     </div>
     <div class="view_html_download_link">
         <%=link_to _("Download original attachment"), @attachment_url %>
         <br>(<%=h @attachment.name_of_content_type %>)
     </div>
-    <%= _('This is an HTML version of an attachment to the Freedom of Information request')%>
-    '<%=link_to h(@info_request.title), incoming_message_url(@incoming_message)%>'.
+    <p class="view_html_description"><%= _('This is an HTML version of an attachment to the Freedom of Information request')%>
+    '<%=link_to h(@info_request.title), incoming_message_path(@incoming_message)%>'.</p>
 </div>


### PR DESCRIPTION
This fixes the overlapping of text in the header of 'attachment html view' pages, see #521 for detail of bug.

The issue was that our _view_html_prefix.html.erb file overrides the theme, but wasn't updated to match markup changes upstream.

We'll need to wipe the cache of these pages for this to take effect.

After change:
![screen shot 2015-04-24 at 9 36 33 am](https://cloud.githubusercontent.com/assets/1239550/7309728/6e63b34e-ea65-11e4-967a-bd802c2446d9.png)

closes #521 
