### PR TITLE
remove dot points from public body list

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -488,19 +488,6 @@ color:#005068;
   }
 }
 
-#public_body_list {
-  ul {
-    margin: 1em 0;
-    padding-left: 40px;
-    line-height: 1.2;
-    list-style-type: disc;
-  }
-
-  li {
-    margin-bottom: 0;
-  }
-}
-
 // Buttons
 
 a.link_button_green:hover,a.link_button_green_large:hover {
@@ -817,12 +804,6 @@ color: #a60201;
 }
 
 #public_body_list {
-  li {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      line-height: normal;
-    }
-  }
-
   h1 {
     margin-bottom: 15px;
   }


### PR DESCRIPTION
The 'dot point' style on the public body list is unnecessary to distinguish items,
and it also takes up a lot of space from the body names, causing many of them to wrap.

This removes our over-ride of the default alaveteli style.

fixes #415

Before:
![screen shot 2015-04-24 at 3 31 17 pm](https://cloud.githubusercontent.com/assets/1239550/7312927/1a1bf33c-ea97-11e4-9be4-c1c83ddbecf5.png)

After:
![screen shot 2015-04-24 at 3 31 11 pm](https://cloud.githubusercontent.com/assets/1239550/7312929/221bb3e2-ea97-11e4-980e-f4cc5d87cbaf.png)
