### PR TITLE
Add Google Adwords tracking code

### DIFF
--- a/lib/views/request/_request_sent.html.erb
+++ b/lib/views/request/_request_sent.html.erb
@@ -63,22 +63,22 @@
 </div>
 
 <% if Rails.env.production? && AlaveteliConfiguration.domain == 'www.righttoknow.org.au' %>
-<!-- Google Code for RTK Request Made Conversion Page -->
-<script type="text/javascript">
-/* <![CDATA[ */
-var google_conversion_id = 1055120173;
-var google_conversion_language = "en";
-var google_conversion_format = "3";
-var google_conversion_color = "ffffff";
-var google_conversion_label = "_HtwCMv6o2oQrbaP9wM";
-var google_remarketing_only = false;
-/* ]]> */
-</script>
-<script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
-</script>
-<noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/1055120173/?label=_HtwCMv6o2oQrbaP9wM&amp;guid=ON&amp;script=0"/>
-  </div>
-</noscript>
+  <!-- Google Code for RTK Request Made Conversion Page -->
+  <script type="text/javascript">
+    /* <![CDATA[ */
+    var google_conversion_id = 1055120173;
+    var google_conversion_language = "en";
+    var google_conversion_format = "3";
+    var google_conversion_color = "ffffff";
+    var google_conversion_label = "_HtwCMv6o2oQrbaP9wM";
+    var google_remarketing_only = false;
+    /* ]]> */
+  </script>
+  <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+  </script>
+  <noscript>
+    <div style="display:inline;">
+      <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/1055120173/?label=_HtwCMv6o2oQrbaP9wM&amp;guid=ON&amp;script=0"/>
+    </div>
+  </noscript>
 <% end %>

--- a/lib/views/request/_request_sent.html.erb
+++ b/lib/views/request/_request_sent.html.erb
@@ -62,7 +62,7 @@
   </div>
 </div>
 
-<% if Rails.env.production? && AlaveteliConfiguration.domain == 'righttoknow.org.au' %>
+<% if Rails.env.production? && AlaveteliConfiguration.domain == 'www.righttoknow.org.au' %>
 <!-- Google Code for RTK Request Made Conversion Page -->
 <script type="text/javascript">
 /* <![CDATA[ */

--- a/lib/views/request/_request_sent.html.erb
+++ b/lib/views/request/_request_sent.html.erb
@@ -61,3 +61,24 @@
     </div>
   </div>
 </div>
+
+<% if Rails.env.production? && AlaveteliConfiguration.domain == 'righttoknow.org.au' %>
+<!-- Google Code for RTK Request Made Conversion Page -->
+<script type="text/javascript">
+/* <![CDATA[ */
+var google_conversion_id = 1055120173;
+var google_conversion_language = "en";
+var google_conversion_format = "3";
+var google_conversion_color = "ffffff";
+var google_conversion_label = "_HtwCMv6o2oQrbaP9wM";
+var google_remarketing_only = false;
+/* ]]> */
+</script>
+<script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+</script>
+<noscript>
+  <div style="display:inline;">
+    <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/1055120173/?label=_HtwCMv6o2oQrbaP9wM&amp;guid=ON&amp;script=0"/>
+  </div>
+</noscript>
+<% end %>


### PR DESCRIPTION
This adds the Adwords conversion tracking code for making a request as per the WDTK theme. The conversion in your Adwords account should be all set!

I've guessed the domain setting as `'righttoknow.org.au'` in the line:

``` rb
<% if Rails.env.production? && AlaveteliConfiguration.domain == 'righttoknow.org.au' %>
```

Please fix this if I've guessed wrong!

(The purpose of this bit is to avoid accidentally logging data from dev or test boxes as this can make a mess of your stats - as I accidentally found out the first time I tried to run a Google A/B test 😞)
