### PR TITLE
Update factsheet link and description

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -278,7 +278,7 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
       For <%= link_to "Federal Authorities", list_public_bodies_path(:tag => "federal") %>,
       have a look at the Freedom of Information
       <a href="http://www.oaic.gov.au/freedom-of-information/applying-the-foi-act/foi-guidelines/">guidelines</a>
-      and <a href="http://www.oaic.gov.au/freedom-of-information/foi-resources/freedom-of-information-fact-sheets/">fact sheets</a>
+      and <a href="https://www.oaic.gov.au/freedom-of-information/guidance-and-advice/fact-sheet-for-foi-practitioners-to-provide-to-agency-staff/">fact sheets that agency staff see</a>
       on the Information Commissioner's website.
     </li>
     <li>


### PR DESCRIPTION
I've updated the fact sheet link. However the fact sheets used to be for the public and now they are designed for Freedom of Information practitioners to provide agency staff with a broad overview of the Freedom of Information Act 1982 (FOI Act) and the steps required to be taken when an FOI request is received. I think this is the best information a user can read, because they know what the OAIC is sharing with the agency on how to deal with requests.

So instead of 'fact sheets', I've called this link 'fact sheets that agency staff see'.
