### PR TITLE
Update Production to same as Staging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file is used to define code owners for this repository.
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+* @openaustralia/team-right-to-know

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,7 +2,6 @@ name: Bug Report
 description: File a bug report to help us improve Right To Know
 title: "[BUG] <title>"
 labels: [bug]
-type: [Bug]
 body:
   - type: checkboxes
     id: search-confirmation

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,7 @@ name: Bug Report
 description: File a bug report to help us improve Right To Know
 title: "[BUG] <title>"
 labels: [bug]
+type: Bug
 body:
   - type: checkboxes
     id: search-confirmation

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: Feature Request
 description: Suggest an idea for Right To Know
 labels: [enhancement]
-type: [Feature]
 body:
   - type: dropdown
     id: feature-area

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: Suggest an idea for Right To Know
 labels: [enhancement]
+type: Feature
 body:
   - type: dropdown
     id: feature-area

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -17,7 +17,8 @@
                     <li role="presentation"><%= link_to 'View authorities', list_public_bodies_default_path %></li>
                     <% if feature_enabled?(:alaveteli_pro) %>
                       <li role="presentation"><%= link_to 'Journalist?', account_request_index_path %></li>
-                   <% if feature_enabled?(:pro_pricing) %>
+	                   <% end %>
+										<% if feature_enabled?(:pro_pricing) %>
                       <li>
                         <%= link_to 'Pro Terms', pro_page_path(:id => 'legal') %>
                       </li>
@@ -29,7 +30,6 @@
                     <li role="presentation"><%= link_to 'Contact us', help_contact_path %></li>
                     <li role="presentation"><%= link_to 'Privacy', help_privacy_path %></li>
                     <li role="presentation"><%= link_to 'API', help_api_path %></li>
-                    <% end %>
                 </ul>
             </nav>
         </div>

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -18,10 +18,8 @@
                     <% if feature_enabled?(:alaveteli_pro) %>
                       <li role="presentation"><%= link_to 'Journalist?', account_request_index_path %></li>
 	                   <% end %>
-										<% if feature_enabled?(:pro_pricing) %>
-                      <li>
-                        <%= link_to 'Pro Terms', pro_page_path(:id => 'legal') %>
-                      </li>
+					<% if feature_enabled?(:pro_pricing) %>
+                      <li role="presentation"><%= link_to 'Pro Terms', pro_page_path(:id => 'legal') %></li>
                     <% end %>
                 </ul>
                 <ul>

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -17,17 +17,18 @@
                     <li role="presentation"><%= link_to 'View authorities', list_public_bodies_default_path %></li>
                     <% if feature_enabled?(:alaveteli_pro) %>
                       <li role="presentation"><%= link_to 'Journalist?', account_request_index_path %></li>
+                   <% if feature_enabled?(:pro_pricing) %>
+                      <li>
+                        <%= link_to 'Pro Terms', pro_page_path(:id => 'legal') %>
+                      </li>
                     <% end %>
                 </ul>
                 <ul>
                     <li role="presentation"><%= link_to 'Help', help_path %></li>
+                    <li role="presentation"><%= link_to 'House Rules', help_house_rules_path%></li>
                     <li role="presentation"><%= link_to 'Contact us', help_contact_path %></li>
                     <li role="presentation"><%= link_to 'Privacy', help_privacy_path %></li>
                     <li role="presentation"><%= link_to 'API', help_api_path %></li>
-                    <% if feature_enabled?(:pro_pricing) %>
-                      <li>
-                        <%= link_to 'Pro Terms', pro_page_path(:id => 'legal') %>
-                      </li>
                     <% end %>
                 </ul>
             </nav>


### PR DESCRIPTION
## Relevant issue(s)
Issue #916

## What does this do?
- **Move 'Pro Terms' link and add 'House Rules' link to footer navigation**
- **Fix GitHub issue template syntax errors by removing invalid type fields**

## Why was this needed?
Adds the House Rules link to the footer navigation, as described in #916

## Implementation notes
Deployment via ```cap -S stage=production themes:install``` required. 

## Screenshots
Refer to #916

## Notes to reviewer
Changes have already been tested in Staging
