### PR TITLE
Update admin email wording

### DIFF
--- a/lib/views/admin_request/hidden_user_explanation/_personal_correspondence.text.erb
+++ b/lib/views/admin_request/hidden_user_explanation/_personal_correspondence.text.erb
@@ -1,0 +1,3 @@
+<%= _('We do not allow requests for information via {{site_name}} ' \
+      'about your personal circumstances. We have therefore hidden your ' \
+      'request from other users.', site_name: site_name) %>

--- a/lib/views/admin_request/hidden_user_explanation/_vexatious.text.erb
+++ b/lib/views/admin_request/hidden_user_explanation/_vexatious.text.erb
@@ -1,0 +1,1 @@
+<%= _('We consider your request does not conform to our House Rules, and have therefore hidden it from other users.') %>


### PR DESCRIPTION
This PR:
1. Resolves #757 by fixing the wording.
2. Modifies the term "Vexatious" to "House Rules" in the Vexatious email that is sent to users from the Admin console.

We can remove the files when/if a fix is deployed upstream.