### PR TITLE
Restore Privacy Request Prompt for authorities that have many hidden requests

### DIFF
--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -1,0 +1,294 @@
+<% unless @batch %>
+  <% content_for :javascript do %>
+    <script type="text/javascript">
+      $(document).ready(function(){
+        // Avoid triggering too often (on each keystroke) by using the
+        // debounce jQuery plugin:
+        // http://benalman.com/projects/jquery-throttle-debounce-plugin/
+        $("#typeahead_search").keypress($.debounce( 300, function() {
+          if ( $('#request_search_ahead_results').text().trim().length > 0) {
+            $('#typeahead_response').slideUp('fast');
+          }
+
+        $("#typeahead_response").load("<%= search_ahead_url %>?q="+encodeURI(this.value)+
+          "&requested_from=<%= @info_request.public_body.url_name %>"+
+          "&per_page=3", function() {
+
+            if ( $('#request_search_ahead_results').text().trim().length > 0) {
+              $('#typeahead_response').hide().slideDown('fast');
+
+              $("#typeahead_response .request_short_listing a").on('click', function(){
+                <%= raw(track_analytics_event(
+                  AnalyticsEvent::Category::VIEW_REQUEST,
+                  AnalyticsEvent::Action::POSSIBLE_RELATED,
+                  :label => "$.trim($(this).text())",
+                  :label_is_script => true
+                )) %>
+              }).attr({
+                "target": "_blank"
+              });
+
+              $("#body-site-search-link").on('click', function(){
+                <%= raw(track_analytics_event(
+                  AnalyticsEvent::Category::SEARCH_OFFICIAL_WEBSITE,
+                  AnalyticsEvent::Action::POSSIBLE_RELATED,
+                  :label => @info_request.public_body.calculated_home_page
+                )) %>
+              }).attr({
+                "target": "_blank",
+                "href": "http://www.google.com/#q="+encodeURI($("#typeahead_search").val())+
+                        "+site:<%= @info_request.public_body.calculated_home_page %>"
+              });
+
+              $('.close-button').click(function() { $(this).parent().hide() });
+            }
+          });
+        }));
+
+        var questions = $('#request_form_questions')
+        var questionInputs = $('input[name=request_form_response]', questions)
+        var questionResponses = $('.request_form_response')
+
+        // when inputs are checked update which response is focused.
+        questionInputs.on('click', function () {
+          var id = '#request_form_response--' + $(this).val()
+          questionResponses.removeClass('request_form_response--focused')
+          questionResponses.filter(id).addClass('request_form_response--focused')
+        })
+
+        // checked state can follow manual page reloads, ensure correct response
+        // is focused.
+        questionInputs.filter(':checked').click()
+      });
+    </script>
+  <% end %>
+<% end %>
+
+<% if @batch %>
+  <% @title = _("Make an {{law_used_short}} request",
+                law_used_short: h(@info_request.legislation)) %>
+<% else %>
+  <% @title = _("Make an {{law_used_short}} request to '{{public_body_name}}'", law_used_short: h(@info_request.legislation), public_body_name: h(@info_request.public_body.name)) %>
+<% end %>
+
+
+<%= form_for(@info_request, :url => (@batch ? new_batch_path : new_request_path),
+                            :html => { :id => 'write_form' }  ) do |f| %>
+  <div id="request_header" class="request_header">
+    <div id="request_header_body" class="request_header_body">
+      <h1><%= _('Make a request') %></h1>
+
+      <% if @existing_request %>
+        <div class="errorExplanation" id="errorExplanation">
+          <ul>
+            <li>
+              <%= _('{{existing_request_user}} already created the same ' \
+                    'request on {{date}}. You can either view the ' \
+                    '<a href="{{existing_request}}">existing request</a>, or ' \
+                    'edit the details below to make a new but similar request.',
+                    :existing_request_user => user_or_you_capital_link(@existing_request.user),
+                    :date => simple_date(@existing_request.created_at),
+                    :existing_request => request_path(@existing_request)) %>
+            </li>
+          </ul>
+        </div>
+      <% end %>
+
+      <% if @existing_batch %>
+        <div class="errorExplanation" id="errorExplanation">
+          <ul>
+            <li>
+              <%= _('You already created the same batch of requests on ' \
+                      '{{date}}. You can either view the ' \
+                      '<a href="{{existing_batch}}">existing batch</a>, or ' \
+                      'edit the details below to make a new but similar batch ' \
+                      'of requests.',
+                    :date => simple_date(@existing_batch.created_at),
+                    :existing_batch => info_request_batch_path(@existing_batch)) %>
+            </li>
+          </ul>
+        </div>
+      <% end %>
+
+      <%= foi_error_messages_for :info_request, :outgoing_message %>
+
+      <%= render :partial => 'request/email_override_warning' %>
+
+      <% if @batch %>
+        <label class="form_label"><%= _('To:') %></label>
+        <span id="to_public_body" class="to_public_body">
+          <%= _("Your selected authorities") %>
+          <span class="batch_public_body_toggle" data-hidetext="<%= _("(hide)") %>" data-showtext="<%= _("(show)") %>"><a class="toggle-message"></a></span>
+        </span>
+
+        <div class="batch_public_body_list">
+          <ul>
+            <% @public_bodies.each do |public_body| %>
+              <li><%= public_body.name %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% else %>
+        <p id="to_public_body" class="to_public_body">
+          <span class="to_public_body_label"><%= _('To') %></span>
+          <%= h(@info_request.public_body.name) %>
+        </p>
+
+        <p id="from_user" class="from_user">
+          <span class="from_user_label"><%= _('From') %></span>
+          <%= @user&.name || '…' %>
+        </p>
+      <% end %>
+
+      <% unless @batch %>
+        <% if @info_request.public_body.has_notes? %>
+          <%= render_notes(@info_request.public_body.notes) %>
+        <% end %>
+      <% end %>
+
+    </div>
+  </div>
+
+  <% unless @batch %>
+    <% if @info_request.public_body.eir_only? %>
+      <div class="request_body">
+        <div id="request_body_header" class="request_body_header">
+          <h3><%= _('Please ask for environmental information only') %></h3>
+
+          <p>
+            <%= _('The Freedom of Information Act <strong>does not apply</strong> to') %> <%=h(@info_request.public_body.name)%>.
+            <%= _('However, you have the right to request environmental ' \
+                  'information under a different law') %>
+            (<a href="/help/requesting#eir">explanation</a>).
+            <%= _('This covers a very wide spectrum of information about the ' \
+                  'state of the <strong>natural and built environment' \
+                  '</strong>, such as:') %>
+          </p>
+
+          <ul>
+            <li><%= _('Air, water, soil, land, flora and fauna (including how these effect human beings)') %></li>
+            <li><%= _('Information on emissions and discharges (e.g. noise, ' \
+                      'energy, radiation, waste materials)') %></li>
+            <li><%= _('Human health and safety') %></li>
+            <li><%= _('Cultural sites and built structures (as they may be affected by the environmental factors listed above)') %></li>
+            <li><%= _('Plans and administrative measures that affect these matters') %></li>
+          </ul>
+
+          <p>
+            <%= _('Please only request information that comes under those ' \
+                  'categories, <strong>do not waste your time</strong> or ' \
+                  'the time of the public authority by requesting unrelated ' \
+                  'information.') %>
+          </p>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+
+  <div class="request_body">
+    <div id="request_advice" class="request_advice">
+      <div class="advice-panel">
+        <h4><%= _('Before you start') %></h4>
+
+        <ul>
+          <li><%= _('Make sure the information you are asking for is not ' \
+                       'already publicly available.') %></li>
+
+          <% unless @batch %>
+            <li>
+              <% if @info_request.public_body.info_requests.is_public.any? %>
+                <%= _("Browse <a href='{{url}}'>other requests</a> to '{{public_body_name}}' for examples of how to word your request.", :public_body_name=>h(@info_request.public_body.name), :url=>public_body_path(@info_request.public_body)) %>
+              <% else %>
+                <%= _("Browse <a href='{{url}}'>other requests</a> for examples of how to word your request.", :url=>request_list_successful_url) %>
+              <% end %>
+            </li>
+      <% end %>
+        </ul>
+      </div>
+
+      <div class="advice-panel">
+        <h4><%= _('Writing your request') %></h4>
+
+        <ul>
+          <li>
+            <%= raw(_("<strong>Can I request information about myself?</strong> " \
+                      "<a href=\"{{url}}\">No!</a>",
+                      :url => help_requesting_path(:anchor => "data_protection").html_safe)) %>
+          </li>
+          <li><%= _('Write your request in <strong>simple, precise language</strong>.') %></li>
+          <li><%= _('Ask for <strong>specific</strong> documents or ' \
+                       'information, this site is not suitable for general ' \
+                       'enquiries.') %></li>
+          <li><%= _('<a href="{{url}}">Keep it <strong>focused</strong></a>, ' \
+                       'you\'ll be more likely to get what you want.',
+                    :url => help_requesting_path(:anchor => 'focused').html_safe) %></li>
+          <li><%= _('Make sure the information you are asking for is not ' \
+                       'already publicly available.') %></li>
+        </ul>
+      </div>
+
+      <div class="advice-panel advice-panel--warning">
+        <h4><%= _('Signing your request') %></h4>
+
+        <ul>
+          <li>
+            <% if @user %>
+              <%= raw(_('Everything that you enter on this page, including ' \
+                        '<strong>your name</strong> ({{user_name}}), will ' \
+                        'be <strong>displayed publicly</strong> on this ' \
+                        'website <a href="{{url}}">forever</a>',
+                        user_name: @user.name,
+                        url: help_privacy_path(anchor: 'public_request').html_safe)) %>.
+            <% else %>
+              <%= raw(_('Everything that you enter on this page, including ' \
+                        '<strong>your name</strong>, will be <strong>displayed ' \
+                        'publicly</strong> on this website ' \
+                        '<a href="{{url}}">forever</a>',
+                        :url => help_privacy_path(:anchor => "public_request").html_safe)) %>.
+            <% end %>
+          </li>
+
+          <% unless @user %>
+            <li>
+              <%= raw(_('<a href="{{url}}">Thinking of using a pseudonym?</a>',
+                        :url => help_privacy_path(:anchor => "real_name").html_safe)) %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+
+    <div id="request_form" class="request_form">
+      <% if @batch || @info_request.public_body.questions.blank? %>
+        <%= render 'form', f: f %>
+      <% else %>
+        <div id="request_form_questions">
+          <h2><%= _('What would you like to do?') %></h2>
+
+          <% @info_request.public_body.questions.each do |question| %>
+            <label for="<%= question.key %>">
+              <input type="radio" name="request_form_response" id="<%= question.key %>" value="<%= question.key %>" <%= 'checked="checked"' if params[:request_form_response] == question.key.to_s %>>
+              <%= question.text %>
+            </label>
+          <% end %>
+        </div>
+
+        <% @info_request.public_body.questions.each do |question| %>
+          <div class="request_form_response request_form_response--<%= question.action %>" id="request_form_response--<%= question.key %>">
+            <% if question.action == :allow %>
+              <%= render 'form', f: f %>
+            <% else %>
+              <div class="request_deny_response"><%= question.response %></div>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<% if @batch %>
+  <% content_for :javascript do %>
+    <%= javascript_include_tag 'new-request.js' %>
+  <% end %>
+<% end %>

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -259,6 +259,24 @@
     </div>
 
     <div id="request_form" class="request_form">
