### PR TITLE
remove redundant tiny layout tweek to datepicker elememts (css only)

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -885,7 +885,7 @@ input::-moz-focus-inner
     padding: 0;
 }
 
-#date_range label.title,h3.title {
+h3.title {
 width:125px;
 padding-right: 0;
 }
@@ -1131,10 +1131,6 @@ label.form_label {
 
 // Date Picker
 
-#ui-datepicker-div {
-  box-sizing: normal;
-}
-
 #ui-datepicker-div.ui-widget {
 font-family: $body-font-family;
 color: $righttoknow-heading-color;
@@ -1153,11 +1149,6 @@ color:#FFF;
 #ui-datepicker-div .ui-state-active {
 background: $righttoknow-heading-color;
 color:#FFF;
-}
-
-input.use-datepicker[type=text] {
-  width: 142px;
-  background: url(/assets/calendar.png) no-repeat 115px 3px;
 }
 
 div.pagination {


### PR DESCRIPTION
This removes tiny width tweeks that were added to match the responsive Right To Know theme to the old non-responsive one. This slightly reduces the width of the inputs, matching the space available to the amount of text to be entered:

Before:
![screen shot 2015-04-27 at 2 49 13 pm](https://cloud.githubusercontent.com/assets/1239550/7341859/c0e0ee00-ecec-11e4-9441-024726f31a79.png)

![screen shot 2015-04-27 at 2 52 40 pm](https://cloud.githubusercontent.com/assets/1239550/7341879/2f15bb8a-eced-11e4-988b-c77fc59e5270.png)

After:
![screen shot 2015-04-27 at 2 48 56 pm](https://cloud.githubusercontent.com/assets/1239550/7341861/c63dbb4e-ecec-11e4-80be-ff58a4610ad1.png)

![screen shot 2015-04-27 at 2 52 22 pm](https://cloud.githubusercontent.com/assets/1239550/7341878/2bf65bc6-eced-11e4-9d3b-2876713b2e86.png)
