### PR TITLE
Clarify handling of personal information requests in house rules

### DIFF
--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -8,6 +8,10 @@
     help you hold governments to account.
   </p>
   <p>
+    You can find information on how we handle requests to remove personal information on 
+    our <a href="<%= help_privacy_path(:anchor => 'delete_requests') %>">privacy page.</a>
+  </p>
+  <p>
     Also, if you break the rules it takes significant amounts of volunteer time to
     deal with and risks our ability to run the service.
   </p>

--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -5,15 +5,12 @@
   <h2> How we expect people to use and behave on the site </h2>
   <p>
     We have house rules to maintain a safe, legal, considerate, and productive environment to
-    help you hold governments to account.
+    help you hold governments to account. If you break the rules it takes significant amounts of time to
+    deal with and risks our ability to run the service.
   </p>
   <p>
     You can find information on how we handle requests to remove personal information on 
     our <a href="<%= help_privacy_path(:anchor => 'delete_requests') %>">privacy page.</a>
-  </p>
-  <p>
-    Also, if you break the rules it takes significant amounts of volunteer time to
-    deal with and risks our ability to run the service.
   </p>
   <p>
     Please keep to the rules.


### PR DESCRIPTION
Resolves #918

Add information regarding the handling of personal information requests to the house rules, directing users to the privacy page for further details.