### PR TITLE
Make the form input-label layout vertical i.e. labels above inputs.

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -841,7 +841,6 @@ form#set_draft_profile_photo_form label.form_label {
 }
 
 .fieldWithErrors {
-background-color:#fee;
 border: none;
 padding: 0;
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -840,10 +840,6 @@ form input[type=text], form input[type=password] {
   }
 }
 
-form#signin_form input[type=text], form#signin_form input[type=password], form#signup_form input[type=text], form#signup_form input[type=password] {
-width:282px;
-}
-
 form#set_draft_profile_photo_form label.form_label {
   width: inherit;
 }
@@ -1045,43 +1041,6 @@ h3.title {
 
 .form_item_note, .form_note {
   font-size: 1em;
-}
-
-.form_item_note {
-  margin-top: -1em;
-
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin-left: 110px;
-    width: 510px;
-  }
-
-  p + & {
-    top: 0;
-    position: static;
-  }
-}
-
-#left_half,
-#right_half {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    width: 46%;
-  }
-}
-
-#left_half {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    float: left;
-    padding-left: 0.9375rem;
-    padding-right: 0;
-  }
-}
-
-#right_half {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    float: right;
-    padding-right: .7em;
-    padding-left: .7em;
-  }
 }
 
 p#sign_in_reason, p#superuser_message {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -927,7 +927,7 @@ h3.title {
     font-size: 1.1em;
   }
 
-  label, .to_public_body_label {
+  #request_form label, .to_public_body_label {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       display: block;
       float: left;
@@ -939,7 +939,7 @@ h3.title {
     }
   }
 
-  .form_item_note,
+  #request_form .form_item_note,
   #request_header_text,
   #request_form .form_note {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
@@ -1050,42 +1050,6 @@ p#sign_in_reason, p#superuser_message {
   font-size: 1.4em;
   font-weight: 700;
   line-height: 1em;
-}
-
-label.form_label {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    display: block;
-    float: left;
-    clear: none;
-    width: 110px;
-    text-align: left;
-    margin: 2px 0 0;
-    padding: 0 10px 0 0;
-    line-height: normal;
-  }
-}
-
-#signup .form_item_note, #signin .form_note {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    font-size: 0.9em;
-    width: inherit;
-  }
-}
-
-.new_public_body_change_request {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin-top: -1px;
-  }
-
-  input[type="text"] {
-    margin-bottom: 0;
-  }
-
-  .form_button {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      margin-left: 135px;
-    }
-  }
 }
 
 // Date Picker

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -394,10 +394,6 @@ float: none;
   padding-top: .8em;
 }
 
-#request_header_subject input {
-  width: 409px;
-}
-
 #request_form label,label.form_label,.to_public_body_label {
 font-family: $body-font-family;
 color: $righttoknow-heading-color;
@@ -871,10 +867,6 @@ background-color:inherit;
 // padding:0px 6px;
 // }
 
-form input[type="text"] {
-  width: 212px;
-}
-
 input::-moz-focus-inner
 {
     border: 0;
@@ -902,11 +894,6 @@ h3.title {
   border-radius: 6px;
   -moz-border-radius: 6px;
   font-weight: 400;
-  margin: 20px 0 30px;
-
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    width: 554px;
-  }
 }
 
 #error, .errorExplanation, #hidden_request {
@@ -917,94 +904,8 @@ h3.title {
   border-width: 1px;
 }
 
-
-#request_new, #request_new_batch {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    @include clearfix;
-  }
-
-  span#to_public_body {
-    font-size: 1.1em;
-  }
-
-  #request_form label, .to_public_body_label {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      display: block;
-      float: left;
-      clear: none;
-      width: 110px;
-      text-align: left;
-      margin: 2px 0 0;
-      padding: 0 10px 0 0;
-    }
-  }
-
-  #request_form .form_item_note,
-  #request_header_text,
-  #request_form .form_note {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      width: 34em;
-      margin-left: 110px;
-    }
-  }
-
-  #request_advice {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      @include grid-column($columns:3.2, $float:right);
-      position: static;
-    }
-
-    ul {
-      margin-top: 1em;
-
-      @include respond-min( $main_menu-mobile_menu_cutoff ) {
-        padding: 0;
-      }
-    }
-  }
-
-  #request_form {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      @include grid-column($columns:8.6, $float:left);
-      position: static;
-    }
-
-    .form_button {
-      @include respond-min( $main_menu-mobile_menu_cutoff ) {
-        margin: 0 0 0 9em;
-      }
-    }
-  }
-
-  #outgoing_message_body {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      width: 33.3em;
-    }
-  }
-
-  input {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      margin-bottom: 0;
-    }
-  }
-}
-
 #request_header {
   background-color: #FFFFE0;
