### PR TITLE
Add South Australia

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -61,7 +61,7 @@ The Freedom of Information Acts simply say that "every person has a legally enfo
 <dd>
 <p>
   At the moment we aim to cover public authorities in the Australian Federal
-  Government, the ACT, the NT, NSW and Victoria. We plan to add more State and Local
+  Government, the ACT, the NT, NSW, SA, and Victoria. We plan to add more State and Local
   Government authorities soon.
 </p>
 <p>
@@ -348,6 +348,11 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
       For <%= link_to "Victorian Authorities", list_public_bodies_path(:tag => "VIC") %>,
       information can be found on the
       <a href="http://www.foi.vic.gov.au/">Victorian Freedom of Information website</a>.
+    </li>
+    <li>
+      For <%= link_to "SA Authorities", list_public_bodies_path(:tag => "SA") %>,
+      information can be found on the
+      <a href="http://www.archives.sa.gov.au/content/foi-in-sa">State Records' FOI in South Australia</a> pages.
     </li>
   </ul>
 </dd>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -76,6 +76,10 @@ to your request '<%=request_link(@info_request) %>'?
     For <%= link_to "Victorian Authorities", list_public_bodies_path(:tag => "VIC") %>, contact the
     <a href="http://www.foicommissioner.vic.gov.au/home/reviews/">Freedom of Information Commissioner</a>.
   </li>
+  <li>
+    For <%= link_to "SA Authorities", list_public_bodies_path(:tag => "SA") %>, contact
+    <a href="http://www.ombudsman.sa.gov.au/freedom-of-information/">Ombudsman SA</a>.
+  </li>
 </ul>
 
 <p>

--- a/lib/views/public_body/_list_sidebar_extra.html.erb
+++ b/lib/views/public_body/_list_sidebar_extra.html.erb
@@ -1,5 +1,5 @@
 <p>
-  We aim to cover Federal, ACT, NT, NSW and Victorian public authorities with more State and local authorities coming soon.
+  We aim to cover Federal, ACT, NT, NSW, SA, and Victorian public authorities with more State and local authorities coming soon.
 </p>
 <p>
   <%= raw(_('<a href="%s">Are we missing a public authority?</a>') % [help_requesting_path + '#missing_body']) %>


### PR DESCRIPTION
This updates the help files with information relevant to South Australia.

[As per the readme](https://github.com/openaustralia/righttoknow#adding-more-jurisdictions) to deploy this we still need to:
- [x] Upload the new authorities (don't forget state and local government!)
- [x] Add categories

Also:
- [x] ~~Decide [what to do with hospitals](https://github.com/openaustralia/righttoknow/pull/609#issuecomment-242253884)~~ Here's [what we decided](https://github.com/openaustralia/righttoknow/issues/619). We still need to do that for this data.
- [x] ~~[And schools](https://github.com/openaustralia/righttoknow/issues/463)?~~ We've decided not to add them for the moment.
- [x] There are two Campbelltown City Councils (one in NSW) - how should we name them? (We're thinking "Campbelltown City Council (NSW)").
