### PR TITLE
Theme changes required for Alaveteli 0.23.2.4

### DIFF
--- a/assets/stylesheets/responsive/_settings.scss
+++ b/assets/stylesheets/responsive/_settings.scss
@@ -2,3 +2,8 @@ $main_menu-mobile_menu_cutoff: 58em;
 $body-font-family: 'Maven Pro', Arial, sans-serif;
 $form-label-font-color: #333333;
 $base-font-size: 15px;
+
+$logo-filename: 'logo.png';
+$logo-highdpi-filename: 'logo.png'; // TODO: Create new highres logo (#579)
+$logo-width: 250px;
+$logo-height: 97px;

--- a/assets/stylesheets/responsive/_sidebar_style.scss
+++ b/assets/stylesheets/responsive/_sidebar_style.scss
@@ -1,0 +1,16 @@
+.act_link a {
+  line-height: 1.5em;
+  padding-left: 20px;
+  background-size: 16px;
+  background-position: 0 3px;
+  background-repeat: no-repeat;
+  display: inline-block;
+}
+
+.act_link--twitter a {
+  background-image: image-url('twitter-16.png');
+}
+
+.act_link--wordpress a {
+  background-image: image-url('wordpress.png');
+}

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1004,9 +1004,6 @@ padding-top:1em;
 
 #frontpage_splash {
   @include grid-row($behavior: nest);
-  @include respond-min( $main_menu-mobile_menu_cutoff ){
-    min-height: 375px;
-  }
 
   #left_column {
     @include grid-column(12);

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1002,6 +1002,55 @@ padding-top:1em;
   }
 }
 
+#frontpage_splash {
+  @include grid-row($behavior: nest);
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    min-height: 375px;
+  }
+
+  #left_column {
+    @include grid-column(12);
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      @include grid-column(8);
+      margin-top:66px;
+      @include ie8{
+        padding-right: 0.9375em;
+      }
+      @include lte-ie7{
+        width: 36.813em;
+      }
+    }
+  }
+
+  #right_column {
+    @include grid-column(12);
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      @include grid-column(4);
+      margin-top: 30px;
+      @include ie8{
+        padding-left: 0.9375em;
+      }
+      @include lte-ie7{
+        width: 17.438em;
+      }
+    }
+
+    input[type=text] {
+      width:180px;
+    }
+  }
+
+  #frontpage_splash #frontpage_search_box {
+    margin-bottom:30px;
+    margin-top:-10px;
+  }
+
+  #frontpage_right_to_know {
+    line-height:20px;
+  }
+}
+
+
 #frontpage_right_to_know {
   @include grid-column($columns:12);
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1053,7 +1053,6 @@ padding-top:1em;
   }
 }
 
-
 #frontpage_right_to_know {
   @include grid-column($columns:12);
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -350,6 +350,10 @@ color:#444;
     li:first-child {
       margin-bottom: 1em;
     }
+
+    p {
+      margin-top: 5px;
+    }
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -310,6 +310,7 @@ color:#444;
 // Site Footer
 
 #footer {
+  padding: 0.5em 0;
   margin-top: 4.95em;
   border-top: 1px #ddd solid;
   background-color: #f0f0f0;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1293,3 +1293,8 @@ table, th, tr, td {
 .admin.navbar {
   display: none;
 }
+
+// Fix upstream regression on blog page
+#general_blog .act_link a {
+  padding-left: 0px;
+}

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1298,3 +1298,7 @@ table, th, tr, td {
 #general_blog .act_link a {
   padding-left: 0px;
 }
+
+dt {
+  font-weight: normal;
+}

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1007,6 +1007,7 @@ padding-top:1em;
   }
 }
 
+// These styles added back after being remove in Alaveteli 0.23
 #frontpage_splash {
   @include grid-row($behavior: nest);
 

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -54,79 +54,39 @@ Rails.configuration.to_prepare do
     end
 
     InfoRequest.class_eval do
+        AUSTRALIAN_LAW_USED_READABLE_DATA =
+          { foi: { short: _('FOI'),
+                   full: _('Freedom of Information'),
+                   act: _('Freedom of Information Act') },
+            gipa: { short: _('GIPA'),
+                    full: _("Government Information (Public Access)"),
+                    act: _("Government Information (Public Access) Act") },
+            rti: { short: _('RTI'),
+                   full: _("Right to Information"),
+                   act: _("Right to Information Act") }
+          }
+
         def australian_law_used
             if public_body
                 case public_body.jurisdiction
                 when :nsw
-                    "gipa"
+                    :gipa
                 when :qld, :tas
-                    "rti"
+                    :rti
                 else
-                    "foi"
+                    :foi
                 end
             else
-                "foi"
+                :foi
             end
         end
 
