### PR TITLE
Help people avoid making requests for personal information by adding a question up front for authorities where this is a common problem

### DIFF
--- a/assets/javascripts/event_tracking.js
+++ b/assets/javascripts/event_tracking.js
@@ -28,5 +28,18 @@ $(document).ready(function() {
     $(".request_personal_message .request_email a").click(function(e) {
       ga('send', 'event', 'Request for personal information question', 'click Authority email address');
     });
+
+    // Making a request
+    $("#request_new input[type='submit']").click(function(e) {
+      ga('send', 'event', 'Make a request', 'click Preview Request button');
+    });
+
+    $(".new_info_request .preview-pane #reedit_button").click(function(e) {
+      ga('send', 'event', 'Make a request', 'click Edit Your Request button from preview');
+    });
+
+    $(".new_info_request .preview-pane #submit_button").click(function(e) {
+      ga('send', 'event', 'Make a request', 'click Send Request button from preview');
+    });
   }
 })

--- a/assets/javascripts/event_tracking.js
+++ b/assets/javascripts/event_tracking.js
@@ -14,5 +14,17 @@ $(document).ready(function() {
 
     $('.unsubscribe__action').click(function(e) { trackUnsubscribe() });
     $('.unsubscribe-request-action').click(function(e) { trackUnsubscribe() });
+
+    $("#request_personal_switch_yes").click(function(e) {
+      ga('send', 'event', 'Request for personal information question', 'click Yes');
+    });
+
+    $("#request_personal_switch_no").click(function(e) {
+      ga('send', 'event', 'Request for personal information question', 'click No');
+    });
+
+    $(".request_personal_message .request_email a").click(function(e) {
+      ga('send', 'event', 'Request for personal information question', 'click Authority email address');
+    });
   }
 })

