### PR TITLE
Support ssh ed25519 keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :development do
 end
 
 group :deployment do
+  gem "bcrypt_pbkdf", "~> 1.1"
   gem 'capistrano', '~> 3.19'
   gem 'capistrano-bundler', '~> 2.1'
   gem 'capistrano-git-with-submodules', '~> 2.0'
@@ -21,6 +22,7 @@ group :deployment do
   gem 'capistrano-rails', '~> 1.6'
   gem 'capistrano-rbenv', '~> 2.2'
   gem "capistrano-tagging3", "~> 2.0"
+  gem "ed25519", "~> 1.3"
   gem 'net-ssh', '~> 7.2.0'
   gem 'net-ssh-gateway', '>= 1.1.0', '< 3.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,9 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt_pbkdf (1.1.2)
+    bcrypt_pbkdf (1.1.2-arm64-darwin)
+    bcrypt_pbkdf (1.1.2-x86_64-darwin)
     capistrano (3.20.0)
       airbrussh (>= 1.0.0)
       i18n
@@ -26,6 +29,7 @@ GEM
       capistrano (~> 3.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
+    ed25519 (1.4.0)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -156,6 +160,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bcrypt_pbkdf (~> 1.1)
   capistrano (~> 3.19)
   capistrano-bundler (~> 2.1)
   capistrano-git-with-submodules (~> 2.0)
@@ -163,6 +168,7 @@ DEPENDENCIES
   capistrano-rails (~> 1.6)
   capistrano-rbenv (~> 2.2)
   capistrano-tagging3 (~> 2.0)
+  ed25519 (~> 1.3)
   guard
   guard-livereload
   json (~> 2.6.2)


### PR DESCRIPTION
## Description

Adds gems needed.

## Motivation and Context
I use ed25519 keys and they are more performant

## How Has This Been Tested?
Deployed with capistrano-tagging3 to production
on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0

## Screenshots (if appropriate):

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
