### PR TITLE
Add a banner for Right To Know Day 2016

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -627,6 +627,13 @@ margin-bottom: 0px;
 .popup {
   .entirebody > & {
     margin: 0;
+    position: relative;
+
+    .popup-close {
+      position: absolute;
+      right: 5px;
+      bottom: 5px;
+    }
   }
 }
 

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -625,7 +625,7 @@ margin-bottom: 0px;
 }
 
 .popup {
-  &#other-country-notice {
+  .entirebody > & {
     margin: 0;
   }
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -627,7 +627,14 @@ margin-bottom: 0px;
 .popup {
   .entirebody > & {
     margin: 0;
+    padding: .5em 1.5em;
     position: relative;
+
+    .popup-content {
+      float: none;
+      display: block;
+      @extend .wrapper;
+    }
 
     .popup-close {
       position: absolute;

--- a/lib/views/general/_popup_banner.html.erb
+++ b/lib/views/general/_popup_banner.html.erb
@@ -1,1 +1,7 @@
-<%#- anything you put here will appear in a green bar on the top of every screen in Alaveteli -%>
+<% if Date.today == Date.new(2016,9,28) %>
+  It's International Right To Know Day.
+  Do your friends know they have a right to information?
+  <strong>Let them know</strong>.
+  Share on <a href="https://www.facebook.com/sharer/sharer.php?u=https://www.righttoknow.org.au/">Facebook</a>
+  or <a href="https://twitter.com/home?status=Everyone%20has%20the%20right%20to%20access%20information%20held%20by%20Australian%20public%20authorities%20https%3A//www.righttoknow.org.au/%20%23RightToKnowDay">Twitter</a>
+<% end %>


### PR DESCRIPTION
On [the Alaveteli list](https://groups.google.com/d/msg/alaveteli-users/6Mle_gTajSo/XKHSGfjuCAAJ) it was suggested that sites might like to add a banner for Right To Know day.

I've quickly whipped this up but there are some visual appearance issues with our banner (grey line across the top, left side of text not aligned with site):

![selection_001](https://cloud.githubusercontent.com/assets/48945/18857235/9c55f54c-84a5-11e6-8d2c-b346b23521c5.png)

I'm assigning this to @equivalentideas to see if he thinks it's a good idea and if so to also fix the appearance issues.