--- a/assets/javascripts/event_tracking.js
+++ b/assets/javascripts/event_tracking.js
@@ -1,6 +1,7 @@
 $(document).ready(function() {
   // check if the Google Analytics function is available
   if (typeof ga == 'function') {
+    // Following
     function trackFollow() {
       ga('send', 'event', 'Following', 'click Follow button');
     };
@@ -15,6 +16,7 @@ $(document).ready(function() {
     $('.unsubscribe__action').click(function(e) { trackUnsubscribe() });
     $('.unsubscribe-request-action').click(function(e) { trackUnsubscribe() });
 
+    // Request for personal information question
     $("#request_personal_switch_yes").click(function(e) {
       ga('send', 'event', 'Request for personal information question', 'click Yes');
     });

--- a/assets/javascripts/personal_message_toggler.js
+++ b/assets/javascripts/personal_message_toggler.js
@@ -4,9 +4,10 @@ $(document).ready(function() {
   personalRequestClass = "personal_request_switcher_focused";
 
   if ($switcherFieldGroup.length) {
-    // If an error is showing they must have selected 'no'
+    // If an error is showing or the subject has been filled then
+    // they must have selected 'no' already
     // so set this and don't hide the form.
-    if ($(".errorExplanation").length) {
+    if ($(".errorExplanation").length || $("#request_header_subject input")[0].value) {
       $("#request_personal_switch_no").prop("checked", true);
     } else {
       $switcherFieldGroup.addClass(personalRequestClass);

--- a/assets/javascripts/personal_message_toggler.js
+++ b/assets/javascripts/personal_message_toggler.js
@@ -1,0 +1,15 @@
+$(document).ready(function() {
+  $switcherFieldGroup = $("#request_personal_switch");
+
+  if ($switcherFieldGroup.length) {
+    $switcherFieldGroup.addClass("personal_request_switcher_focused");
+
+    $("#request_personal_switch_no").click(function(e) {
+      $switcherFieldGroup.removeClass("personal_request_switcher_focused");
+    });
+
+    $("#request_personal_switch_yes").click(function(e) {
+      $switcherFieldGroup.addClass("personal_request_switcher_focused");
+    });
+  }
+});

--- a/assets/javascripts/personal_message_toggler.js
+++ b/assets/javascripts/personal_message_toggler.js
@@ -1,5 +1,6 @@
 $(document).ready(function() {
   $switcherFieldGroup = $("#request_personal_switch");
+  $formSubmitButton = $("#request_form input[type='submit']")[0];
 
   if ($switcherFieldGroup.length) {
     // If an error is showing they must have selected 'no'
@@ -8,14 +9,17 @@ $(document).ready(function() {
       $("#request_personal_switch_no").prop("checked", true);
     } else {
       $switcherFieldGroup.addClass("personal_request_switcher_focused");
-
-      $("#request_personal_switch_no").click(function(e) {
-        $switcherFieldGroup.removeClass("personal_request_switcher_focused");
-      });
-
-      $("#request_personal_switch_yes").click(function(e) {
-        $switcherFieldGroup.addClass("personal_request_switcher_focused");
-      });
+      $formSubmitButton.disabled = true;
     }
+
+    $("#request_personal_switch_no").click(function(e) {
+      $switcherFieldGroup.removeClass("personal_request_switcher_focused");
+      $formSubmitButton.disabled = false;
+    });
+
+    $("#request_personal_switch_yes").click(function(e) {
+      $switcherFieldGroup.addClass("personal_request_switcher_focused");
+      $formSubmitButton.disabled = true;
+    });
   }
 });

--- a/assets/javascripts/personal_message_toggler.js
+++ b/assets/javascripts/personal_message_toggler.js
@@ -1,6 +1,7 @@
 $(document).ready(function() {
   $switcherFieldGroup = $("#request_personal_switch");
   $formSubmitButton = $("#request_form input[type='submit']")[0];
+  personalRequestClass = "personal_request_switcher_focused";
 
   if ($switcherFieldGroup.length) {
     // If an error is showing they must have selected 'no'
@@ -8,17 +9,17 @@ $(document).ready(function() {
     if ($(".errorExplanation").length) {
       $("#request_personal_switch_no").prop("checked", true);
     } else {
-      $switcherFieldGroup.addClass("personal_request_switcher_focused");
+      $switcherFieldGroup.addClass(personalRequestClass);
       $formSubmitButton.disabled = true;
     }
 
     $("#request_personal_switch_no").click(function(e) {
-      $switcherFieldGroup.removeClass("personal_request_switcher_focused");
+      $switcherFieldGroup.removeClass(personalRequestClass);
       $formSubmitButton.disabled = false;
     });
 
     $("#request_personal_switch_yes").click(function(e) {
-      $switcherFieldGroup.addClass("personal_request_switcher_focused");
+      $switcherFieldGroup.addClass(personalRequestClass);
       $formSubmitButton.disabled = true;
     });
   }

--- a/assets/javascripts/personal_message_toggler.js
+++ b/assets/javascripts/personal_message_toggler.js
@@ -2,14 +2,20 @@ $(document).ready(function() {
   $switcherFieldGroup = $("#request_personal_switch");
 
   if ($switcherFieldGroup.length) {
-    $switcherFieldGroup.addClass("personal_request_switcher_focused");
-
-    $("#request_personal_switch_no").click(function(e) {
-      $switcherFieldGroup.removeClass("personal_request_switcher_focused");
-    });
-
-    $("#request_personal_switch_yes").click(function(e) {
+    // If an error is showing they must have selected 'no'
+    // so set this and don't hide the form.
+    if ($(".errorExplanation").length) {
+      $("#request_personal_switch_no").prop("checked", true);
+    } else {
       $switcherFieldGroup.addClass("personal_request_switcher_focused");
-    });
+
+      $("#request_personal_switch_no").click(function(e) {
+        $switcherFieldGroup.removeClass("personal_request_switcher_focused");
+      });
+
+      $("#request_personal_switch_yes").click(function(e) {
+        $switcherFieldGroup.addClass("personal_request_switcher_focused");
+      });
+    }
   }
 });

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1453,6 +1453,17 @@ a.leaderboard-person-details {
   font-weight: normal;
 }
 
+#request_personal_switch input[type="radio"],
+#request_personal_switch input[type="radio"] + label {
+  font-size: 1.125em;
+}
+
+#request_personal_switch input[type="radio"] + label {
+  font-weight: bold;
+  margin: 0 2em 0 0;
+  padding: .5em 1em 1em .5em;
+}
+
 .personal_request_switcher_focused ~ * {
    display: none;
  }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1443,7 +1443,7 @@ a.leaderboard-person-details {
 
   .request_email {
     display: block;
-    margin: 1em;
+    margin: 1em 0;
     text-align: center;
     font-weight: bold;
   }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1441,7 +1441,7 @@ a.leaderboard-person-details {
     display: block;
   }
 
-  a.request_email {
+  .request_email {
     display: block;
     margin: 1em;
     text-align: center;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1433,11 +1433,15 @@ a.leaderboard-person-details {
   padding: 0 0 1em 1em;
 }
 
-// Request for personal information switch
+// Requests for personal information
 .request_personal_message {
   display: none;
 
   input#request_personal_switch_yes:checked ~ & {
     display: block;
   }
+}
+
+#request_personal_switch legend {
+  font-weight: normal;
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1452,3 +1452,7 @@ a.leaderboard-person-details {
 #request_personal_switch legend {
   font-weight: normal;
 }
+
+.personal_request_switcher_focused ~ * {
+   display: none;
+ }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1453,15 +1453,23 @@ a.leaderboard-person-details {
   font-weight: normal;
 }
 
-#request_personal_switch input[type="radio"],
 #request_personal_switch input[type="radio"] + label {
   font-size: 1.125em;
+  margin: 0 2em 1em 0;
+  padding: .5em 1.5em;
+  border: 2px solid #ccc;
+  border-radius: 2px;
 }
 
-#request_personal_switch input[type="radio"] + label {
+#request_personal_switch input[type="radio"]:focus + label,
+#request_personal_switch input[type="radio"] + label:hover {
+  border-color: #005068;
+}
+
+#request_personal_switch input[type="radio"]:checked + label {
   font-weight: bold;
-  margin: 0 2em 0 0;
-  padding: .5em 1em 1em .5em;
+  background-color: #f5f5f5;
+  box-shadow: inset 0 2px 5px 1px rgba(0, 0, 0, 0.2);
 }
 
 .personal_request_switcher_focused ~ * {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1443,6 +1443,7 @@ a.leaderboard-person-details {
   }
 
   .request_email {
+    font-size: 1.125em;
     display: block;
     margin: 1em 0;
     text-align: center;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1435,6 +1435,7 @@ a.leaderboard-person-details {
 
 // Requests for personal information
 .request_personal_message {
+  margin: 2em 0;
   display: none;
 
   input#request_personal_switch_yes:checked ~ & {
@@ -1459,7 +1460,7 @@ a.leaderboard-person-details {
 
 #request_personal_switch input[type="radio"] + label {
   font-size: 1.125em;
-  margin: 0 2em 1em 0;
+  margin: 0 2em 0 0;
   padding: .5em 1.5em;
   border: 2px solid #ccc;
   border-radius: 2px;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1451,6 +1451,10 @@ a.leaderboard-person-details {
 
 #request_personal_switch legend {
   font-weight: normal;
+
+  & + p {
+    margin: 0 0 1em;
+  }
 }
 
 #request_personal_switch input[type="radio"] + label {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1458,7 +1458,6 @@ a.leaderboard-person-details {
 }
 
 #request_personal_switch input[type="radio"] + label {
-  font-size: 1.125em;
   margin: 0 2em 0 0;
   padding: .5em 1.5em;
   border: 2px solid #ccc;

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1440,6 +1440,13 @@ a.leaderboard-person-details {
   input#request_personal_switch_yes:checked ~ & {
     display: block;
   }
+
+  a.request_email {
+    display: block;
+    margin: 1em;
+    text-align: center;
+    font-weight: bold;
+  }
 }
 
 #request_personal_switch legend {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1432,3 +1432,12 @@ a.leaderboard-person-details {
   font-size: 1.125em;
   padding: 0 0 1em 1em;
 }
+
+// Request for personal information switch
+.request_personal_message {
+  display: none;
+
+  input#request_personal_switch_yes:checked ~ & {
+    display: block;
+  }
+}

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1444,8 +1444,6 @@ a.leaderboard-person-details {
 
   .request_email {
     font-size: 1.125em;
-    display: block;
-    margin: 1em 0;
     text-align: center;
     font-weight: bold;
   }

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -9,7 +9,8 @@ THEME_NAME = File.split(File.expand_path("../..", __FILE__))[1]
     Rails.application.config.assets.paths.unshift theme_asset_path
 end
 
-Rails.application.config.assets.precompile << "event_tracking.js"
+Rails.application.config.assets.precompile << ["event_tracking.js",
+                                               "personal_message_toggler.js"]
 
 class ActionController::Base
     # The following prepends the path of the current theme's views to

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -51,6 +51,10 @@ Rails.configuration.to_prepare do
         'calendar'
       end
     end
+
+    def info_requests_hidden_count
+      info_requests.where("prominence != ?", "normal").count
+    end
   end
 
   InfoRequest.class_eval do

--- a/lib/views/general/_before_head_end.html.erb
+++ b/lib/views/general/_before_head_end.html.erb
@@ -1,2 +1,3 @@
 <link href='https://fonts.googleapis.com/css?family=Maven+Pro:400,700%7CActor' rel='stylesheet' type='text/css'>
 <%= javascript_include_tag 'event_tracking' unless AlaveteliConfiguration::ga_code.empty? || (@user && @user.super?) %>
+<%= javascript_include_tag 'personal_message_toggler' %>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -212,7 +212,7 @@
           <label for="request_personal_switch_no">No</label>
           <div class="request_personal_message">
             <p>
-              Please <strong>email your request</strong> directly to <%= @info_request.public_body.name %>:
+              <strong>Email your request</strong> directly to <%= @info_request.public_body.name %>:
               <%= mail_to @info_request.public_body.request_email, @info_request.public_body.request_email, class: "request_email" %>
             </p>
             <p>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -211,7 +211,10 @@
           <input type="radio" name="personal_request" id="request_personal_switch_no" value="no" />
           <label for="request_personal_switch_no">No</label>
           <div class="request_personal_message">
-            <p>Please email your request directly to NSW Police Force using: gipaapp@police.nsw.gov.au</p>
+            <p>
+              Please email your request directly to NSW Police Force using:
+              <%= mail_to "gipaapp@police.nsw.gov.au" %>
+            </p>
             <p>You cannot make requests for personal information using this site. If you do you will be posting your information publicly on the internet for anyone to see.</p>
           </div>
         </fieldset>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -205,7 +205,8 @@
     <div id="request_form" class="request_form">
       <% if !@batch && @info_request.public_body.info_requests_hidden_count >= 2 %>
         <fieldset id="request_personal_switch" class="request_personal_switch">
-          <legend>Are you asking for <strong>personal information</strong> about yourself or someone else?</legend>
+          <legend>Are you asking for <strong>personal information</strong> that should be confidential?</legend>
+          <p>This includes <em>police incident reports</em>, <em>medical records</em>, <em>paperwork for insurance</em>, etc.</p>
           <input type="radio" name="personal_request" id="request_personal_switch_yes" value="yes" />
           <label for="request_personal_switch_yes">Yes</label>
           <input type="radio" name="personal_request" id="request_personal_switch_no" value="no" />

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -213,7 +213,7 @@
           <div class="request_personal_message">
             <p>
               <strong>Email your request</strong> directly to <%= @info_request.public_body.name %>:
-              <%= mail_to @info_request.public_body.request_email, @info_request.public_body.request_email, class: "request_email" %>
+              <%= mail_to @info_request.public_body.request_email, @info_request.public_body.request_email, subject: "Request for personal information", class: "request_email" %>
             </p>
             <p>
               You <%= link_to "cannot make requests for personal information", help_requesting_path(:anchor => "data_protection") %>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -212,10 +212,8 @@
           <input class="visually-hidden" type="radio" name="personal_request" id="request_personal_switch_no" value="no" />
           <label for="request_personal_switch_no">No</label>
           <div class="request_personal_message">
-            <p>
-              <strong>Email your request</strong> directly to <%= @info_request.public_body.name %>:
-              <div class="request_email"><%= mail_to @info_request.public_body.request_email, @info_request.public_body.request_email, subject: "Request for personal information" %></div>
-            </p>
+            <p><strong>Email your request</strong> directly to <%= @info_request.public_body.name %>:</p>
+            <p class="request_email"><%= mail_to @info_request.public_body.request_email, @info_request.public_body.request_email, subject: "Request for personal information" %></p>
             <p>
               You <%= link_to "cannot make requests for personal information", help_requesting_path(:anchor => "data_protection") %>
               using this site. If you do you will be posting your information publicly on the internet for anyone to see.</p>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -203,50 +203,54 @@
     </div>
 
     <div id="request_form" class="request_form">
-      <div id="request_header_subject" class="request_header_subject">
-        <p>
-          <label class="form_label" for="typeahead_search"><%= _('Summary:') %></label>
-          <%= f.text_field :title, :size => 50, :id =>"typeahead_search" %>
-        </p>
+      <% if !@batch && @info_request.public_body.info_requests_hidden_count >= 2 %>
+          <p>Are you asking for personal information about yourself?</p>
+      <% else %>
+        <div id="request_header_subject" class="request_header_subject">
+          <p>
+            <label class="form_label" for="typeahead_search"><%= _('Summary:') %></label>
+            <%= f.text_field :title, :size => 50, :id =>"typeahead_search" %>
+          </p>
 
-        <div class="form_item_note">
-          <%= _("A one line summary of the information you are requesting, e.g.") %>
-          <%= render :partial => "summary_suggestion" %>
+          <div class="form_item_note">
+            <%= _("A one line summary of the information you are requesting, e.g.") %>
+            <%= render :partial => "summary_suggestion" %>
+          </div>
         </div>
-      </div>
 
-      <div id="typeahead_response" class="typeahead_response">
-      </div>
+        <div id="typeahead_response" class="typeahead_response">
+        </div>
 
-      <%= fields_for :outgoing_message do |o| %>
-        <p>
-          <label class="form_label" for="outgoing_message_body">
-            <%= _('Your request:') %></label>
-          <%= o.text_area :body, :rows => 20, :cols => 60 %>
-        </p>
-      <% end %>
-
-      <div class="form_button">
-        <% if @batch %>
-          <% params[:public_body_ids].each do |public_body_id| %>
-            <%= hidden_field_tag("public_body_ids[]", public_body_id)%>
-          <% end %>
-        <% else %>
-          <%= f.hidden_field(:public_body_id, { :value => @info_request.public_body_id } ) %>
+        <%= fields_for :outgoing_message do |o| %>
+          <p>
+            <label class="form_label" for="outgoing_message_body">
+              <%= _('Your request:') %></label>
+            <%= o.text_area :body, :rows => 20, :cols => 60 %>
+          </p>
         <% end %>
-        <%= hidden_field_tag(:submitted_new_request, 1 ) %>
-        <%= hidden_field_tag(:preview, 1 ) %>
-        <%= submit_tag _("Preview your public request") %>
-      </div>
 
-      <% if !@info_request.tag_string.empty? %>
-        <p class="form_note">
-          <!-- <label class="form_label" for="info_request_tag_string"><%= _("Tags (separated by a space):") %></label>
-            <%= f.text_field :tag_string, :size => 50 %> -->
+        <div class="form_button">
+          <% if @batch %>
+            <% params[:public_body_ids].each do |public_body_id| %>
+              <%= hidden_field_tag("public_body_ids[]", public_body_id)%>
+            <% end %>
+          <% else %>
+            <%= f.hidden_field(:public_body_id, { :value => @info_request.public_body_id } ) %>
+          <% end %>
+          <%= hidden_field_tag(:submitted_new_request, 1 ) %>
+          <%= hidden_field_tag(:preview, 1 ) %>
+          <%= submit_tag _("Preview your public request") %>
+        </div>
 
-            <%= f.hidden_field(:tag_string) %>
-            <strong>Tags:</strong> <%=h @info_request.tag_string %>
-        </p>
+        <% if !@info_request.tag_string.empty? %>
+          <p class="form_note">
+            <!-- <label class="form_label" for="info_request_tag_string"><%= _("Tags (separated by a space):") %></label>
+              <%= f.text_field :tag_string, :size => 50 %> -->
+
+              <%= f.hidden_field(:tag_string) %>
+              <strong>Tags:</strong> <%=h @info_request.tag_string %>
+          </p>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -206,7 +206,7 @@
       <% if !@batch && @info_request.public_body.info_requests_hidden_count >= 2 %>
         <fieldset id="request_personal_switch" class="request_personal_switch">
           <legend>Are you asking for <strong>personal information</strong> that should be confidential?</legend>
-          <p>This includes <em>police incident reports</em>, <em>medical records</em>, <em>paperwork for insurance</em>, etc.</p>
+          <p>This includes <em>police incident reports</em>, <em>court records</em>, <em>medical records</em>, <em>paperwork for insurance or court</em>, etc.</p>
           <input type="radio" name="personal_request" id="request_personal_switch_yes" value="yes" />
           <label for="request_personal_switch_yes">Yes</label>
           <input type="radio" name="personal_request" id="request_personal_switch_no" value="no" />

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -204,53 +204,62 @@
 
     <div id="request_form" class="request_form">
       <% if !@batch && @info_request.public_body.info_requests_hidden_count >= 2 %>
-          <p>Are you asking for personal information about yourself?</p>
-      <% else %>
-        <div id="request_header_subject" class="request_header_subject">
-          <p>
-            <label class="form_label" for="typeahead_search"><%= _('Summary:') %></label>
-            <%= f.text_field :title, :size => 50, :id =>"typeahead_search" %>
-          </p>
-
-          <div class="form_item_note">
-            <%= _("A one line summary of the information you are requesting, e.g.") %>
-            <%= render :partial => "summary_suggestion" %>
+        <fieldset id="request_personal_switch" class="request_personal_switch">
+          <legend>Are you asking for personal information about yourself?</legend>
+          <input type="radio" name="personal_request" id="request_personal_switch_yes" value="yes" />
+          <label for="request_personal_switch_yes">Yes</label>
+          <input type="radio" name="personal_request" id="request_personal_switch_no" value="no" />
+          <label for="request_personal_switch_no">No</label>
+          <div class="request_personal_message">
+            <p>Please email your request directly to NSW Police Force using: gipaapp@police.nsw.gov.au</p>
+            <p>You cannot make requests for personal information using this site. If you do you will be posting your information publicly on the internet for anyone to see.</p>
           </div>
+        </fieldset>
+      <% end %>
+      <div id="request_header_subject" class="request_header_subject">
+        <p>
+          <label class="form_label" for="typeahead_search"><%= _('Summary:') %></label>
+          <%= f.text_field :title, :size => 50, :id =>"typeahead_search" %>
+        </p>
+
+        <div class="form_item_note">
+          <%= _("A one line summary of the information you are requesting, e.g.") %>
+          <%= render :partial => "summary_suggestion" %>
         </div>
+      </div>
 
-        <div id="typeahead_response" class="typeahead_response">
-        </div>
+      <div id="typeahead_response" class="typeahead_response">
+      </div>
 
-        <%= fields_for :outgoing_message do |o| %>
-          <p>
-            <label class="form_label" for="outgoing_message_body">
-              <%= _('Your request:') %></label>
-            <%= o.text_area :body, :rows => 20, :cols => 60 %>
-          </p>
-        <% end %>
+      <%= fields_for :outgoing_message do |o| %>
+        <p>
+          <label class="form_label" for="outgoing_message_body">
+            <%= _('Your request:') %></label>
+          <%= o.text_area :body, :rows => 20, :cols => 60 %>
+        </p>
+      <% end %>
 
-        <div class="form_button">
-          <% if @batch %>
-            <% params[:public_body_ids].each do |public_body_id| %>
-              <%= hidden_field_tag("public_body_ids[]", public_body_id)%>
-            <% end %>
-          <% else %>
-            <%= f.hidden_field(:public_body_id, { :value => @info_request.public_body_id } ) %>
+      <div class="form_button">
+        <% if @batch %>
+          <% params[:public_body_ids].each do |public_body_id| %>
+            <%= hidden_field_tag("public_body_ids[]", public_body_id)%>
           <% end %>
-          <%= hidden_field_tag(:submitted_new_request, 1 ) %>
-          <%= hidden_field_tag(:preview, 1 ) %>
-          <%= submit_tag _("Preview your public request") %>
-        </div>
-
-        <% if !@info_request.tag_string.empty? %>
-          <p class="form_note">
-            <!-- <label class="form_label" for="info_request_tag_string"><%= _("Tags (separated by a space):") %></label>
-              <%= f.text_field :tag_string, :size => 50 %> -->
-
-              <%= f.hidden_field(:tag_string) %>
-              <strong>Tags:</strong> <%=h @info_request.tag_string %>
-          </p>
+        <% else %>
+          <%= f.hidden_field(:public_body_id, { :value => @info_request.public_body_id } ) %>
         <% end %>
+        <%= hidden_field_tag(:submitted_new_request, 1 ) %>
+        <%= hidden_field_tag(:preview, 1 ) %>
+        <%= submit_tag _("Preview your public request") %>
+      </div>
+
+      <% if !@info_request.tag_string.empty? %>
+        <p class="form_note">
+          <!-- <label class="form_label" for="info_request_tag_string"><%= _("Tags (separated by a space):") %></label>
+            <%= f.text_field :tag_string, :size => 50 %> -->
+
+            <%= f.hidden_field(:tag_string) %>
+            <strong>Tags:</strong> <%=h @info_request.tag_string %>
+        </p>
       <% end %>
     </div>
   </div>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -213,7 +213,7 @@
           <div class="request_personal_message">
             <p>
               Please email your request directly to <%= @info_request.public_body.name %> using:
-              <%= mail_to "gipaapp@police.nsw.gov.au" %>
+              <%= mail_to @info_request.public_body.request_email %>
             </p>
             <p>
               You <%= link_to "cannot make requests for personal information", help_requesting_path(:anchor => "data_protection") %>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -212,8 +212,8 @@
           <label for="request_personal_switch_no">No</label>
           <div class="request_personal_message">
             <p>
-              Please email your request directly to <%= @info_request.public_body.name %> using:
-              <%= mail_to @info_request.public_body.request_email %>
+              Please <strong>email your request</strong> directly to <%= @info_request.public_body.name %>:
+              <%= mail_to @info_request.public_body.request_email, @info_request.public_body.request_email, class: "request_email" %>
             </p>
             <p>
               You <%= link_to "cannot make requests for personal information", help_requesting_path(:anchor => "data_protection") %>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -205,7 +205,7 @@
     <div id="request_form" class="request_form">
       <% if !@batch && @info_request.public_body.info_requests_hidden_count >= 2 %>
         <fieldset id="request_personal_switch" class="request_personal_switch">
-          <legend>Are you asking for personal information about yourself?</legend>
+          <legend>Are you asking for <strong>personal information</strong> about yourself or someone else?</legend>
           <input type="radio" name="personal_request" id="request_personal_switch_yes" value="yes" />
           <label for="request_personal_switch_yes">Yes</label>
           <input type="radio" name="personal_request" id="request_personal_switch_no" value="no" />

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -1,0 +1,257 @@
+<% unless @batch %>
+  <script type="text/javascript">
+    $(document).ready(function(){
+      // Avoid triggering too often (on each keystroke) by using the
+      // debounce jQuery plugin:
+      // http://benalman.com/projects/jquery-throttle-debounce-plugin/
+      $("#typeahead_search").keypress($.debounce( 300, function() {
+        if ( $('#request_search_ahead_results').text().trim().length > 0) {
+          $('#typeahead_response').slideUp('fast');
+        }
+
+      $("#typeahead_response").load("<%= search_ahead_url %>?q="+encodeURI(this.value)+
+        "&requested_from=<%= @info_request.public_body.url_name %>"+
+        "&per_page=3", function() {
+
+          if ( $('#request_search_ahead_results').text().trim().length > 0) {
+            $('#typeahead_response').hide().slideDown('fast');
+
+            // When following links in typeahead results, open new
+            // tab/window
+            $("#typeahead_response a").attr("target","_blank");
+
+            // Update the public body site search link
+            $("#body-site-search-link").attr("href", "http://www.google.com/#q="+encodeURI($("#typeahead_search").val())+
+              "+site:<%= @info_request.public_body.calculated_home_page %>");
+
+            $('.close-button').click(function() { $(this).parent().hide() });
+          }
+        });
+      }));
+    });
+  </script>
+<% end %>
+
+<% if @batch %>
+  <% @title = _("Make an {{law_used_short}} request",
+                :law_used_short => h(@info_request.law_used_human(:short))) %>
+<% else %>
+  <% @title = _("Make an {{law_used_short}} request to '{{public_body_name}}'",:law_used_short=>h(@info_request.law_used_human(:short)),:public_body_name=>h(@info_request.public_body.name))  %>
+<% end %>
+
+
+<%= form_for(@info_request, :url => (@batch ? new_batch_path : new_request_path),
+                            :html => { :id => 'write_form' }  ) do |f| %>
+  <div id="request_header" class="request_header">
+    <div id="request_header_body" class="request_header_body">
+      <h1><%= _('Make a request') %></h1>
+
+      <% if @existing_request %>
+        <div class="errorExplanation" id="errorExplanation">
+          <ul>
+            <li>
+              <%= _('{{existing_request_user}} already created the same ' \
+                    'request on {{date}}. You can either view the ' \
+                    '<a href="{{existing_request}}">existing request</a>, or ' \
+                    'edit the details below to make a new but similar request.',
+                    :existing_request_user => user_or_you_capital_link(@existing_request.user),
+                    :date => simple_date(@existing_request.created_at),
+                    :existing_request => request_path(@existing_request)) %>
+            </li>
+          </ul>
+        </div>
+      <% end %>
+
+      <% if @existing_batch %>
+        <div class="errorExplanation" id="errorExplanation">
+          <ul>
+            <li>
+              <%= _('You already created the same batch of requests on ' \
+                      '{{date}}. You can either view the ' \
+                      '<a href="{{existing_batch}}">existing batch</a>, or ' \
+                      'edit the details below to make a new but similar batch ' \
+                      'of requests.',
+                    :date => simple_date(@existing_batch.created_at),
+                    :existing_batch => info_request_batch_path(@existing_batch)) %>
+            </li>
+          </ul>
+        </div>
+      <% end %>
+
+      <%= foi_error_messages_for :info_request, :outgoing_message %>
+
+      <% if !AlaveteliConfiguration::override_all_public_body_request_emails.blank? %>
+        <div class="warning">
+          <%= _("<strong>Note:</strong> Because we're testing, requests are being sent to {{email}} rather than to the actual authority.", :email => AlaveteliConfiguration::override_all_public_body_request_emails) %>
+        </div>
+      <% end %>
+
+      <% if @batch %>
+        <label class="form_label"><%= _('To:') %></label>
+        <span id="to_public_body" class="to_public_body">
+          <%= _("Your selected authorities") %>
+          <span class="batch_public_body_toggle" data-hidetext="<%= _("(hide)") %>" data-showtext="<%= _("(show)") %>"><a class="toggle-message"></a></span>
+        </span>
+
+        <div class="batch_public_body_list">
+          <ul>
+            <% @public_bodies.each do |public_body| %>
+              <li><%= public_body.name %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% else %>
+        <p id="to_public_body" class="to_public_body">
+          <span class="to_public_body_label"><%= _('To:') %></span>
+          <%= h(@info_request.public_body.name) %>
+        </p>
+      <% end %>
+
+      <% unless @batch %>
+        <% if @info_request.public_body.has_notes? %>
+          <div id="request_header_text" class="request_header_text">
+            <p><%= @info_request.public_body.notes_as_html.html_safe %></p>
+          </div>
+        <% end %>
+      <% end %>
+
+    </div>
+  </div>
+
+  <% unless @batch %>
+    <% if @info_request.public_body.eir_only? %>
+      <div class="request_body">
+        <div id="request_body_header" class="request_body_header">
+          <h3><%= _('Please ask for environmental information only') %></h3>
+
+          <p>
+            <%= _('The Freedom of Information Act <strong>does not apply</strong> to') %> <%=h(@info_request.public_body.name)%>.
+            <%= _('However, you have the right to request environmental ' \
+                  'information under a different law') %>
+            (<a href="/help/requesting#eir">explanation</a>).
+            <%= _('This covers a very wide spectrum of information about the ' \
+                  'state of the <strong>natural and built environment' \
+                  '</strong>, such as:') %>
+          </p>
+
+          <ul>
+            <li><%= _('Air, water, soil, land, flora and fauna (including how these effect human beings)') %></li>
+            <li><%= _('Information on emissions and discharges (e.g. noise, ' \
+                      'energy, radiation, waste materials)') %></li>
+            <li><%= _('Human health and safety') %></li>
+            <li><%= _('Cultural sites and built structures (as they may be affected by the environmental factors listed above)') %></li>
+            <li><%= _('Plans and administrative measures that affect these matters') %></li>
+          </ul>
+
+          <p>
+            <%= _('Please only request information that comes under those ' \
+                  'categories, <strong>do not waste your time</strong> or ' \
+                  'the time of the public authority by requesting unrelated ' \
+                  'information.') %>
+          </p>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+
+  <div class="request_body">
+    <div id="request_advice" class="request_advice">
+      <% unless @batch %>
+        <p>
+          <% if @info_request.public_body.info_requests.size > 0 %>
+            <%= _("Browse <a href='{{url}}'>other requests</a> to '{{public_body_name}}' for examples of how to word your request.", :public_body_name=>h(@info_request.public_body.name), :url=>public_body_path(@info_request.public_body)) %>
+          <% else %>
+            <%= _("Browse <a href='{{url}}'>other requests</a> for examples of how to word your request.", :url=>request_list_successful_url) %>
+          <% end %>
+        </p>
+      <% end %>
+
+      <p>
+        <%= raw(_('Everything that you enter on this page, including ' \
+                  '<strong>your name</strong>, will be <strong>displayed ' \
+                  'publicly</strong> on this website ' \
+                  '<a href="{{url}}">forever</a>',
+                  :url => help_privacy_path(:anchor => "public_request").html_safe)) %>.
+      </p>
+
+      <% unless @user %>
+        <p>
+          <%= raw(_('<a href="{{url}}">Thinking of using a pseudonym?</a>',
+                    :url => help_privacy_path(:anchor => "real_name").html_safe)) %>
+        </p>
+      <% end %>
+
+      <p>
+        <%= raw(_("<strong>Can I request information about myself?</strong> " \
+                  "<a href=\"{{url}}\">No!</a>",
+                  :url => help_requesting_path(:anchor => "data_protection").html_safe)) %>
+      </p>
+
+      <div class="advice-panel">
+        <ul>
+          <li><%= _('Write your request in <strong>simple, precise language</strong>.') %></li>
+          <li><%= _('Ask for <strong>specific</strong> documents or ' \
+                       'information, this site is not suitable for general ' \
+                       'enquiries.') %></li>
+          <li><%= _('<a href="{{url}}">Keep it <strong>focused</strong></a>, ' \
+                       'you\'ll be more likely to get what you want.',
+                    :url => help_requesting_path(:anchor => 'focused').html_safe) %></li>
+          <li><%= _('Make sure the information you are asking for is not ' \
+                       'already publicly available.') %></li>
+        </ul>
+      </div>
+    </div>
+
+    <div id="request_form" class="request_form">
+      <div id="request_header_subject" class="request_header_subject">
+        <p>
+          <label class="form_label" for="typeahead_search"><%= _('Summary:') %></label>
+          <%= f.text_field :title, :size => 50, :id =>"typeahead_search" %>
+        </p>
+
+        <div class="form_item_note">
+          <%= _("A one line summary of the information you are requesting, e.g.") %>
+          <%= render :partial => "summary_suggestion" %>
+        </div>
+      </div>
+
+      <div id="typeahead_response" class="typeahead_response">
+      </div>
+
+      <%= fields_for :outgoing_message do |o| %>
+        <p>
+          <label class="form_label" for="outgoing_message_body">
+            <%= _('Your request:') %></label>
+          <%= o.text_area :body, :rows => 20, :cols => 60 %>
+        </p>
+      <% end %>
+
+      <div class="form_button">
+        <% if @batch %>
+          <% params[:public_body_ids].each do |public_body_id| %>
+            <%= hidden_field_tag("public_body_ids[]", public_body_id)%>
+          <% end %>
+        <% else %>
+          <%= f.hidden_field(:public_body_id, { :value => @info_request.public_body_id } ) %>
+        <% end %>
+        <%= hidden_field_tag(:submitted_new_request, 1 ) %>
+        <%= hidden_field_tag(:preview, 1 ) %>
+        <%= submit_tag _("Preview your public request") %>
+      </div>
+
+      <% if !@info_request.tag_string.empty? %>
+        <p class="form_note">
+          <!-- <label class="form_label" for="info_request_tag_string"><%= _("Tags (separated by a space):") %></label>
+            <%= f.text_field :tag_string, :size => 50 %> -->
+
+            <%= f.hidden_field(:tag_string) %>
+            <strong>Tags:</strong> <%=h @info_request.tag_string %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<% if @batch %>
+  <%= javascript_include_tag 'new-request.js' %>
+<% end %>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -207,9 +207,9 @@
         <fieldset id="request_personal_switch" class="request_personal_switch">
           <legend>Are you asking for <strong>personal information</strong> that should be confidential?</legend>
           <p>This includes <em>police incident reports</em>, <em>court records</em>, <em>medical records</em>, <em>paperwork for insurance or court</em>, etc.</p>
-          <input type="radio" name="personal_request" id="request_personal_switch_yes" value="yes" />
+          <input class="visually-hidden" type="radio" name="personal_request" id="request_personal_switch_yes" value="yes" />
           <label for="request_personal_switch_yes">Yes</label>
-          <input type="radio" name="personal_request" id="request_personal_switch_no" value="no" />
+          <input class="visually-hidden" type="radio" name="personal_request" id="request_personal_switch_no" value="no" />
           <label for="request_personal_switch_no">No</label>
           <div class="request_personal_message">
             <p>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -215,7 +215,9 @@
               Please email your request directly to NSW Police Force using:
               <%= mail_to "gipaapp@police.nsw.gov.au" %>
             </p>
-            <p>You cannot make requests for personal information using this site. If you do you will be posting your information publicly on the internet for anyone to see.</p>
+            <p>
+              You <%= link_to "cannot make requests for personal information", help_requesting_path(:anchor => "data_protection") %>
+              using this site. If you do you will be posting your information publicly on the internet for anyone to see.</p>
           </div>
         </fieldset>
       <% end %>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -213,7 +213,7 @@
           <div class="request_personal_message">
             <p>
               <strong>Email your request</strong> directly to <%= @info_request.public_body.name %>:
-              <%= mail_to @info_request.public_body.request_email, @info_request.public_body.request_email, subject: "Request for personal information", class: "request_email" %>
+              <div class="request_email"><%= mail_to @info_request.public_body.request_email, @info_request.public_body.request_email, subject: "Request for personal information" %></div>
             </p>
             <p>
               You <%= link_to "cannot make requests for personal information", help_requesting_path(:anchor => "data_protection") %>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -212,7 +212,7 @@
           <label for="request_personal_switch_no">No</label>
           <div class="request_personal_message">
             <p>
-              Please email your request directly to NSW Police Force using:
+              Please email your request directly to <%= @info_request.public_body.name %> using:
               <%= mail_to "gipaapp@police.nsw.gov.au" %>
             </p>
             <p>


### PR DESCRIPTION
This is an experimental solution to #584, directly asking people making requests to authorities that commonly get requests for personal information if they're doing it.

The question [only shows up if the authority has had at least 2 requests hidden](https://github.com/openaustralia/righttoknow/compare/production...requests-for-personal-information#diff-0b9a57b824f19df0a7686168810a0c86R206).

![screen shot 2016-10-28 at 12 07 34 pm](https://cloud.githubusercontent.com/assets/1239550/19790952/acd07746-9d08-11e6-839a-86c5707a7ce4.png)
![screen shot 2016-10-28 at 12 07 50 pm](https://cloud.githubusercontent.com/assets/1239550/19790953/ad03a116-9d08-11e6-88f2-1d40711fa2fa.png)
![screen shot 2016-10-28 at 12 08 02 pm](https://cloud.githubusercontent.com/assets/1239550/19790954/ad0d47c0-9d08-11e6-8d84-7dd0eeb1731f.png)
