### PR TITLE
Help page version history

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -966,3 +966,16 @@ dt {
     display: none;
   }
 }
+
+.changes {
+  background-color: darken($body-bg, 2%);
+  border-radius: 2px;
+  border: 1px solid darken($body-bg, 12%);
+  font-size: smaller;
+  margin-top: 2em;
+  padding: 0.1em 1.5em;
+
+  h2 {
+    font-size: 1.65em;
+  }
+}

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -6,6 +6,16 @@
 #
 Rails.configuration.to_prepare do
   HelpController.class_eval do
+    before_action :set_history
+
     def house_rules; end    
+
+    private
+
+    def set_history
+      @history ||= HelpPageHistory.new(
+        lookup_context.find_template("#{controller_path}/#{action_name}")
+      )
+    end
   end
 end

--- a/lib/help_page_history.rb
+++ b/lib/help_page_history.rb
@@ -1,0 +1,16 @@
+class HelpPageHistory
+  GITHUB_BASE =
+    'https://github.com/openaustralia/righttoknow/commits/production'.freeze
+
+  def initialize(template)
+    @template = template
+  end
+
+  def commits_url
+    template.inspect.gsub(/lib\/themes\/righttoknow/, GITHUB_BASE)
+  end
+
+  protected
+
+  attr_reader :template
+end

--- a/lib/views/help/_history.html.erb
+++ b/lib/views/help/_history.html.erb
@@ -5,8 +5,7 @@
     </h2>
 
     <p>
-      We keep these pages under review, and may make changes from time to
-      time to ensure that they remain up-to-date and accurate. You can find a
+      We may make changes to this this page from time to time. You can find a
       synopsis of changes we've made at our <%= link_to 'GitHub repository',
         @history.commits_url,
         alt: "Link to version history for Right To Know #{@title} (hosted on GitHub)" %>

--- a/lib/views/help/_history.html.erb
+++ b/lib/views/help/_history.html.erb
@@ -1,0 +1,17 @@
+<% if @history %>
+  <div class="changes">
+    <h2 id="changes">
+      Changes <a href="#changes">#</a>
+    </h2>
+
+    <p>
+      We keep these pages under review, and may make changes from time to
+      time to ensure that they remain up-to-date and accurate. You can find a
+      synopsis of changes we've made at our <%= link_to 'GitHub repository',
+        @history.commits_url,
+        alt: "Link to version history for Right To Know #{@title} (hosted on GitHub)" %>
+      but if you have any questions, please do
+      <%= link_to 'contact us', help_contact_path %>.
+    </p>
+  </div>
+<% end %>

--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -46,5 +46,7 @@
 
   <p><strong>Next</strong>, read about <a href="/help/requesting">making requests</a> --&gt;
 
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/alaveteli.html.erb
+++ b/lib/views/help/alaveteli.html.erb
@@ -26,5 +26,7 @@
       website</a>, or <a href="mailto:hello@alaveteli.org">drop us an
       email</a>.</p>
 
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -84,6 +84,8 @@ A spreadsheet file listing every body in <%= site_name %> is available:
 <p>Please <a href="/help/contact">contact us</a> if you need an API feature that isn't there yet. It's
 very much a work in progress, and we do add things when people ask us to.</p>
 
+<%= render partial: 'history' %>
+
 <div id="hash_link_padding"></div>
 
 </div>

--- a/lib/views/help/credits.html.erb
+++ b/lib/views/help/credits.html.erb
@@ -104,6 +104,9 @@
 
 
 </dl>
+
+<%= render partial: 'history' %>
+
 <div id="hash_link_padding"></div>
 
 

--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -76,5 +76,7 @@
     against you by the authorities or an aggrieved party.
   </p>
 
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -147,6 +147,8 @@ requests, and for good public relations, we'd advise you not to do that.
 <p><strong>If you haven't already</strong>, read <a href="/help/about">the introduction</a> --&gt;
 <br><strong>Otherwise</strong>, the <a href="/help/credits">credits</a> or the <a href="/help/api">programmers API</a> --&gt;
 
+<%= render partial: 'history' %>
+
 <div id="hash_link_padding"></div>
 
 

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -146,6 +146,8 @@ that authorities resend these with the personal information removed.</p>
 
 <p><strong>Learn more</strong> from the help for <a href="/help/officers">FOI officers</a> --&gt;
 
+<%= render partial: 'history' %>
+
 <div id="hash_link_padding"></div>
 
 

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -376,6 +376,8 @@ Post a link to a suitable forum or campaign site elsewhere.</p>
 
 <p><strong>Next</strong>, read about <a href="/help/privacy">your privacy</a> --&gt;
 
+<%= render partial: 'history' %>
+
 <div id="hash_link_padding"></div>
 
 </div>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -128,3 +128,6 @@ issue to yours for ideas. You can sometimes find them by browsing this site;
 contact any registered user from their page. There may be an Internet
 forum or group that they hang out in.</li>
 </ul>
+
+<%= render partial: 'history' %>
+</div>

--- a/spec/help_page_history_spec.rb
+++ b/spec/help_page_history_spec.rb
@@ -1,0 +1,21 @@
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','..','spec','spec_helper'))
+
+describe HelpPageHistory do
+  describe '#commits_url' do
+    subject { described_class.new(template).commits_url }
+
+    context 'with a custom help page' do
+      let(:template) do
+        double(inspect: 'lib/themes/righttoknow/lib/views/' \
+                        'help/house_rules.html.erb')
+      end
+
+      it do
+        is_expected.to eq('https://github.com/openaustralia/righttoknow/' \
+                          'commits/production/lib/views/help/house_rules.html.erb')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #868

Adds a "Changes" section at the bottom of each help page, which links back to our production Github:
<img width="784" height="360" alt="image" src="https://github.com/user-attachments/assets/90a9f770-8834-4e4f-80e3-c1ecc410f7e1" />

Credit to @mysociety team who implemented this already on WDTK: https://github.com/mysociety/whatdotheyknow-theme/pull/761