### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   rubocop:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/openaustralia/righttoknow/security/code-scanning/1](https://github.com/openaustralia/righttoknow/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` section specifying the minimal required scopes for the `GITHUB_TOKEN`. For a read‑only, analysis‑only workflow like this rubocop check, `contents: read` is sufficient: it lets the workflow fetch code but prevents it from modifying repository contents or other resources.

The best fix here is to add a `permissions` block at the job level for the `rubocop` job, directly under `runs-on: ubuntu-latest`. This limits permissions only for this job; there is currently only one job, so behavior is unchanged except for the more restrictive token. Concretely, in `.github/workflows/rubocop.yml`, between lines 16 and 18, insert:

```yaml
    permissions:
      contents: read
```

No imports or additional methods are needed because this is YAML configuration for GitHub Actions, not application code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
