### PR TITLE
[#917] Refine contact page messaging and structure for clarity

### DIFF
--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -6,37 +6,40 @@
 
 <div id="contact_preamble">
 
-    <% if !flash[:notice] %>
-        <h2>Contact an authority to get official information</h2>
-        <ul>
-            <li><a href="<%= new_request_path %>">Go here</a> to make a request, in public, for information
-            from public authorities.</li>
+        <% if !flash[:notice] %>
+            <h2>Want to contact us?</h2>
+            <p>You can — but you might get what you need faster by following the steps below.</p>
 
-            <li>
-            Asking for <b>private information about yourself</b>?
-            Please read our
-            <a href="<%= help_requesting_path(:anchor => 'data_protection') %>">help page</a>.
-            </li>
-        </ul>
-
-        <h2>Removing information</h2>
-        <p>Our <a href="<%= help_house_rules_url %>">House Rules</a> provide information on what we do 
-            and don't allow on <%= site_name %>. </p>
-        <p> Please use the <b> report button </b> that can be found on each request.</p>
-
-    <h2>Contact the <%= site_name %> team</h2>
+            <h2>Contact an authority to get official information</h2>
             <ul>
-            <li>
-                Please read the  <a href="<%= help_about_path %>">help pages</a> first, as it may
-                answer your question quicker.
-            </li>
-            <li>
-                We are a <strong>charity</strong> and not part of the
-                Government.
-            </li>
-            
+                <li>
+                    <a href="<%= new_request_path %>">Request information from a public authority</a> — your request will be published on the site.
+                </li>
+                <li>
+                    Looking for personal information about yourself? Please read our
+                    <a href="<%= help_requesting_path(:anchor => 'data_protection') %>">help page</a>.
+                </li>
             </ul>
-    <% end %>
+
+            <h2>Report or remove information</h2>
+            <p>
+                If you want to report a problem, first read our <a href="<%= help_house_rules_url %>">House Rules</a>. These clearly explain what <%= site_name %> does and doesn’t allow.
+                To report a specific problem, use the <b>Report</b> button on the request page.
+            </p>
+
+            <h2>Contact the <%= site_name %> team</h2>
+            <ul>
+                <li>
+                    Check the <a href="<%= help_about_path %>">help pages</a> first — they often answer questions much quicker than we can.
+                </li>
+                <li>
+                    <strong>Still need help?</strong> Please get in touch using the form below.
+                </li>
+                <li>
+                    Please remember: <%= site_name %> is a charity and not part of the Government.
+                </li>
+            </ul>
+        <% end %>
 </div>
 
 <%= form_for :contact do |f| %>

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -13,30 +13,28 @@
             from public authorities.</li>
 
             <li>
-            Asking for private information about yourself?
+            Asking for <b>private information about yourself</b>?
             Please read our
             <a href="<%= help_requesting_path(:anchor => 'data_protection') %>">help page</a>.
             </li>
         </ul>
 
-    <% end %>
+        <h2>Removing information</h2>
+        <p>Our <a href="<%= help_house_rules_url %>">House Rules</a> provide information on what we do 
+            and don't allow on <%= site_name %>. </p>
+        <p> Please use the <b> report button </b> that can be found on each request.</p>
 
     <h2>Contact the <%= site_name %> team</h2>
-    <% if !flash[:notice] %>
             <ul>
             <li>
-            Please read the  <a href="<%= help_about_path %>">help page</a> first, as it may
-            answer your question quicker.
+                Please read the  <a href="<%= help_about_path %>">help pages</a> first, as it may
+                answer your question quicker.
             </li>
-
             <li>
-                We'd love to hear how you've found using this site.
-                Either fill in this form, or send an email to
-                <a href="mailto:<%=@contact_email%>"><%=@contact_email%></a>.
+                We are a <strong>charity</strong> and not part of the
+                Government.
             </li>
-
-            <li>We are a <strong>charity</strong> and not part of the
-            Government.</li>
+            
             </ul>
     <% end %>
 </div>

--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -76,6 +76,12 @@
     against you by the authorities or an aggrieved party.
   </p>
 
+  <h2> What to do if you believe someone has broken these rules </h2>
+    <p>
+    Each request, annotation and email has a "Report" button. You should use this if you feel that someone has broken these rules.
+    </p>
+
+
   <%= render partial: 'history' %>
 
   <div id="hash_link_padding"></div>


### PR DESCRIPTION
Partially resovles #917 by:
- Removing our email address from the "Contact Us" form.
- Including a link to our House Rules and encouraging people to use the "Report" buttons found around the site.

Previous:
<img width="953" height="348" alt="image" src="https://github.com/user-attachments/assets/d9af005b-e18c-4141-ad5f-5766d932e834" />


New Look: 
<img width="782" height="484" alt="image" src="https://github.com/user-attachments/assets/10799cdf-83e2-441a-b320-a2c2e432f079" />