### PR TITLE
Don't set history if a template doesn't exist

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -13,9 +13,13 @@ Rails.configuration.to_prepare do
     private
 
     def set_history
-      @history ||= HelpPageHistory.new(
-        lookup_context.find_template("#{controller_path}/#{action_name}")
-      )
+      # Only set history if a template exists for this action
+      begin
+        template = lookup_context.find_template("#{controller_path}/#{action_name}")
+        @history ||= HelpPageHistory.new(template)
+      rescue ActionView::MissingTemplate
+        # No template for this action, skip setting history
+      end
     end
   end
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -14,12 +14,10 @@ Rails.configuration.to_prepare do
 
     def set_history
       # Only set history if a template exists for this action
-      begin
-        template = lookup_context.find_template("#{controller_path}/#{action_name}")
-        @history ||= HelpPageHistory.new(template)
-      rescue ActionView::MissingTemplate
-        # No template for this action, skip setting history
-      end
+      template = lookup_context.find_template("#{controller_path}/#{action_name}")
+      @history ||= HelpPageHistory.new(template)
+    rescue ActionView::MissingTemplate
+      # No template for this action, skip setting history
     end
   end
 end


### PR DESCRIPTION
Fixes #934

To test, browse to /help and confirm you are redirected to /help/about without an error.