### PR TITLE
Update Contact to remove individual email address

### DIFF
--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -33,22 +33,6 @@
                 We'd love to hear how you've found using this site.
                 Either fill in this form, or send an email to
                 <a href="mailto:<%=@contact_email%>"><%=@contact_email%></a>.
-
-                <p>
-                    When you get in touch with us (either by email at <%=@contact_email%> or by
-                    using the form below) a copy is sent to the following people:
-                </p>
-                <ul>
-                    <li>Ben Fairless (ben@righttoknow.org.au)</li>
-                    <li>Katherine Szuminska (kat@righttoknow.org.au)</li>
-                    <li>Matthew Landauer (matthew@righttoknow.org.au)</li>
-                </ul>
-                <p>
-                    Having a group contact email address is a really useful thing. There's less
-                    chance that something important will be missed if one of us is away from our computer.
-                    That said, we feel it's important that you can put names to the people
-                    behind the email address. That's transparency!
-                </p>
             </li>
 
             <li>We are a <strong>charity</strong> and not part of the


### PR DESCRIPTION
We get a lot of people who send an email to Kat, Matthew and I individually instead of sending the email to the contact email address. Now that we use Front, this creates duplicates of the email which break the change.

This commit removes the emails/paragraphs in relation to names.

<img src="https://frontapp.com/assets/img/favicons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_1xf0l)