### PR TITLE
remove unnecessary layout css

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1380,28 +1380,7 @@ padding-top:1em;
 }
 
 #frontpage_examples {
-  ul {
-    padding-bottom: 1em;
-  }
-
-  #examples_0 {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      padding-right: .5em;
-    }
-  }
-
   #examples_1 {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      padding-right: .5em;
-      padding-left: .75em;
-    }
-
-    ul li {
-      @include respond-min( $main_menu-mobile_menu_cutoff ) {
-        padding: 5px 0;
-      }
-    }
-
     li:last-child {
       border-bottom: 0;
     }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -394,12 +394,6 @@ float: none;
   padding-top: .8em;
 }
 
-#middle_strip {
-color:#005068;
-font-family: georgia;
-font-style: italic;
-}
-
 #request_header_subject input {
   width: 409px;
 }
@@ -1141,17 +1135,6 @@ h3.title {
   p + & {
     top: 0;
     position: static;
-  }
-}
-
-#middle_strip {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin-top: -.5em;
-    float: left;
-    width: 8%;
-    height: 100px;
-    padding: 0 0 0 .25em;
-    white-space: onwrap;
   }
 }
 


### PR DESCRIPTION
This removes out layout overrides in a couple more places:
- the front page examples columns had very small padding adjustments for matching the old theme,
- styles for the middle strip of the old signing form that was removed upstream.
