### PR TITLE
Update Footer to include House Rules

### DIFF
--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -17,7 +17,8 @@
                     <li role="presentation"><%= link_to 'View authorities', list_public_bodies_default_path %></li>
                     <% if feature_enabled?(:alaveteli_pro) %>
                       <li role="presentation"><%= link_to 'Journalist?', account_request_index_path %></li>
-                   <% if feature_enabled?(:pro_pricing) %>
+	                   <% end %>
+										<% if feature_enabled?(:pro_pricing) %>
                       <li>
                         <%= link_to 'Pro Terms', pro_page_path(:id => 'legal') %>
                       </li>
@@ -29,7 +30,6 @@
                     <li role="presentation"><%= link_to 'Contact us', help_contact_path %></li>
                     <li role="presentation"><%= link_to 'Privacy', help_privacy_path %></li>
                     <li role="presentation"><%= link_to 'API', help_api_path %></li>
-                    <% end %>
                 </ul>
             </nav>
         </div>

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -18,10 +18,8 @@
                     <% if feature_enabled?(:alaveteli_pro) %>
                       <li role="presentation"><%= link_to 'Journalist?', account_request_index_path %></li>
 	                   <% end %>
-										<% if feature_enabled?(:pro_pricing) %>
-                      <li>
-                        <%= link_to 'Pro Terms', pro_page_path(:id => 'legal') %>
-                      </li>
+					<% if feature_enabled?(:pro_pricing) %>
+                      <li role="presentation"><%= link_to 'Pro Terms', pro_page_path(:id => 'legal') %></li>
                     <% end %>
                 </ul>
                 <ul>

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -17,17 +17,18 @@
                     <li role="presentation"><%= link_to 'View authorities', list_public_bodies_default_path %></li>
                     <% if feature_enabled?(:alaveteli_pro) %>
                       <li role="presentation"><%= link_to 'Journalist?', account_request_index_path %></li>
+                   <% if feature_enabled?(:pro_pricing) %>
+                      <li>
+                        <%= link_to 'Pro Terms', pro_page_path(:id => 'legal') %>
+                      </li>
                     <% end %>
                 </ul>
                 <ul>
                     <li role="presentation"><%= link_to 'Help', help_path %></li>
+                    <li role="presentation"><%= link_to 'House Rules', help_house_rules_path%></li>
                     <li role="presentation"><%= link_to 'Contact us', help_contact_path %></li>
                     <li role="presentation"><%= link_to 'Privacy', help_privacy_path %></li>
                     <li role="presentation"><%= link_to 'API', help_api_path %></li>
-                    <% if feature_enabled?(:pro_pricing) %>
-                      <li>
-                        <%= link_to 'Pro Terms', pro_page_path(:id => 'legal') %>
-                      </li>
                     <% end %>
                 </ul>
             </nav>


### PR DESCRIPTION
Fixes #916 by:
- Add 'House Rules' link to footer navigation
- Move 'Pro Terms' link to make the display look right