### PR TITLE
Add confidence_intervals.rb from core, and update it to use Statistics3

### DIFF
--- a/lib/confidence_intervals.rb
+++ b/lib/confidence_intervals.rb
@@ -1,0 +1,31 @@
+# Calculate the confidence interval for a samples from a binonial
+# distribution using Wilson's score interval.  For more theoretical
+# details, please see:
+#
+#  http://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson%20score%20interval
+#
+# This is a variant of the function suggested here:
+#
+#  http://www.evanmiller.org/how-not-to-sort-by-average-rating.html
+#
+# total: the total number of observations
+# successes: the subset of those observations that were "successes"
+# power: for a 95% confidence interval, this should be 0.05
+#
+# The naive proportion is (successes / total).  This returns an array
+# with the proportions that represent the lower and higher confidence
+# intervals around that.
+
+require 'statistics3'
+
+def ci_bounds(successes, total, power)
+  if total == 0
+    raise RuntimeError, "Can't calculate the CI for 0 observations"
+  end
+  z = Statistics3.pnormaldist(1 - power/2)
+  phat = successes.to_f/total
+  offset = z*Math.sqrt((phat*(1 - phat) + z*z/(4*total))/total)
+  denominator = 1 + z*z/total
+  return [(phat + z*z/(2*total) - offset)/denominator,
+          (phat + z*z/(2*total) + offset)/denominator]
+end


### PR DESCRIPTION
## Relevant issue(s)
Fixes openaustralia/righttoknow#960

## What does this do?
Adds the confidence_intervals.rb file from Alaveteli core with a change at L25 to use Statistics3.

## Why was this needed?
We don't use Statistics2 any more, which was causing issues.

## Implementation notes
I'm not able to replicate the bug in either staging or test as the number of requests is quite high.

## Screenshots

## Notes to reviewer
This change should not affect any other parts of the software and can be reversed quickly if needed.