### PR TITLE
Fixed issue #649 Broken Link

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -241,17 +241,17 @@ then read our page '<a href="/help/unhappy">Unhappy about the response you got?<
 <p>
   Authorities often add legal boilerplate about Copyright, which at first
   glance implies you may not be able do anything with the information. This is
-  likely to be incorrect. For example, the latest
-  <a href="http://www.ags.gov.au/publications/express-law/el125.pdf">
-    Statement of IP Principles for Australian Government Agencies
+  likely to be incorrect. For example, Recommendation 6.3 of the
+  <a href="http://www.finance.gov.au/sites/default/files/Government20TaskforceReport.pdf?v=1">
+    Government 2.0 Taskforce Report
   </a>
   explicitly encourages reuse.
 </p>
 
 <blockquote>
   <p>
-    Consistent with the need for free and open re-use and adaptation, public
-    sector information should be licensed by agencies under the Creative
+    Consistent with the need for free and open reuse and adaptation, public
+    sector information released should be licensed under the Creative
     Commons BY standard as the default.
   </p>
 </blockquote>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -242,7 +242,7 @@ then read our page '<a href="/help/unhappy">Unhappy about the response you got?<
   Authorities often add legal boilerplate about Copyright, which at first
   glance implies you may not be able do anything with the information. This is
   likely to be incorrect. For example, the latest
-  <a href="http://www.ag.gov.au/RightsAndProtections/IntellectualProperty/Documents/StatementofIPprinciplesforAusGovagencies.pdf">
+  <a href="http://www.ags.gov.au/publications/express-law/el125.pdf">
     Statement of IP Principles for Australian Government Agencies
   </a>
   explicitly encourages reuse.


### PR DESCRIPTION
This pull request tries to fix the issue https://github.com/openaustralia/righttoknow/issues/649
The link Statement of IP Principles for Australian Government Agencies on the page https://www.righttoknow.org.au/help/requesting#reuse is broken. It initially pointed to a page which does not exist i.e., https://www.ag.gov.au/RightsAndProtections/IntellectualProperty/Documents/StatementofIPprinciplesforAusGovagencies.pdf
Now it links to the page http://www.ags.gov.au/publications/express-law/el125.pdf