-        # Used in messages shown to the user when interacting with a request
-        # and in outbound emails to the authority
-        def law_used_full
-            case australian_law_used
-            when "gipa"
-                _("Government Information (Public Access)")
-            when "rti"
-                _("Right to Information")
-            when "foi"
-                _("Freedom of Information")
-            else
-                raise "Unknown law used '#{australian_law_used}'"
-            end
-        end
-
-        # Used in messages shown to the user when interacting with a request
-        # and in outbound emails to the authority
-        def law_used_short
-            case australian_law_used
-            when "gipa"
-                _("GIPA")
-            when "rti"
-                _("RTI")
-            when "foi"
-                _("FOI")
-            else
-                raise "Unknown law used '#{australian_law_used}'"
-            end
-        end
-
-        # This method isn't currently used in Alaveteli but we're overriding it
-        # for completeness
-        def law_used_act
-            case australian_law_used
-            when "gipa"
-                _("Government Information (Public Access) Act")
-            when "rti"
-                _("Right to Information Act")
-            when "foi"
-                _("Freedom of Information Act")
-            else
-                raise "Unknown law used '#{australian_law_used}'"
-            end
-        end
-
-        # This method isn't currently used in Alaveteli but we're overriding it
-        # for completeness
-        def law_used_with_a
-            case australian_law_used
-            when "gipa"
-                _("A Government Information (Public Access) request")
-            when "rti"
-                _("A Right to Information request")
-            when "foi"
-                _("A Freedom of Information request")
-            else
-                raise "Unknown law used '#{australian_law_used}'"
-            end
+        def applicable_law
+          begin
+            AUSTRALIAN_LAW_USED_READABLE_DATA.fetch(australian_law_used)
+          rescue KeyError
+            raise "Unknown law used '#{australian_law_used}'"
+          end
         end
 
         def date_response_required_by

--- a/lib/views/general/_frontpage_new_request.html.erb
+++ b/lib/views/general/_frontpage_new_request.html.erb
@@ -1,0 +1,7 @@
+<h1>
+  <%= _("Make a new<br/>
+  <strong>Freedom <span>of</span><br/>
+  Information<br/>
+  request</strong>") %>
+</h1>
+<a class="link_button_green_large" href="<%= select_authority_path %>"><%= _("Make a request &raquo;") %></a>

--- a/lib/views/general/_frontpage_requests_list.html.erb
+++ b/lib/views/general/_frontpage_requests_list.html.erb
@@ -1,0 +1,41 @@
+<%- @request_events, @request_events_all_successful = InfoRequest.recent_requests %>
+<div id="examples_1">
+  <h3>
+    <% if @request_events_all_successful %>
+      <%= _("What information has been released?") %>
+    <% else %>
+      <%= _("What information has been requested?") %>
+    <% end %>
+  </h3>
+  <%= _("{{site_name}} users have made {{number_of_requests}} requests, including:",
+        :site_name => site_name,
+        :number_of_requests => number_with_delimiter(InfoRequest.visible.count)) %>
+
+  <ul>
+    <% @request_events.each do |event| %>
+      <li>
+        <% if @request_events_all_successful %>
+          <%= _("{{public_body_link}} answered a request about",
+                :public_body_link => public_body_link(event.info_request.public_body)) %>
+        <% else %>
+          <%= _("{{public_body_link}} was sent a request about",
+                :public_body_link => public_body_link(event.info_request.public_body)) %>
+        <% end %>
+
+        <%=link_to h(event.info_request.title), request_path(event.info_request)%>
+        <%= _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(event.described_at)) %>
+        <p class="excerpt" onclick="document.location.href='<%=request_path(event.info_request)%>'"><%= excerpt(event.search_text_main(true), "", :radius => 200) %></p>
+      </li>
+    <% end %>
+  </ul>
+
+  <p>
+    <strong>
+      <% if @request_events_all_successful %>
+        <%= link_to _('More successful requests...'), request_list_successful_path %>
+      <% else %>
+        <%= link_to _('More requests...'), request_list_all_path %>
+      <% end %>
+    </strong>
+  </p>
+</div>

--- a/lib/views/request/_request_sent.html.erb
+++ b/lib/views/request/_request_sent.html.erb
@@ -2,7 +2,7 @@
   <div class="request-sent-message" id="notice">
     <h1>
       <%= _("Your {{law_used_full}} request has been sent",
-            :law_used_full => @info_request.law_used_full) %>
+            :law_used_full => @info_request.law_used_human(:full)) %>
     </h1>
     <div class="request-sent-message__row">
       <div class="request-sent-message__column-1">


### PR DESCRIPTION
Things from the [release notes](https://github.com/mysociety/alaveteli/blob/develop/doc/CHANGES.md#version-023) that we need to check:

~~This release adds geoip-database to the list of required packages. You can install it with sudo apt-get install geoip-database. If you don't want to or can't use a local GeoIP database, set GEOIP_DATABASE' to an empty string in config/general.yml`.~~

~~This release introduces a new default homepage - if you want to keep your existing homepage layout, copy the old homepage templates to your theme before upgrading and check that you have translations for them in your theme-locale directory.~~

~~This release takes the first steps to deprecate the link_button_green class, which will be removed in a future release. We've added contextually relevant classes to these elements. Please update your themes to ensure you're no longer using link_button_green for styling.~~ [It's not clear to me what needs to happen so I'm not going to worry about it for this upgrade - we can fix it when it's a problem]

~~The InfoRequest methods law_used_short, law_used_act and law_used_with_a have been deprecated and will be removed in a future release. The new method law_used_human has been supplied instead which takes a key to access the equivalent information of the original methods, e.g. law_used_human(:full), law_used_human(:short) etc. As the law_used_with_a functionality does not appear to be in use, if you do still need this functionality in future you may need to override the LAW_USED_READABLE_DATA hash to ensure it has a :with_a key value pair for each law you are supporting before calling law_used_human(:with_a).~~
