### PR TITLE
Add help and text changes for including authorities in the Tasmanian Right To Information jurisdiction

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -61,7 +61,7 @@ The Freedom of Information Acts simply say that "every person has a legally enfo
 <dd>
 <p>
   At the moment we aim to cover public authorities in the Australian Federal
-  Government, the ACT, the NT, NSW, SA, and Victoria. We plan to add more State and Local
+  Government, the ACT, the NT, NSW, SA, Victoria, and Tasmania. We plan to add more State and Local
   Government authorities soon.
 </p>
 <p>
@@ -353,6 +353,11 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
       For <%= link_to "SA Authorities", list_public_bodies_path(:tag => "SA") %>,
       information can be found on the
       <a href="http://www.archives.sa.gov.au/content/foi-in-sa">State Records' FOI in South Australia</a> pages.
+    </li>
+    <li>
+      For <%= link_to "Tasmanian Authorities", list_public_bodies_path(:tag => "TAS") %>,
+      information can be found on
+      <a href="http://www.ombudsman.tas.gov.au/right_to_information/process">Ombudsman Tasmania’s Right To Information</a> pages.
     </li>
   </ul>
 </dd>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -80,6 +80,10 @@ to your request '<%=request_link(@info_request) %>'?
     For <%= link_to "SA Authorities", list_public_bodies_path(:tag => "SA") %>, contact
     <a href="http://www.ombudsman.sa.gov.au/freedom-of-information/">Ombudsman SA</a>.
   </li>
+  <li>
+    For <%= link_to "Tasmanian Authorities", list_public_bodies_path(:tag => "TAS") %>, contact
+    <a href="http://www.ombudsman.tas.gov.au/right_to_information/process">Ombudsman Tasmania</a>.
+  </li>
 </ul>
 
 <p>

--- a/lib/views/public_body/_list_sidebar_extra.html.erb
+++ b/lib/views/public_body/_list_sidebar_extra.html.erb
@@ -1,5 +1,5 @@
 <p>
-  We aim to cover Federal, ACT, NT, NSW, SA, and Victorian public authorities with more State and local authorities coming soon.
+  We aim to cover Federal, ACT, NT, NSW, SA, Victorian, and Tasmanian public authorities with more State and local authorities coming soon.
 </p>
 <p>
   <%= raw(_('<a href="%s">Are we missing a public authority?</a>') % [help_requesting_path + '#missing_body']) %>


### PR DESCRIPTION
I'm gonna deploy this to staging, and do a test of adding the categories and authorities in there.
