### PR TITLE
Use upstream grid

### DIFF
--- a/assets/stylesheets/responsive/_settings.scss
+++ b/assets/stylesheets/responsive/_settings.scss
@@ -1,5 +1,4 @@
 $main_menu-mobile_menu_cutoff: 58em;
-$row-width: 60em;
 $body-font-family: "Helvetica Neue", Arial, Helvetica, Helmet, Freesans, sans-serif;
 $form-label-font-color: #333333;
 $base-font-size: 15px;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1325,8 +1325,7 @@ padding-top:1em;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     margin-top: 80px;
-    padding-right: 0;
-    width: 236px;
+    @include grid-column($columns:4);
   }
 }
 
@@ -1339,10 +1338,7 @@ padding-top:1em;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     margin-top: 49px;
-    margin-left: 70px;
-    margin-right: 70px;
-    padding: 0;
-    width: 291px;
+    @include grid-column($columns:4);
   }
 }
 
@@ -1357,8 +1353,8 @@ padding-top:1em;
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     margin-top: 80px;
     margin-bottom: 0px;
-    padding: 0;
-    width: 221px;
+    @include grid-column($columns:4);
+    padding-left: 2.5%;
 
     h2 {
       margin-bottom: 15px;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -394,13 +394,6 @@ float: none;
   padding-top: .8em;
 }
 
-#header_right {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    width: 255px;
-    padding-top: 3em;
-  }
-}
-
 #middle_strip {
 color:#005068;
 font-family: georgia;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -394,37 +394,6 @@ float: none;
   padding-top: .8em;
 }
 
-#right_column {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin-top: 35px;
-    width: 210px;
-    box-sizing: content-box;
-  }
-}
-
-#right_column_flip {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin-top: 38px;
-    width: 225px;
-    box-sizing: content-box;
-  }
-}
-
-#left_column {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    width: 630px;
-    box-sizing: content-box;
-  }
-}
-
-#left_column_flip {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin-top: 10px;
-    width: 615px;
-    box-sizing: content-box;
-  }
-}
-
 #header_right {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     width: 255px;


### PR DESCRIPTION
This removes Right To Know theme overrides in to effect the site in 4 ways, described in the commits.

The basic visual impacts on our theme are:
- it widens the whole site a bit
- makes the basic left-right column layout wider to fit the wider site
- mores the header_right boxes to the left to fit the wider site and match upstreams design. (I've raised an [issue upstream](https://github.com/mysociety/alaveteli/issues/2370) querying this where they place this). 
- makes each element in the frontpage 'splash' wider to fit the wider site

Sorry for the inconsistent (css only) labels on the commits, they're all css only! :S

relates to #503 
## Before:

![screen shot 2015-04-24 at 12 37 57 pm](https://cloud.githubusercontent.com/assets/1239550/7311440/b722e216-ea7f-11e4-90c2-4c2861a88828.png)
![screen shot 2015-04-24 at 12 46 27 pm](https://cloud.githubusercontent.com/assets/1239550/7311456/f87aa3d4-ea7f-11e4-8865-547d8942e2d2.png)
## After:

![screen shot 2015-04-24 at 12 37 51 pm](https://cloud.githubusercontent.com/assets/1239550/7311462/01786570-ea80-11e4-849c-2f28517d7285.png)
![screen shot 2015-04-24 at 12 38 25 pm](https://cloud.githubusercontent.com/assets/1239550/7311460/fc7eaf02-ea7f-11e4-83cd-7b89fc9dff25.png)
