### PR TITLE
[PROD] Update house rules for clarity and detail

### DIFF
--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -2,85 +2,35 @@
 <%= render :partial => 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
   <h1><%=@title %></h1>
-  <h2> How we expect people to use and behave on the site </h2>
+  <h2>How to use this site</h2>
   <p>
-    We have house rules to maintain a safe, legal, considerate, and productive environment to
-    help you hold governments to account. If you break the rules it takes significant amounts of time to
-    deal with and risks our ability to run the service.
+    These rules help keep <%= site_name %> safe, legal and useful for everyone.
+    If rules are broken, our team has to spend time fixing problems instead of
+    improving the service.
   </p>
   <p>
-    You can find information on how we handle requests to remove personal information on 
+    You can find information about how we handle requests to remove personal information on
     our <a href="<%= help_privacy_path(:anchor => 'delete_requests') %>">privacy page.</a>
   </p>
   <p>
-    Please keep to the rules.
+    Please follow these rules.
   </p>
-  <ul>
-    <li>
-      Use <%= site_name %> only to request specific information, not for general
-      correspondence with public authorities, and certainly not for
-      correspondence about your own personal circumstances.
-    </li>
-    <li>
-      Do not include potentially defamatory/potential libellous comments (such
-      as allegations) in your requests and annotations.
-    </li>
-    <li>
-      Do not post information that is unlawful, harassing, defamatory, abusive,
-      threatening, harmful, obscene, discriminatory or profane.
-    </li>
-    <li>
-      Do not use <%= site_name %> to request your personal information from
-      authorities. You should request this information directly from the authority.
-    </li>
-    <li>
-      Keep messages sent via our service concise and tightly focused on the
-      subject of the request for information. Heed our
-      <%= link_to help_requesting_path(anchor: 'responsible') do -%>
-        advice on making responsible and effective requests.
-      <% end %>
-    </li>
-    <li>
-      Do not try to impersonate someone else.
-    </li>
-    <li>
-      Do not use any language likely to offend in your requests and annotations.
-    </li>
-    <li>
-      No spamming.
-    </li>
-    <li>
-      Do not make vexatious requests (requests with no serious purpose, or which
-      are intended to disrupt the operation of a public body). The Office of
-      the Australian Information Commissioner has
-      <a href="https://www.oaic.gov.au/freedom-of-information/foi-guidelines/part-12-vexatious-applicant-declarations#grounds-for-declaration">
-      published guidance on vexatious behaviour</a>.
-    </li>
-    <li>
-      Do not use our service to request other people’s personal information and
-      do not include such information in requests, annotations or follow-ups.
-    </li>
-    <li>
-      Do not try to evade the actions of site administrators by, for example,
-      creating new accounts to evade a ban, or a rate-limiting cap, or by
-      republishing material which you know has been removed by moderators.
-    </li>
-  </ul>
+  <%= render partial: 'help/house_rules/list_of_house_rules' %>
   <h2>What happens if you break these rules</h2>
   <p>
-    If you break any of the rules there are a number of actions we may take.
-    These include removing your request/annotation, or reminding you of our house rules.
-    In more serious or repeated cases, we will likely suspend your account.
+    If you break these rules, we may remove your content, remind you of the
+    rules, or suspend your account.
   </p>
   <p>
-    In some cases, breaking these rules could lead to legal action being taken
-    against you by the authorities or an aggrieved party.
+    In serious cases, legal action may be taken against you by an authority or
+    an affected person or organisation.
   </p>
 
-  <h2> What to do if you believe someone has broken these rules </h2>
-    <p>
-    Each request, annotation and email has a "Report" button. Use this if you feel that someone has broken these rules.
-    </p>
+  <h2>What to do if you think someone has broken these rules</h2>
+  <p>
+    Each request, annotation and email has a "Report" button. Use it if you
+    think someone has broken these rules.
+  </p>
 
 
   <%= render partial: 'history' %>

--- a/lib/views/help/house_rules/_list_of_house_rules.html.erb
+++ b/lib/views/help/house_rules/_list_of_house_rules.html.erb
@@ -1,0 +1,72 @@
+<ol>
+  <li>
+    Use <%= site_name %> only to ask for specific information from public
+    authorities. Do not use it for general messages or personal matters.
+  </li>
+  <li>
+    Do not make accusations in your requests or annotations.
+  </li>
+  <li>
+    Do not post anything illegal, threatening, abusive, discriminatory,
+    obscene, or otherwise harmful.
+  </li>
+  <li>
+    Do not use <%= site_name %> to ask for your own personal information.
+    Request this directly from the authority.
+  </li>
+  <li>
+    Keep your messages short and focused on the information you are asking for.
+    See our
+    <%= link_to help_requesting_path(anchor: 'responsible') do -%>
+      advice on making responsible and effective requests.
+    <% end %>
+  </li>
+  <li>
+    Do not pretend to be someone else.
+  </li>
+  <li>
+    Do not use language that is likely to offend in your requests and
+    annotations.
+  </li>
+  <li>
+    Do not send spam, bulk requests, or promotional messages.
+  </li>
+  <li>
+    Do not make vexatious requests. This means requests with no real purpose,
+    or requests intended to disrupt a public body. The Office of the
+    Australian Information Commissioner has
+    <a href="https://www.oaic.gov.au/freedom-of-information/foi-guidelines/part-12-vexatious-applicant-declarations#grounds-for-declaration">
+    published guidance on vexatious behaviour</a>.
+  </li>
+  <li>
+    Do not ask for other people's personal information. Do not include personal
+    information in requests, annotations or follow-ups unless it is lawful and
+    genuinely necessary.
+  </li>
+  <li>
+    Do not try to get around actions by site administrators. For example, do
+    not create new accounts to avoid a ban or rate limit, and do not repost
+    material removed by moderators.
+  </li>
+  <li>
+    Most people need only one account. Do not create multiple accounts to get
+    around site rules or moderation, or to make vexatious requests.
+  </li>
+  <li>
+    Do not use disposable or one-time email addresses.
+  </li>
+  <li>
+    Do not use scripts, bots, or unapproved automation. Approved automation is
+    available through <%= pro_site_name %> or the API, but you must not use
+    automation to bypass limits.
+  </li>
+  <li>
+    Commercial and for-profit use of <%= site_name %> requires a
+    <%= link_to pro_site_name, account_request_index_path %> subscription.
+  </li>
+  <li>
+    Do not ask for email addresses in your requests. Email addresses are
+    automatically redacted, so you will not be able to access them if they are
+    included in a response.
+  </li>
+</ol>


### PR DESCRIPTION
## Relevant issue(s)
Deployed and tested in staging here:
- https://github.com/openaustralia/righttoknow/pull/990
 
## What does this do?
Updates the House Rules in PROD. Includes:
- Refactors Right to Know House Rules content into a reusable partial.
- Changes House Rules from a bulleted list to a numbered list.
- Rewrites the House Rules page and rule text into plain language for better readability.
- Expands and clarifies policy coverage (including anti-abuse and account-use expectations).
- States commercial use as explicit policy: commercial and for-profit use requires a Pro subscription.

## Why was this needed?
- The previous wording was harder for regular users to scan and understand.
- Rules were embedded directly in the page template, making maintenance harder.
- Numbered rules improve readability and make moderation/admin references easier.
- Clearer policy language reduces ambiguity, especially around:
-- misuse/abuse behavior
-- automation limits
-- account use
-- commercial usage requirements


## Implementation notes
- Implementation via standard theme update process

## Screenshots
Refer to: https://github.com/openaustralia/righttoknow/pull/990

## Notes to reviewer
This is a Help Page change only.
