### PR TITLE
.gitignore update to exclude .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *#*#
 TAGS
 .DS_Store
+.ruby-version


### PR DESCRIPTION
## Relevant issue(s)
N/A

## What does this do?
Adds `.ruby-version` to the `.gitignore` file.

## Why was this needed?
Prevents the Ruby version file from being tracked by Git.

## Implementation notes
N/A 

## Screenshots
N/A 

## Notes to reviewer
Minor change