### PR TITLE
Resolved #669

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -445,7 +445,8 @@ color: $righttoknow-heading-color;
 }
 
 .make-request-quick-button {
-  margin-top: 1em;
+    max-width: 11em;
+    margin-top: 1em;
 }
 
 .request_listing {


### PR DESCRIPTION
Hi

Upon upgrading the version of alaveteli, this button was somehow broken and 'Make a Request' was coming on two lines. It was because of the addition of a class in alaveteli which is `body_listing__request-button`, which made me realize that this was a design altercation in alaveteli and not in RightToKnow. 
But I searched a little more and came to find out that [WhatDoTheyKnow](https://www.whatdotheyknow.com/) is another FOI website used in UK and it uses the current alaveteli version but still, 'Make a Request' comes in a single line. 
Hence it was clear that some changes had to be made in RightToKnow to fix the issue. 

*Changes Made:*
The `max-width` of the button was hence changed from its inherited 10em to 11em. 
Screenshot attached. 
![screenshot](https://cloud.githubusercontent.com/assets/19797779/24582244/d706c9d8-1748-11e7-8b03-33f32efb297f.png)


