### PR TITLE
Add confidence_intervals.rb from core, and update it to use Statistics3

### DIFF
--- a/lib/confidence_intervals.rb
+++ b/lib/confidence_intervals.rb
@@ -1,0 +1,31 @@
+# Calculate the confidence interval for a samples from a binonial
+# distribution using Wilson's score interval.  For more theoretical
+# details, please see:
+#
+#  http://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson%20score%20interval
+#
+# This is a variant of the function suggested here:
+#
+#  http://www.evanmiller.org/how-not-to-sort-by-average-rating.html
+#
+# total: the total number of observations
+# successes: the subset of those observations that were "successes"
+# power: for a 95% confidence interval, this should be 0.05
+#
+# The naive proportion is (successes / total).  This returns an array
+# with the proportions that represent the lower and higher confidence
+# intervals around that.
+
+require 'statistics3'
+
+def ci_bounds(successes, total, power)
+  if total == 0
+    raise RuntimeError, "Can't calculate the CI for 0 observations"
+  end
+  z = Statistics3.pnormaldist(1 - power/2)
+  phat = successes.to_f/total
+  offset = z*Math.sqrt((phat*(1 - phat) + z*z/(4*total))/total)
+  denominator = 1 + z*z/total
+  return [(phat + z*z/(2*total) - offset)/denominator,
+          (phat + z*z/(2*total) + offset)/denominator]
+end


### PR DESCRIPTION
## Relevant issue(s)
Fixes openaustralia/righttoknow#965

## What does this do?
- Creates the confidence_intervals.rb file
- Updates L25 to use Statistics3 instead of Statistics2

## Why was this needed?
To resolve the bug in openaustralia/righttoknow#965

## Implementation notes
- Deployment should occur on the host by running the below command as deploy: `bundle exec rails themes:install`

## Screenshots
Nil

## Notes to reviewer
This change won't make any impact in staging or test due to the number of records required to make it happen.