### PR TITLE
Add spacing to request filters

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -943,7 +943,7 @@ input::-moz-focus-inner
     padding: 0;
 }
 
-#date_range label.title,#filter_requests_form label.title,h3.title {
+#date_range label.title,h3.title {
 width:125px;
 padding-right: 0;
 }
@@ -953,14 +953,6 @@ h3.title {
     display: inline-block;
     vertical-align: middle;
     margin-top: 11px;
-  }
-
-  #filter_form & {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      margin-top: 0;
-      margin-bottom: 5px;
-      width:120px;
-    }
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -960,23 +960,6 @@ h3.title {
   margin-top: 20px;
 }
 
-.list-filter-item {
-  input {
-    margin-bottom: 0.7em;
-    height: auto;
-  }
-}
-
-#filter_requests_form .list-filter-item, #search_form .list-filter-item, #filter_form .list-filter-item {
-  margin-bottom: 0;
-}
-
-#filter_requests_form, #filter_requests_form input[type="submit"] {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin-bottom: 5px;
-  }
-}
-
 .errorExplanation {
   border-radius: 6px;
   -moz-border-radius: 6px;


### PR DESCRIPTION
Remove theme overrides reducing the spacing of the filter forms. These were there to match the old theme. This makes the input elements a bit more distinct :+1: .

closes #528 
## Before:

![screen shot 2015-04-24 at 5 19 04 pm](https://cloud.githubusercontent.com/assets/1239550/7314425/ba762b12-eaa7-11e4-9313-a8ba7f26586d.png)
![screen shot 2015-04-24 at 5 22 13 pm](https://cloud.githubusercontent.com/assets/1239550/7314430/bddba098-eaa7-11e4-8104-1270cc6a2910.png)
![screen shot 2015-04-24 at 5 24 58 pm](https://cloud.githubusercontent.com/assets/1239550/7314433/c15dd830-eaa7-11e4-95b1-cad42d207939.png)
## After

![screen shot 2015-04-24 at 5 24 50 pm](https://cloud.githubusercontent.com/assets/1239550/7314450/eaf173b4-eaa7-11e4-988c-c1bd46cd26ee.png)
![screen shot 2015-04-24 at 5 22 07 pm](https://cloud.githubusercontent.com/assets/1239550/7314452/ef0eddd8-eaa7-11e4-8d9b-e9c5e4e70301.png)
![screen shot 2015-04-24 at 5 18 58 pm](https://cloud.githubusercontent.com/assets/1239550/7314455/f3b513fc-eaa7-11e4-92a2-e5c588b08faa.png)
