### PR TITLE
Fix GitHub Changes links formatting in house rules page

### DIFF
--- a/lib/help_page_history.rb
+++ b/lib/help_page_history.rb
@@ -7,7 +7,11 @@ class HelpPageHistory
   end
 
   def commits_url
-    template.inspect.gsub(/lib\/themes\/righttoknow/, GITHUB_BASE)
+    # Use the template identifier (full path) and replace the local path prefix with the GitHub base URL
+  path = template.identifier
+  filename = File.basename(path)
+  # Build the GitHub commits URL for this file
+  "#{GITHUB_BASE}/lib/views/help/#{filename}"
   end
 
   protected

--- a/lib/help_page_history.rb
+++ b/lib/help_page_history.rb
@@ -8,8 +8,8 @@ class HelpPageHistory
 
   def commits_url
     # Use the template identifier (full path) and replace the local path prefix with the GitHub base URL
-  path = template.identifier
-  filename = File.basename(path)
+    path = template.identifier
+    filename = File.basename(path)
   # Build the GitHub commits URL for this file
   "#{GITHUB_BASE}/lib/views/help/#{filename}"
   end


### PR DESCRIPTION
Corrects the formatting of GitHub Changes links to direct users to the appropriate commits URL instead of an incorrectly formatted link. This change ensures that the links point to the correct GitHub repository path for the house rules page.

Fixes openaustralia/righttoknow#942