-
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    width: auto;
-    margin: 0 -0.9375rem;
-    padding-left: 0.9375rem;
-  }
-
-  #request_header_body,
-  #request_header_subject {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      padding-right: 0;
-      padding-left: 0;
-    }
-  }
 }
 
 #request_header_text, #request_search_ahead_results {
@@ -1016,27 +917,6 @@ h3.title {
   border: #1EFF38 solid 1px;
   font-style: italic;
   padding: 0.5em;
-}
-
-#request_new #request_header_text,
-#request_new #request_header_subject input {
-  width: 100%;
-
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    width: 420px;
-  }
-}
-
-#request_search_ahead_results {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    margin-left: 11em;
-  }
-
-  h3:first-child {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      margin-top: 0;
-    }
-  }
 }
 
 .form_item_note, .form_note {


### PR DESCRIPTION
This moves form labels above their inputs rather than next to them, as is the current layout in most places. This removes Right To Know overrides of the default alaveteli layout for forms, reducing the complexity of our theme. I think it is also a win for users in simplifying these forms.

Closes #523 

Here's some notes of form label placement from [Luke Wroblewski](http://www.lukew.com/ff/entry.asp?504):

> Top-aligned labels tend to reduce completion times (how long it takes to complete a form) the most for familiar data (i.e. address, credit card, etc.) because they only require a single eye fixation to take in both input label & field. Top-aligned labels also work well for forms that require localization or long labels as there is plenty of horizontal real estate to expand/contract the label without negatively impacting the overall page layout. Top-aligned labels, however, do take up a lot of vertical real estate.
> 
> Left-aligned forms are the slowest of the three to complete because of the number of eye fixations they require to parse. However, for forms with lots of optional fields or unfamiliar data (like preferences dialogs or advanced settings), they allow users to effectively scan labels. In fact, if you want users to slow down and consider each input in a form more carefully, left-aligned labels are a good way to go.

You can see why Alaveteli went for a 'Top-aligned' pattern with the needs for localization, and the general push for simplicity.

I've tested this out around the site, but it's quite a major layout change and it would be good if you could take some of the forms for a quick test spin @henare .
## Before:

![screen shot 2015-04-27 at 2 02 10 pm](https://cloud.githubusercontent.com/assets/1239550/7341726/903665ca-ecea-11e4-9bef-d5b4c1167de6.png)
![screen shot 2015-04-27 at 2 03 57 pm](https://cloud.githubusercontent.com/assets/1239550/7341727/9338d6c2-ecea-11e4-83b7-2504775fd570.png)
![screen shot 2015-04-27 at 2 04 16 pm](https://cloud.githubusercontent.com/assets/1239550/7341728/9570e574-ecea-11e4-9977-8825f3e10cf8.png)
![screen shot 2015-04-27 at 2 19 14 pm](https://cloud.githubusercontent.com/assets/1239550/7341729/987f7afa-ecea-11e4-8904-885fbaebc427.png)
## After:

![screen shot 2015-04-27 at 2 19 27 pm](https://cloud.githubusercontent.com/assets/1239550/7341730/9e423c8e-ecea-11e4-9c81-d2fe6fe566e3.png)
![screen shot 2015-04-27 at 2 04 35 pm](https://cloud.githubusercontent.com/assets/1239550/7341733/a185fb24-ecea-11e4-8a94-8098cda9e405.png)
![screen shot 2015-04-27 at 2 02 57 pm](https://cloud.githubusercontent.com/assets/1239550/7341735/a575923a-ecea-11e4-9251-3e6f51d8e929.png)
![screen shot 2015-04-27 at 2 02 34 pm](https://cloud.githubusercontent.com/assets/1239550/7341736/a8849a2a-ecea-11e4-8cd7-8a466cb2528f.png)
![screen shot 2015-04-27 at 2 01 59 pm](https://cloud.githubusercontent.com/assets/1239550/7341737/ab3aeb20-ecea-11e4-9541-8a81dd6a0504.png)
