### PR TITLE
Add issue and pull request templates for consistent contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug Report
+description: File a bug report to help us improve Right To Know
+title: "[BUG] <title>"
+labels: [bug]
+type: [Bug]
+body:
+  - type: checkboxes
+    id: search-confirmation
+    attributes:
+      label: Have you searched for existing issues?
+      options:
+        - label: I have searched the existing issues and this is not a duplicate
+          required: true
+  - type: dropdown
+    id: bug-area
+    attributes:
+      label: What area of the site is affected?
+      options:
+        - Making a request
+        - Browsing requests
+        - User account/profile
+        - Authority pages
+        - Search functionality
+        - Email notifications
+        - Mobile/responsive design
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Tell us how to reproduce this bug
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened?
+      description: What did you see instead?
+    validations:
+      required: true
+  - type: checkboxes
+    id: user-type
+    attributes:
+      label: Are you logged in?
+      options:
+        - label: I was logged in when this happened
+        - label: I was not logged in when this happened
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or error messages
+      description: If applicable, add screenshots or copy any error messages you saw.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Browser and device
+      description: Help us understand your setup
+      placeholder: |
+        - Device: [e.g. iPhone, Desktop]
+        - OS: [e.g. iOS 15, Windows 11, macOS]
+        - Browser: [e.g. Chrome 98, Safari, Firefox]
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contact us for support
+    url: https://www.righttoknow.org.au/help/contact
+    about: Please click the "Report" button on the relevant material that you are concerned about. If you can't, please click here to contact us.
+  - name: Add an Authority
+    url: https://www.righttoknow.org.au/change_request/new
+    about: Authority changes are requested directly on the site

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature Request
+description: Suggest an idea for Right To Know
+labels: [enhancement]
+type: [Feature]
+body:
+  - type: dropdown
+    id: feature-area
+    attributes:
+      label: What area would this feature improve?
+      options:
+        - Making FOI requests
+        - Browsing and searching requests
+        - User account and notifications
+        - Authority information
+        - Mobile experience
+        - Accessibility
+        - Site administration
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the issue or limitation you're experiencing.
+      placeholder: Ex. When I try to [action], I find it difficult because [...]
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe your proposed solution
+      description: What would you like to see implemented?
+    validations:
+      required: true
+  - type: dropdown
+    id: user-type
+    attributes:
+      label: Who would benefit from this feature?
+      options:
+        - FOI requesters
+        - Journalists
+        - Researchers
+        - General public
+        - Site administrators
+        - All users
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternative solutions considered
+      description: Have you considered other ways to solve this problem?
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context, examples, or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -1,0 +1,29 @@
+name: General Issue (Contributor Use Only)
+description: For contributors to report issues that don't fit other templates
+labels: [triage]
+body:
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue Type
+      options:
+        - Bug
+        - Feature Request
+        - Documentation
+        - Question
+        - Discussion
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the issue, question, or topic you'd like to discuss.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any relevant context, links, or screenshots.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Relevant issue(s)
+
+## What does this do?
+
+## Why was this needed?
+
+## Implementation notes
+
+## Screenshots
+
+## Notes to reviewer


### PR DESCRIPTION
Resolves https://github.com/openaustralia/oaf-internal/issues/164

Introduce templates for bug reports, feature requests, and general issues to streamline contributions and improve clarity in submissions. A pull request template is also added to guide contributors in providing relevant information.