+      <% if !@batch && @info_request.public_body.info_requests_hidden_count >= 2 %>
+        <fieldset id="request_personal_switch" class="request_personal_switch">
+          <legend>Are you asking for <strong>personal information</strong> that should be confidential?</legend>
+          <p>This includes <em>police incident reports</em>, <em>court records</em>, <em>medical records</em>, <em>paperwork for insurance or court</em>, etc.</p>
+          <input class="visually-hidden" type="radio" name="personal_request" id="request_personal_switch_yes" value="yes" />
+          <label for="request_personal_switch_yes">Yes</label>
+          <input class="visually-hidden" type="radio" name="personal_request" id="request_personal_switch_no" value="no" />
+          <label for="request_personal_switch_no">No</label>
+          <div class="request_personal_message">
+            <p><strong>Email your request</strong> directly to <%= @info_request.public_body.name %>:</p>
+            <p class="request_email"><%= mail_to @info_request.public_body.request_email, @info_request.public_body.request_email, subject: "Request for personal information" %></p>
+            <p>
+              You <%= link_to "cannot make requests for personal information", help_requesting_path(:anchor => "data_protection") %>
+              using this site. If you do you will be posting your information publicly on the internet for anyone to see.</p>
+          </div>
+        </fieldset>
+      <% end %>
+
       <% if @batch || @info_request.public_body.questions.blank? %>
         <%= render 'form', f: f %>
       <% else %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A customisation we added that added a privacy check if an authority had more than 2 hidden requests was removed in Commit 1c80d39.

This PR re-adds this feature.

## Motivation and Context
We don't want people making requests for personal information on Right to Know.

## How Has This Been Tested?
Tested in local development by creating an authority and checking that it has 2 or more hidden requests. Confirmed that the request flow worked as expected.

Tested with another authority that had no hidden requests to verify that the issue targets only those authorities with a low number of hidden requests.

## Screenshots (if appropriate):

<img width="702" height="926" alt="image" src="https://github.com/user-attachments/assets/6afe2330-5ed3-4367-8400-597363eaedb4" />
<img width="687" height="383" alt="image" src="https://github.com/user-attachments/assets/c8f06c79-8386-440b-afe1-37458dc5cbbc" />


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
