### PR TITLE
[#919] Add reporting instructions to house rules page

### DIFF
--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -78,7 +78,7 @@
 
   <h2> What to do if you believe someone has broken these rules </h2>
     <p>
-    Each request, annotation and email has a "Report" button. You should use this if you feel that someone has broken these rules.
+    Each request, annotation and email has a "Report" button. Use this if you feel that someone has broken these rules.
     </p>
 
 

--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -76,6 +76,12 @@
     against you by the authorities or an aggrieved party.
   </p>
 
+  <h2> What to do if you believe someone has broken these rules </h2>
+    <p>
+    Each request, annotation and email has a "Report" button. You should use this if you feel that someone has broken these rules.
+    </p>
+
+
   <%= render partial: 'history' %>
 
   <div id="hash_link_padding"></div>


### PR DESCRIPTION
Resolves #919

Include guidance on how to report rule violations directly on the house rules page.

Adds the below to the page:
<img width="827" height="153" alt="image" src="https://github.com/user-attachments/assets/2f5335e0-58ae-4b41-88f1-e8e55fbbd31a" />
