### PR TITLE
Add CODEOWNERS file to define repository code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file is used to define code owners for this repository.
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+* @openaustralia/team-right-to-know


### PR DESCRIPTION
Introduce a CODEOWNERS file to specify the code owners for the repository, streamlining the review process and clarifying responsibilities.