### PR TITLE
Update Help link toAG's  IP principles

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -242,7 +242,7 @@ then read our page '<a href="/help/unhappy">Unhappy about the response you got?<
   Authorities often add legal boilerplate about Copyright, which at first
   glance implies you may not be able do anything with the information. This is
   likely to be incorrect. For example, the latest
-  <a href="http://www.ag.gov.au/RightsAndProtections/IntellectualProperty/Documents/StatementofIPprinciplesforAusGovagencies.pdf">
+  <a href=" https://www.ag.gov.au/RightsAndProtections/IntellectualProperty/Documents/StatementofIPprinciplesforAusGovagencies.pdf">
     Statement of IP Principles for Australian Government Agencies
   </a>
   explicitly encourages reuse.


### PR DESCRIPTION
update link to Statement of Principles for Australian Government Agencies.
This is an updated document, you can check it against the Internet Archive's copy from the previous link. The new document has  improved text formatting, and a link or two added inline; so its more web friendly, even if bizarrely still a PDF. Puzzling mixed message!