### PR TITLE
Add Capistrano deployment configuration

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,4 @@
+load 'deploy'
+# Uncomment if you are using Rails' asset pipeline
+load 'deploy/assets'
+load 'config/deploy' # remove this line to skip loading any of the default tasks

--- a/Capfile
+++ b/Capfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 load 'deploy'
 # Uncomment if you are using Rails' asset pipeline
 load 'deploy/assets'

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,9 @@ group :development do
   gem 'rubocop', require: false
   gem 'ruby-lsp', require: false
 end
+
+group :deployment do
+  gem 'capistrano', '~> 2.15.11'
+  gem 'net-ssh', '~> 7.2.0'
+  gem 'net-ssh-gateway', '>= 1.1.0', '< 3.0.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    capistrano (2.15.11)
+      highline
+      net-scp (>= 1.0.0)
+      net-sftp (>= 2.0.0)
+      net-ssh (>= 2.0.14)
+      net-ssh-gateway (>= 1.1.0)
     coderay (1.1.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
@@ -37,6 +43,8 @@ GEM
       guard (~> 2.8)
       guard-compat (~> 1.0)
       multi_json (~> 1.8)
+    highline (3.1.2)
+      reline
     http_parser.rb (0.8.0)
     io-console (0.8.1)
     json (2.19.2)
@@ -50,6 +58,13 @@ GEM
     method_source (1.1.0)
     multi_json (1.18.0)
     nenv (0.3.0)
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-ssh (7.2.3)
+    net-ssh-gateway (2.0.0)
+      net-ssh (>= 4.0.0)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -101,7 +116,7 @@ GEM
     tsort (0.2.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
-    unicode-emoji (4.1.0)
+    unicode-emoji (4.2.0)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -117,9 +132,12 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  capistrano (~> 2.15.11)
   guard
   guard-livereload
   json
+  net-ssh (~> 7.2.0)
+  net-ssh-gateway (>= 1.1.0, < 3.0.0)
   rack-livereload
   rb-fsevent
   rb-inotify

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/capistrano'
 
 set :stage, 'staging' unless exists? :stage
@@ -25,7 +27,7 @@ set(:rbenv_ruby_version) do
 end
 
 if rbenv_ruby_version
-  set(:rbenv_path) { capture("echo $HOME/.rbenv").strip }
+  set(:rbenv_path) { capture('echo $HOME/.rbenv').strip }
   set(:rbenv_shims_path) { File.join(rbenv_path, 'shims') }
   set :default_environment, {
     'PATH' => [rbenv_shims_path, '$PATH'].join(':')
@@ -52,7 +54,6 @@ set(:shared_children) do
 end
 
 namespace :deploy do
-
   desc 'Check that shared files and directories exist before deploying'
   task :check_shared do
     general_config = YAML.safe_load(capture("cat #{shared_path}/general.yml"))
@@ -62,10 +63,10 @@ namespace :deploy do
   end
   before 'deploy:symlink_configuration', 'deploy:check_shared'
 
-  [:start, :stop, :restart].each do |t|
+  %i[start stop restart].each do |t|
     desc "#{t.to_s.capitalize} Alaveteli service defined in /etc/init.d/"
     task t, roles: :app, except: { no_release: true } do
-      run "/etc/init.d/#{ daemon_name } #{ t }"
+      run "/etc/init.d/#{daemon_name} #{t}"
     end
   end
 
@@ -82,11 +83,9 @@ namespace :deploy do
       ]
     end
 
-    if rbenv_ruby_version
-      commands << "ln -snf #{shared_path}/rbenv-version #{release_path}/.rbenv-version"
-    end
+    commands << "ln -snf #{shared_path}/rbenv-version #{release_path}/.rbenv-version" if rbenv_ruby_version
 
-    run commands.join(" && ")
+    run commands.join(' && ')
   end
 
   namespace :assets do
@@ -100,7 +99,7 @@ namespace :deploy do
     general_config = YAML.safe_load(capture("cat #{shared_path}/general.yml"))
     shared_dirs = Array(general_config['SHARED_DIRECTORIES']).map { |d| d.chomp('/') }
     dirs_to_create = shared_dirs.map { |d| "#{shared_path}/#{File.basename(d)}" }
-    run dirs_to_create.map { |d| "mkdir -p #{d}" }.join(" && ")
+    run dirs_to_create.map { |d| "mkdir -p #{d}" }.join(' && ')
   end
 end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,114 @@
+require 'bundler/capistrano'
+
+set :stage, 'staging' unless exists? :stage
+
+configuration = YAML.load_file('config/deploy.yml')[stage]
+
+set :application, 'alaveteli'
+set :scm, :git
+set :deploy_via, :remote_cache
+set :repository, configuration['repository']
+set :branch, configuration['branch']
+set :git_enable_submodules, true
+set :deploy_to, configuration['deploy_to']
+set :user, configuration['user']
+set :use_sudo, false
+set :rails_env, configuration['rails_env']
+set :daemon_name, configuration.fetch('daemon_name', 'alaveteli')
+
+server configuration['server'], :app, :web, :db, primary: true
+
+set(:rbenv_ruby_version) do
+  command = "cat #{shared_path}/rbenv-version 2>/dev/null || true"
+  result = capture(command).strip
+  result.empty? ? nil : result
+end
+
+if rbenv_ruby_version
+  set(:rbenv_path) { capture("echo $HOME/.rbenv").strip }
+  set(:rbenv_shims_path) { File.join(rbenv_path, 'shims') }
+  set :default_environment, {
+    'PATH' => [rbenv_shims_path, '$PATH'].join(':')
+  }
+end
+
+namespace :themes do
+  task :install do
+    run "cd #{latest_release} && bundle exec rake themes:install RAILS_ENV=#{rails_env}"
+  end
+end
+
+# Not in the rake namespace because we're also specifying app-specific arguments here
+namespace :xapian do
+  desc 'Rebuilds the Xapian index as per the ./scripts/destroy-and-rebuild-xapian-index script'
+  task :destroy_and_rebuild_index do
+    run "cd #{current_path} && bundle exec rake xapian:destroy_and_rebuild_index models='PublicBody User InfoRequestEvent' RAILS_ENV=#{rails_env}"
+  end
+end
+
+set(:shared_children) do
+  general_config = YAML.safe_load(capture("cat #{shared_path}/general.yml"))
+  Array(general_config['SHARED_DIRECTORIES']).map { |d| File.basename(d.chomp('/')) }
+end
+
+namespace :deploy do
+
+  desc 'Check that shared files and directories exist before deploying'
+  task :check_shared do
+    general_config = YAML.safe_load(capture("cat #{shared_path}/general.yml"))
+    shared_files = Array(general_config['SHARED_FILES']).map { |f| "#{shared_path}/#{File.basename(f)}" }
+    missing = shared_files.select { |f| capture("test -f #{f} && echo exists || echo missing").strip == 'missing' }
+    abort "Missing shared files:\n#{missing.join("\n")}" unless missing.empty?
+  end
+  before 'deploy:symlink_configuration', 'deploy:check_shared'
+
+  [:start, :stop, :restart].each do |t|
+    desc "#{t.to_s.capitalize} Alaveteli service defined in /etc/init.d/"
+    task t, roles: :app, except: { no_release: true } do
+      run "/etc/init.d/#{ daemon_name } #{ t }"
+    end
+  end
+
+  desc 'Link configuration after a code update'
+  task :symlink_configuration do
+    general_config = YAML.safe_load(capture("cat #{shared_path}/general.yml"))
+    shared_files = Array(general_config['SHARED_FILES'])
+    shared_dirs = Array(general_config['SHARED_DIRECTORIES']).map { |d| d.chomp('/') }
+
+    commands = (shared_files + shared_dirs).flat_map do |f|
+      [
+        "mkdir -p $(dirname #{release_path}/#{f})",
+        "ln -snf #{shared_path}/#{File.basename(f)} #{release_path}/#{f}"
+      ]
+    end
+
+    if rbenv_ruby_version
+      commands << "ln -snf #{shared_path}/rbenv-version #{release_path}/.rbenv-version"
+    end
+
+    run commands.join(" && ")
+  end
+
+  namespace :assets do
+    desc 'Symlink non-digest asset paths to the most recent digest versions'
+    task :link_non_digest do
+      run "cd #{latest_release} && bundle exec rake assets:link_non_digest RAILS_ENV=#{rails_env}"
+    end
+  end
+
+  after 'deploy:setup' do
+    general_config = YAML.safe_load(capture("cat #{shared_path}/general.yml"))
+    shared_dirs = Array(general_config['SHARED_DIRECTORIES']).map { |d| d.chomp('/') }
+    dirs_to_create = shared_dirs.map { |d| "#{shared_path}/#{File.basename(d)}" }
+    run dirs_to_create.map { |d| "mkdir -p #{d}" }.join(" && ")
+  end
+end
+
+after 'deploy:assets:symlink', 'deploy:symlink_configuration'
+
+before 'deploy:assets:precompile', 'themes:install'
+after 'deploy:assets:precompile', 'deploy:assets:link_non_digest'
+
+# Put up a maintenance notice if doing a migration which could take a while
+before 'deploy:migrate', 'deploy:web:disable'
+after 'deploy:migrate', 'deploy:web:enable'

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,0 +1,17 @@
+production:
+  branch: production
+  repository: https://github.com/openaustralia/alaveteli.git
+  server: prod.righttoknow.org.au
+  user: deploy
+  deploy_to: /srv/www/production
+  rails_env: production
+  daemon_name: alaveteli-production
+
+staging:
+  branch: staging
+  repository: https://github.com/openaustralia/alaveteli.git
+  server: staging.righttoknow.org.au
+  user: deploy
+  deploy_to: /srv/www/staging
+  rails_env: production
+  daemon_name: alaveteli-staging


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/righttoknow/issues/995

## What does this do?
Integrates Capistrano for deployment with configuration files and necessary gems.

## Why was this needed?
Capistrano is being removed from the main Alaveteli repo in a later release. This change moves the capistrano deployment of Alaveteli and Righht to Know to this repository.

## Implementation notes
Includes a `Capfile`, deployment scripts, and a configuration YAML file for production and staging environments.

## Screenshots

## Notes to reviewer
Review the deployment configurations and ensure they align with the existing infrastructure.