### PR TITLE
Fix #650 appearence of 'not_foi' message.

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1358,8 +1358,14 @@ $status-pending: #d87c10;
 .icon_waiting_response_very_overdue,
 .icon_error_message,
 .icon_failed,
+.icon_not_foi,
 .icon_rejected {
   color: $status-failure;
+}
+
+.icon_not_foi {
+  background-image:image-url('navimg/status-icons-fail.png');
+  background-size: 22px 22px;
 }
 
 // For People experiment

--- a/locale-theme/en/app.po
+++ b/locale-theme/en/app.po
@@ -26,3 +26,11 @@ msgstr "Ask for <strong>specific documents</strong>, this site is not suitable f
 
 msgid "e.g. Ministry of Defence"
 msgstr "e.g. Department of Health"
+
+msgid "This request has been <strong>hidden</strong> from the site, because an administrator considers it not to be an FOI request"
+msgstr "This request has been <strong>hidden</strong> from the site by an administrator."
+
+msgid "Considered by administrators as not an FOI request and hidden from site."
+msgstr "Hidden from the site by an administrator."
+
+ 


### PR DESCRIPTION
This pull request amends the appearance and content of "not_foi" message (issue #650), in particular, it adds an icon with red cross, sets red text color and replaces original message with "This request has been hidden from the site by an administrator.
![screenshot from 2017-04-18 14-53-02](https://cloud.githubusercontent.com/assets/20787120/25130355/81a098fc-244a-11e7-8064-a9678e20c9d2.png)
![screenshot from 2017-04-18 14-52-39](https://cloud.githubusercontent.com/assets/20787120/25130307/65283ed2-244a-11e7-9c6c-7f3215b62e31.png)

