### PR TITLE
Exclude Ruby version files from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *#*#
 TAGS
 .DS_Store
+.ruby-version


### PR DESCRIPTION
Add `.ruby-version` to `.gitignore` to prevent tracking of Ruby version files in the repository. You don't need to track ruby versions in the theme.