### PR TITLE
Update the link to the OAIC FOI Guidelines

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -277,7 +277,7 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
     <li>
       For <%= link_to "Federal Authorities", list_public_bodies_path(:tag => "federal") %>,
       have a look at the Freedom of Information
-      <a href="http://www.oaic.gov.au/freedom-of-information/applying-the-foi-act/foi-guidelines/">guidelines</a>
+      <a href="https://www.oaic.gov.au/freedom-of-information/foi-guidelines/">guidelines</a>
       and <a href="http://www.oaic.gov.au/freedom-of-information/foi-resources/freedom-of-information-fact-sheets/">fact sheets</a>
       on the Information Commissioner's website.
     </li>


### PR DESCRIPTION
The current URL 404s. I've replaced that with the new URL.