### PR TITLE
[WIP] Significant Updates to Help Pages (Fixes #712)

### DIFF
--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -36,6 +36,7 @@ end
 # Monkey patch app code
 for patch in ['controller_patches.rb',
               'model_patches.rb',
+              'helper_patches.rb',
               'patch_mailer_paths.rb']
     require File.expand_path "../#{patch}", __FILE__
 end

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -42,7 +42,7 @@ end
 
 # Note you should rename the file at "config/custom-routes.rb" to
 # something unique (e.g. yourtheme-custom-routes.rb":
-$alaveteli_route_extensions << 'custom-routes.rb'
+$alaveteli_route_extensions << 'rtk-custom-routes.rb'
 
 # Tell FastGettext about the theme's translations: look in the theme's
 # locale-theme directory for a translation in the first place, and if

--- a/lib/config/rtk-custom-routes.rb
+++ b/lib/config/rtk-custom-routes.rb
@@ -3,9 +3,5 @@
 Alaveteli::Application.routes.draw do
     # brand new controller example
     match '/mycontroller' => 'general#mycontroller', :as => :mycontroller
-
-    # Additional help page example
-    match '/help/help_out' => 'help#help_out', :as => :help_out
-
     match '/people' => 'general#people', :as => :people
 end

--- a/lib/config/rtk-custom-routes.rb
+++ b/lib/config/rtk-custom-routes.rb
@@ -4,6 +4,11 @@ Alaveteli::Application.routes.draw do
     # brand new controller example
     match '/mycontroller' => 'general#mycontroller', :as => :mycontroller
 
+
+    get '/help/house_rules'  => 'help#house_rules',
+      :via => 'get',
+      :as => 'help_house_rules'
+
     get '/help/complaints'  => 'help#complaints',
       :via => 'get',
       :as => 'help_complaints'

--- a/lib/config/rtk-custom-routes.rb
+++ b/lib/config/rtk-custom-routes.rb
@@ -3,5 +3,10 @@
 Alaveteli::Application.routes.draw do
     # brand new controller example
     match '/mycontroller' => 'general#mycontroller', :as => :mycontroller
+
+    get '/help/complaints'  => 'help#complaints',
+      :via => 'get',
+      :as => 'help_complaints'
+
     match '/people' => 'general#people', :as => :people
 end

--- a/lib/config/rtk-custom-routes.rb
+++ b/lib/config/rtk-custom-routes.rb
@@ -8,5 +8,9 @@ Alaveteli::Application.routes.draw do
       :via => 'get',
       :as => 'help_complaints'
 
+    get '/help/beginners'  => 'help#beginners',
+      :via => 'get',
+      :as => 'help_beginners'
+
     match '/people' => 'general#people', :as => :people
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -6,6 +6,7 @@
 #
 Rails.configuration.to_prepare do
   # Example adding an instance variable to the frontpage controller
+    def house_rules; end
     def complaints; end
     def beginners; end
   GeneralController.class_eval do

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -6,6 +6,7 @@
 #
 Rails.configuration.to_prepare do
   # Example adding an instance variable to the frontpage controller
+    def complaints; end
   GeneralController.class_eval do
     def mycontroller
       @say_something = "Greetings friend"

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -7,6 +7,7 @@
 Rails.configuration.to_prepare do
   # Example adding an instance variable to the frontpage controller
     def complaints; end
+    def beginners; end
   GeneralController.class_eval do
     def mycontroller
       @say_something = "Greetings friend"

--- a/lib/helper_patches.rb
+++ b/lib/helper_patches.rb
@@ -1,0 +1,8 @@
+# Load our helpers
+Rails.configuration.to_prepare do
+  ApplicationHelper.class_eval do
+    def is_contact_page?
+      controller.controller_name == 'help' && controller.action_name == 'contact'
+    end
+  end
+end

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -18,3 +18,6 @@
 </div>      <li>
         <%= link_to_unless_current "Making a complaint", help_complaints_path %>
       </li>
+        <%= link_to_unless_current "Beginner’s Guide", help_beginners_path %>
+      </li>
+    </ul>

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -15,4 +15,6 @@
 <p>If your question isn't answered here, or you just wanted to let us know
   something about the site, <a href="<%= help_contact_path %>">contact&nbsp;us</a>.
 </p>
-</div>
+</div>      <li>
+        <%= link_to_unless_current "Making a complaint", help_complaints_path %>
+      </li>

--- a/lib/views/help/beginners.html.erb
+++ b/lib/views/help/beginners.html.erb
@@ -1,0 +1,21 @@
+<% @title = "Beginner’s Guide" %>
+<%= render :partial => 'sidebar' %>
+<div id="left_column_flip" class="left_column_flip">
+  <h1>
+    <%= @title %>
+  </h1>
+  <p>
+    Detailed information on how to make a Freedom of Information request using
+    this website, can be found in this <a
+    href="https://www.oaf.org.au/2016/11/24/theres-no-better-way-to-learn-how-easy-foi-requests-are-than-to-make-one/">
+    blog post</a>.
+  </p>
+  <p>
+    We also have written a <a href="https://www.oaf.org.au/2015/01/20/how-to-find-what-youre-looking-for-on-right-to-know/">
+    blog post </a> which shows you how to find what you're looking for.
+  </p>
+  <p>
+    If you need further advice, please don't heistate to <a href="<%=  help_contact_path
+    %>">contact the <%= site_name %> team.</a>
+  </p>
+</div>

--- a/lib/views/help/complaints.html.erb
+++ b/lib/views/help/complaints.html.erb
@@ -1,0 +1,40 @@
+<% @title = "Complaints about us" %>
+<%= render :partial => 'sidebar' %>
+<div id="left_column_flip" class="left_column_flip">
+  <h1>
+    <%= @title %>
+  </h1>
+  <dl>
+    <dt id="complaints">
+      How do we deal with complaints about us?
+      <a href="#complaints">#</a>
+    </dt>
+    <dd>
+      <p>
+        If you have a complaint about the way we are running the <%= site_name %>
+        website, please <a href="<%=  help_contact_path %>">tell us</a>.
+      </p>
+      <p>
+        The <%= site_name %> volunteers will seek to apply the site’s existing
+        policies or discuss adapting the policies to respond to any novel
+        circumstances which arise.
+      </p>
+      <p>
+        We endeavour to deal with complaints promptly, however some cases raise
+        unique issues which require further consideration. We may take time to
+        discuss the case in one of our regular team meetings or seek advice.
+      </p>
+      <p>
+        If you're unhappy with a decision made by the <%= site_name %> team,
+        you may ask for the decision to be reviewed internally with a group
+        including a director of the OpenAustralia Foundation.
+        <%= site_name %> is a project of the OpenAustralia Foundation.
+      </p>
+      <p>
+        Ultimately, the directors of the OpenAustralia Foundation are
+        responsible for the running of <%= site_name %> and will make the final
+        decision in relation to any complaint.
+      </p>
+    </dd>
+  </dl>
+</div>

--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -1,0 +1,84 @@
+<% @title = "House Rules" %>
+<%= render :partial => 'sidebar' %>
+<div id="left_column_flip" class="left_column_flip">
+  <h1><%=@title %></h1>
+  <p><i>Please note that these rules came into effect on [DATE], and will apply
+  to activity after this date.</i></p>
+  <h2> How we expect people to use and behave on the site </h2>
+  <p>
+    Violation of any of the below rules is likely to lead to the suspension of
+    your account. This means you will no longer be able to make requests or
+    updates on <%= site_name %>. We don't want to see you go, so we encourage
+    you to follow these rules.
+  </p>
+  <p>
+    In some cases, breaking these rules could lead to legal action being taken
+    against you by the authorities or an aggrieved party.
+  </p>
+  <p>
+    Additionally, breaches take significant amounts of volunteer time to
+    deal with and risk our ability to run the service.
+  </p>
+  <ul>
+    <li>
+      Use <%= site_name %> only to request specific information, not for general
+      correspondence with public authorities, and certainly not for
+      correspondence about your own personal circumstances.
+    </li>
+    <li>
+      Do not include potentially defamatory/potential libellous comments (such
+      as allegations) in your requests and annotations.
+    </li>
+    <li>
+      Do not post information that is unlawful, harassing, defamatory, abusive,
+      threatening, harmful, obscene, discriminatory or profane.
+    </li>
+    <li>
+      Do not use <%= site_name %> to request your personal information from
+      authorities. You should request this information directly from the authority.
+    </li>
+    <li>
+      Keep messages sent via our service concise and tightly focused on the
+      subject of the request for information. Heed our
+      <%= link_to help_requesting_path(anchor: 'responsible') do -%>
+        advice on making responsible and effective requests.
+      <% end %>
+    </li>
+    <li>
+      Do not try to impersonate someone else.
+    </li>
+    <li>
+      Do not use any language likely to offend in your requests and annotations.
+    </li>
+    <li>
+      No spamming.
+    </li>
+    <li>
+      Requests must be made in mixed case letters, i.e. not all in capitals and
+      not all in lowercase (this is automatically enforced by the software that
+      <%= site_name %> runs on).
+    </li>
+    <li>
+      Do not make vexatious requests (requests with no serious purpose, or which
+      are intended to disrupt the operation of a public body). The Office of
+      the Australian Information Commissioner has guidance on vexatious
+      behaviour <a href="https://www.oaic.gov.au/freedom-of-information/foi-guidelines/part-12-vexatious-applicant-declarations#grounds-for-declaration">
+      here</a>.
+    </li>
+    <li>
+      Do not post other people’s sensitive personal data to the site.
+    </li>
+    <li>
+      Do not seek to evade the actions of site administrators by, for example,
+      creating new accounts to evade a ban, or a rate-limiting cap, or by
+      republishing material which you know has been removed by moderators.
+    </li>
+  </ul>
+  <p>
+    By breaking the rules above, you risk being banned from using the site,
+    and/or your requests/annotations being removed. In cases where it’s clear
+    that your intentions are not malicious, we will contact you first so that we
+    can give advice on how better to use the service.
+  </p>
+  <div id="hash_link_padding"></div>
+</div>


### PR DESCRIPTION
This is an update to our Help Pages, and an attempt to clearly define how we run the site.

It's based off the current help pages of [WhatDoTheyKnow](https://github.com/mysociety/whatdotheyknow-theme)

It also includes some minor changes to bring the theme in line with [Alaveteli Recommendations](https://github.com/openaustralia/righttoknow/commit/b1196e4f26b718678b1e8e1816b9cba905b7ec7e)