### PR TITLE
Change moderation reasons

### DIFF
--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -67,9 +67,9 @@
   </ul>
   <h2>What happens if you break these rules</h2>
   <p>
-    If you break any of the rules we will likely suspend your account. This means you will no longer be able to make new requests or
-    updates on <%= site_name %>. We also may
-    remove your existing requests and annotations.
+    If you break any of the rules there are a number of actions we may take.
+    These include removing your request/annotation, or reminding you of our house rules.
+    In more serious or repeated cases, we will likely suspend your account.
   </p>
   <p>
     In some cases, breaking these rules could lead to legal action being taken

--- a/locale-theme/en/app.po
+++ b/locale-theme/en/app.po
@@ -29,6 +29,8 @@ msgstr "e.g. Department of Health"
 
 msgid "This request has been reviewed by an administrator and is considered not to be an FOI request"
 msgstr "This request has been <strong>hidden</strong> from the site by an administrator."
+
+msgid "This request has been reviewed by an administrator and is considered to be vexatious"
 msgstr "This request has been <strong>hidden</strong> from the site by an administrator."
 
 msgid "Considered by administrators as not an FOI request and hidden from site."

--- a/locale-theme/en/app.po
+++ b/locale-theme/en/app.po
@@ -27,7 +27,8 @@ msgstr "Ask for <strong>specific documents</strong>, this site is not suitable f
 msgid "e.g. Ministry of Defence"
 msgstr "e.g. Department of Health"
 
-msgid "This request has been <strong>hidden</strong> from the site, because an administrator considers it not to be an FOI request"
+msgid "This request has been reviewed by an administrator and is considered not to be an FOI request"
+msgstr "This request has been <strong>hidden</strong> from the site by an administrator."
 msgstr "This request has been <strong>hidden</strong> from the site by an administrator."
 
 msgid "Considered by administrators as not an FOI request and hidden from site."

--- a/locale-theme/en/app.po
+++ b/locale-theme/en/app.po
@@ -41,3 +41,6 @@ msgstr "This request has been made by an individual using Right to Know. This me
 
 msgid "Your right to know"
 msgstr "Get answers from government and the public sector"
+
+msgid "We consider it is not a valid FOI request as it was correspondence about your personal circumstances, and we have therefore hidden it from other users."
+msgstr "We don't allow requests for personal information on Right to Know. We have therefore hidden it from other users."


### PR DESCRIPTION
This PR resolves #758 and makes everything generic again.

It also updates the wording in the admin back-end so it's more like what I would normally manually type to someone:

<img width="967" alt="image" src="https://user-images.githubusercontent.com/6841582/110558615-c02cf900-817d-11eb-8733-12515b09c60e.png">
