### PR TITLE
Pro pricing & coupons for 0.45 Prices API (0.45.8.0 stack 3/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
   - [Development](#development)
   - [Development Environment - Simple Steps](#development-environment---simple-steps)
   - [Seeding test data](#seeding-test-data)
+  - [Pro subscriptions](#pro-subscriptions)
+    - [Restricting a coupon to a billing interval](#restricting-a-coupon-to-a-billing-interval)
   - [Contributing](#contributing)
   - [Deployment](#deployment)
     - [Prerequisites](#prerequisites)
@@ -116,6 +118,35 @@ Optional environment variables:
 The script is idempotent: re-running it reuses existing authorities and
 categories and won't stack additional seeded requests onto authorities that
 already have them.
+
+## Pro subscriptions
+
+### Restricting a coupon to a billing interval
+
+Stripe coupons can only be limited to a **product**, not to an individual
+**price**. Because the Pro monthly and annual plans are two prices under one
+product, Stripe's own `applies_to` restriction cannot stop a coupon from
+discounting both. Some coupons are meant for a single plan (for example, a
+monthly-only referral coupon).
+
+The theme enforces a per-interval restriction itself, driven by coupon
+**metadata** so the rule lives with the coupon in Stripe (no code change or
+deploy needed to add or adjust restricted coupons):
+
+- Add a metadata key `interval` to the coupon in the Stripe dashboard, set to
+  the billing interval the coupon is allowed on: `day`, `week`, `month` or
+  `year`. A monthly-only coupon takes `interval` = `month`.
+- A coupon **without** an `interval` metadata key is unrestricted and applies to
+  any plan, exactly as before.
+
+With `interval` set, [`lib/controller_patches.rb`](lib/controller_patches.rb)
+blocks the coupon at checkout on a non-matching plan (before any subscription is
+created) and the live plan-page price preview refuses it too, so a discount is
+never advertised that checkout would then reject.
+
+For extra defence-in-depth you can also set the coupon's native `applies_to`
+products to the Pro product; this stops it discounting any other product, though
+it still can't separate monthly from annual.
 
 ## Contributing
 

--- a/app/assets/javascripts/alaveteli_pro/coupon_preview.js
+++ b/app/assets/javascripts/alaveteli_pro/coupon_preview.js
@@ -17,7 +17,12 @@
   var originalEl = document.getElementById('js-plan-original');
   var savingEl = document.getElementById('js-plan-saving');
   var feedbackEl = document.getElementById('js-coupon-feedback');
-  if (!input || !priceEl) { return; }
+  // Every one of these is dereferenced below, in reset() or apply() or when
+  // reading data-original. Bail out if the template stops rendering any of them,
+  // rather than throwing and taking the whole preview down with it.
+  if (!input || !amountEl || !priceEl || !originalEl || !savingEl || !feedbackEl) {
+    return;
+  }
 
   var url = wrap.getAttribute('data-preview-url');
   var original = amountEl.getAttribute('data-original');

--- a/app/assets/javascripts/alaveteli_pro/coupon_preview.js
+++ b/app/assets/javascripts/alaveteli_pro/coupon_preview.js
@@ -1,0 +1,84 @@
+// Live coupon price preview for the Pro plan signup page.
+//
+// Listens on the coupon_code field, asks the server (plan_coupon_preview) what
+// the discounted price would be, and updates the plan overview before the user
+// submits. All server values are written via textContent - the discounted
+// amount and the coupon terms both originate from Stripe and must never be
+// treated as HTML.
+(function () {
+  'use strict';
+
+  var wrap = document.querySelector('.plan-coupon[data-preview-url]');
+  if (!wrap) { return; }
+
+  var input = document.getElementById('coupon_code');
+  var amountEl = document.getElementById('js-plan-amount');
+  var priceEl = document.getElementById('js-plan-price');
+  var originalEl = document.getElementById('js-plan-original');
+  var savingEl = document.getElementById('js-plan-saving');
+  var feedbackEl = document.getElementById('js-coupon-feedback');
+  if (!input || !priceEl) { return; }
+
+  var url = wrap.getAttribute('data-preview-url');
+  var original = amountEl.getAttribute('data-original');
+  var seq = 0;
+  var timer;
+
+  function reset() {
+    priceEl.textContent = original;
+    originalEl.hidden = true;
+    originalEl.textContent = '';
+    savingEl.hidden = true;
+    savingEl.textContent = '';
+  }
+
+  function apply(mine, data) {
+    if (mine !== seq) { return; } // a newer request has superseded this one
+
+    if (data.status === 'valid') {
+      priceEl.textContent = data.amount;
+      originalEl.textContent = data.original;
+      originalEl.hidden = false;
+      if (data.saving) {
+        savingEl.textContent = data.saving;
+        savingEl.hidden = false;
+      }
+      feedbackEl.textContent = data.terms || '';
+      feedbackEl.className = 'plan-coupon__feedback plan-coupon__feedback--valid';
+    } else if (data.status === 'empty') {
+      reset();
+      feedbackEl.textContent = '';
+      feedbackEl.className = 'plan-coupon__feedback';
+    } else {
+      // invalid / expired / error
+      reset();
+      feedbackEl.textContent = data.message || '';
+      feedbackEl.className = 'plan-coupon__feedback plan-coupon__feedback--invalid';
+    }
+  }
+
+  input.addEventListener('input', function () {
+    clearTimeout(timer);
+    timer = setTimeout(function () {
+      var mine = ++seq;
+      var code = input.value.trim();
+
+      fetch(url + '?coupon_code=' + encodeURIComponent(code), {
+        headers: { 'Accept': 'application/json' },
+        credentials: 'same-origin'
+      }).then(function (response) {
+        return response.ok ? response.json() : Promise.reject();
+      }).then(function (data) {
+        apply(mine, data);
+      }).catch(function () {
+        // Non-JSON response (e.g. session expired -> login page) or network
+        // error: fail quietly and leave the list price in place.
+        if (mine === seq) {
+          reset();
+          feedbackEl.textContent = '';
+          feedbackEl.className = 'plan-coupon__feedback';
+        }
+      });
+    }, 350);
+  });
+})();

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -822,3 +822,18 @@ dt {
     font-size: 1.65em;
   }
 }
+
+/*
+ * Pricing
+ */
+
+.price-label-option {
+  a {
+    color: $color_white;
+    &:hover,
+    &:active,
+    &:focus {
+      color: $color_yellow;
+    }
+  }
+}

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -837,3 +837,30 @@ dt {
     }
   }
 }
+
+// Live coupon price preview (see alaveteli_pro/coupon_preview.js)
+.plan-overview__original {
+  color: $color_dark_grey;
+  text-decoration: line-through;
+  margin-right: 0.5em;
+}
+
+.plan-overview__saving {
+  color: darken($color_green, 10%);
+  font-size: 0.875em;
+  text-align: right;
+  margin: 0.25em 0 0;
+}
+
+.plan-coupon__feedback {
+  font-size: 0.875em;
+  margin: 0.4em 0 0;
+
+  &--valid {
+    color: darken($color_green, 10%);
+  }
+
+  &--invalid {
+    color: $error-color;
+  }
+}

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -5,7 +5,8 @@ theme_name.gsub!('-', '_')
 THEME_NAME = theme_name
 
 Rails.application.config.assets.precompile << ['event_tracking.js',
-                                               'personal_message_toggler.js']
+                                               'personal_message_toggler.js',
+                                               'alaveteli_pro/coupon_preview.js']
 
 module ActionController
   class Base

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -31,6 +31,7 @@ end
 # Monkey patch app code
 ['controller_patches.rb',
  'model_patches.rb',
+ 'helper_patches.rb',
  'patch_mailer_paths.rb'].each do |patch|
   require File.expand_path "../#{patch}", __FILE__
 end

--- a/lib/config/custom-routes.rb
+++ b/lib/config/custom-routes.rb
@@ -12,4 +12,17 @@ Rails.application.routes.draw do
   # in the main project there is no need for our version. Just to be
   # safe let's redirect the old url
   get '/people' => redirect('statistics#people')
+
+  # Live coupon price preview for the Pro plan signup page. Read-only JSON
+  # endpoint (GET, no CSRF) consumed by alaveteli_pro/coupon_preview.js to show
+  # the discounted price before the user submits. The action is added to
+  # AlaveteliPro::PlansController in lib/controller_patches.rb. Gated by the
+  # same pro_pricing feature flag as the plans pages it serves.
+  constraints AlaveteliFeatures::Constraints::FeatureConstraint.new(:pro_pricing) do
+    scope module: :alaveteli_pro do
+      get 'plans/:price_id/coupon_preview',
+          to: 'plans#coupon_preview',
+          as: :plan_coupon_preview
+    end
+  end
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -31,17 +31,56 @@ Rails.configuration.to_prepare do
   # PlansController#show (login required, pro membership not) and skips
   # html_response so it can render JSON.
   AlaveteliPro::PlansController.class_eval do
-    skip_before_action :html_response, only: [:coupon_preview]
+    # raise: false so that an upstream rename of the html_response callback
+    # degrades this action rather than failing to boot the whole application.
+    skip_before_action :html_response, only: [:coupon_preview], raise: false
     before_action :authenticate, only: [:coupon_preview]
 
     def coupon_preview
       price = AlaveteliPro::Price.retrieve(params[:price_id])
       return render(json: { status: 'error' }, status: :not_found) unless price
 
-      render json: coupon_preview_json(price, params[:coupon_code].to_s.strip)
+      code = params[:coupon_code].to_s.strip
+
+      # Only count attempts that actually reach Stripe. A blank code is answered
+      # from the price alone, so it must not consume the user's allowance - the
+      # field is cleared and retyped in the course of ordinary use.
+      if code.present?
+        if coupon_preview_rate_limiter.limit?(coupon_preview_rate_limit_id)
+          return render(
+            json: { status: 'error',
+                    message: _('Too many attempts. Please try again later.') },
+            status: :too_many_requests
+          )
+        end
+
+        coupon_preview_rate_limiter.record!(coupon_preview_rate_limit_id)
+      end
+
+      render json: coupon_preview_json(price, code)
     end
 
     private
+
+    # 30 coupon codes per user per hour: generous for somebody typing a code
+    # they hold (the JS debounces, so one attempt is normally one request),
+    # restrictive for anyone probing to find codes that exist. Built here rather
+    # than held in a constant because this runs inside a to_prepare block, where
+    # defining constants would be redefined on every reload in development.
+    def coupon_preview_rate_limiter
+      @coupon_preview_rate_limiter ||=
+        AlaveteliRateLimiter::RateLimiter.new(
+          AlaveteliRateLimiter::Rule.new(
+            :coupon_preview, 30, AlaveteliRateLimiter::Window.new(1, :hour)
+          )
+        )
+    end
+
+    # Rate limit per user rather than per IP: the action requires a login, and
+    # keying on IP would penalise everyone behind a shared address.
+    def coupon_preview_rate_limit_id
+      @user.id
+    end
 
     def coupon_preview_json(price, code)
       return empty_preview(price) if code.blank?
@@ -96,16 +135,33 @@ Rails.configuration.to_prepare do
 
     # Replicates the arithmetic in
     # AlaveteliPro::Subscription::Discount#coupon_reduction (which mixes into a
-    # Subscription and can't be called against a bare Price + Coupon). That
-    # method is the source of truth; keep this in sync with it. Tax is applied
-    # to the post-discount net, matching Taxable and the legacy tax_percent the
-    # real subscription is created with.
-    def coupon_preview_payload(price, coupon)
+    # Subscription and so can't be called against a bare Price + Coupon). That
+    # method is the source of truth, and spec/coupon_preview_parity_spec.rb
+    # asserts the two agree - if upstream changes, that spec fails rather than
+    # this quietly drifting.
+    #
+    # Deliberately does NOT round the percent_off reduction: upstream's
+    # coupon_reduction is a bare `plan.amount * coupon.percent_off / 100`. Real
+    # Stripe returns a fractional percent_off (percent_off_precise), so rounding
+    # here would show a price a cent away from the one the subscription page
+    # displays after purchase.
+    #
+    # Tax matches Taxable#tax exactly: rounded VAT added to the unrounded net.
+    # Kept separate from the formatting below so it can be compared directly
+    # against upstream's figure in spec/coupon_preview_parity_spec.rb. Comparing
+    # formatted strings would not do: format_currency rounds to the cent and
+    # would mask a sub-cent divergence.
+    def coupon_discounted_gross(price, coupon)
       net = price.unit_amount
-      reduction = coupon.amount_off || (net * coupon.percent_off / 100).round
+      reduction = coupon.amount_off || (net * coupon.percent_off / 100)
       discounted_net = [net - reduction, 0].max
       tax_rate = AlaveteliConfiguration.stripe_tax_rate.to_f
-      discounted_gross = discounted_net + (discounted_net * tax_rate).round
+
+      discounted_net + (discounted_net * tax_rate).round(0)
+    end
+
+    def coupon_preview_payload(price, coupon)
+      discounted_gross = coupon_discounted_gross(price, coupon)
       saving = price.unit_amount_with_tax - discounted_gross
 
       {

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -57,6 +57,9 @@ Rails.configuration.to_prepare do
         { status: 'expired', message: _('Coupon code has expired.') }
       elsif mismatched_currency?(coupon)
         { status: 'invalid', message: _('Coupon code is invalid.') }
+      elsif mismatched_interval?(price, coupon)
+        { status: 'invalid',
+          message: _('This coupon code cannot be used with this plan.') }
       else
         coupon_preview_payload(price, coupon)
       end
@@ -78,6 +81,17 @@ Rails.configuration.to_prepare do
       coupon.amount_off && coupon.currency &&
         coupon.currency.downcase !=
           AlaveteliConfiguration.iso_currency_code.downcase
+    end
+
+    # A coupon can carry an `interval` metadata restriction (e.g. "month") to
+    # limit it to a single billing interval. Stripe's coupon applies_to is
+    # product-scoped only and can't distinguish the monthly price from the
+    # annual price within the Pro product, so SubscriptionsController#create
+    # enforces this restriction itself. The preview must refuse it too,
+    # otherwise we'd advertise a discount that checkout then rejects.
+    def mismatched_interval?(price, coupon)
+      required = coupon.metadata.to_h[:interval]
+      required.present? && required != price.recurring&.[]('interval')
     end
 
     # Replicates the arithmetic in
@@ -123,6 +137,32 @@ Rails.configuration.to_prepare do
       return humanized if humanized.present?
 
       coupon.name if coupon.respond_to?(:name)
+    end
+  end
+
+  # Enforce coupon `interval` metadata restrictions at checkout. Stripe's
+  # coupon applies_to is product-scoped only, so it can't stop a coupon meant
+  # for a single interval (e.g. a monthly-only coupon) from discounting the
+  # annual price within the same product. We block the mismatch here.
+  #
+  # This must halt via a before_action redirect rather than just setting
+  # flash[:error]: SubscriptionsController#create runs its subscription-creating
+  # block unconditionally and only checks flash[:error] afterwards, so a late
+  # error would still charge the customer at full price before redirecting.
+  AlaveteliPro::SubscriptionsController.class_eval do
+    before_action :check_coupon_matches_price, only: [:create]
+
+    private
+
+    def check_coupon_matches_price
+      return unless @coupon && @price
+
+      required = @coupon.metadata.to_h[:interval]
+      return if required.blank?
+      return if required == @price.recurring&.[]('interval')
+
+      flash[:error] = _('This coupon code cannot be used with this plan.')
+      json_redirect_to plan_path(@price)
     end
   end
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -24,4 +24,105 @@ Rails.configuration.to_prepare do
       # No template for this action, skip setting history
     end
   end
+
+  # Live coupon price preview for the Pro plan signup page. Returns the
+  # discounted price as JSON so alaveteli_pro/coupon_preview.js can update the
+  # displayed amount before the user submits. Mirrors the access rules of
+  # PlansController#show (login required, pro membership not) and skips
+  # html_response so it can render JSON.
+  AlaveteliPro::PlansController.class_eval do
+    skip_before_action :html_response, only: [:coupon_preview]
+    before_action :authenticate, only: [:coupon_preview]
+
+    def coupon_preview
+      price = AlaveteliPro::Price.retrieve(params[:price_id])
+      return render(json: { status: 'error' }, status: :not_found) unless price
+
+      render json: coupon_preview_json(price, params[:coupon_code].to_s.strip)
+    end
+
+    private
+
+    def coupon_preview_json(price, code)
+      return empty_preview(price) if code.blank?
+
+      coupon = AlaveteliPro::Coupon.retrieve(code)
+
+      # Existence is not validity: a coupon can exist in Stripe yet be rejected
+      # at checkout (expired, max redemptions reached, etc). Mirror the two
+      # failure messages SubscriptionsController#create surfaces.
+      if coupon.nil?
+        { status: 'invalid', message: _('Coupon code is invalid.') }
+      elsif !coupon.valid
+        { status: 'expired', message: _('Coupon code has expired.') }
+      elsif mismatched_currency?(coupon)
+        { status: 'invalid', message: _('Coupon code is invalid.') }
+      else
+        coupon_preview_payload(price, coupon)
+      end
+    end
+
+    def empty_preview(price)
+      {
+        status: 'empty',
+        amount: helpers.format_currency(
+          price.unit_amount_with_tax, no_cents_if_whole: true
+        )
+      }
+    end
+
+    # An amount_off coupon only applies to a matching currency; Stripe would
+    # reject a mismatch at checkout, so treat it as invalid rather than
+    # previewing a bogus discount.
+    def mismatched_currency?(coupon)
+      coupon.amount_off && coupon.currency &&
+        coupon.currency.downcase !=
+          AlaveteliConfiguration.iso_currency_code.downcase
+    end
+
+    # Replicates the arithmetic in
+    # AlaveteliPro::Subscription::Discount#coupon_reduction (which mixes into a
+    # Subscription and can't be called against a bare Price + Coupon). That
+    # method is the source of truth; keep this in sync with it. Tax is applied
+    # to the post-discount net, matching Taxable and the legacy tax_percent the
+    # real subscription is created with.
+    def coupon_preview_payload(price, coupon)
+      net = price.unit_amount
+      reduction = coupon.amount_off || (net * coupon.percent_off / 100).round
+      discounted_net = [net - reduction, 0].max
+      tax_rate = AlaveteliConfiguration.stripe_tax_rate.to_f
+      discounted_gross = discounted_net + (discounted_net * tax_rate).round
+      saving = price.unit_amount_with_tax - discounted_gross
+
+      {
+        status: 'valid',
+        amount: helpers.format_currency(
+          discounted_gross, no_cents_if_whole: true
+        ),
+        original: helpers.format_currency(
+          price.unit_amount_with_tax, no_cents_if_whole: true
+        ),
+        saving: coupon_saving_text(saving),
+        terms: coupon_terms(coupon)
+      }
+    end
+
+    def coupon_saving_text(saving)
+      return if saving <= 0
+
+      _('You save {{amount}}',
+        amount: helpers.format_currency(saving, no_cents_if_whole: true))
+    end
+
+    # AlaveteliPro::Coupon#terms is metadata.humanized_terms || name, but both
+    # accesses raise NoMethodError on the Stripe gem's StripeObject when the
+    # attribute is absent. Read them defensively so an ordinary coupon (no
+    # humanized_terms metadata, or a null name) can't 500 the preview.
+    def coupon_terms(coupon)
+      humanized = coupon.metadata.to_h[:humanized_terms]
+      return humanized if humanized.present?
+
+      coupon.name if coupon.respond_to?(:name)
+    end
+  end
 end

--- a/lib/helper_patches.rb
+++ b/lib/helper_patches.rb
@@ -1,0 +1,6 @@
+# Load our helpers
+require 'helpers/alaveteli_pro/alternative_price_text_helper'
+
+Rails.configuration.to_prepare do
+  ActionView::Base.send(:include, AlaveteliPro::AlternativePriceTextHelper)
+end

--- a/lib/helper_patches.rb
+++ b/lib/helper_patches.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # Load our helpers
 require 'helpers/alaveteli_pro/alternative_price_text_helper'
 
 Rails.configuration.to_prepare do
-  ActionView::Base.send(:include, AlaveteliPro::AlternativePriceTextHelper)
+  ActionView::Base.include AlaveteliPro::AlternativePriceTextHelper
 end

--- a/lib/helpers/alaveteli_pro/alternative_price_text_helper.rb
+++ b/lib/helpers/alaveteli_pro/alternative_price_text_helper.rb
@@ -1,0 +1,21 @@
+module AlaveteliPro::AlternativePriceTextHelper
+  def alternative_price_text(price)
+    amount = format_currency(
+      price.unit_amount_with_tax, no_cents_if_whole: true
+    )
+
+    if interval(price) == 'day' && interval_count(price) == 1
+      _('or {{amount}} daily', amount: amount)
+    elsif interval(price) == 'week' && interval_count(price) == 1
+      _('or {{amount}} weekly', amount: amount)
+    elsif interval(price) == 'month' && interval_count(price) == 1
+      _('or {{amount}} monthly', amount: amount)
+    elsif interval(price) == 'year' && interval_count(price) == 1
+      _('or {{amount}} annually', amount: amount)
+    else
+      _('or {{amount}} every {{interval}}',
+        amount: amount,
+        interval: pluralize_interval(price))
+    end
+  end
+end

--- a/lib/helpers/alaveteli_pro/alternative_price_text_helper.rb
+++ b/lib/helpers/alaveteli_pro/alternative_price_text_helper.rb
@@ -1,21 +1,27 @@
-module AlaveteliPro::AlternativePriceTextHelper
-  def alternative_price_text(price)
-    amount = format_currency(
-      price.unit_amount_with_tax, no_cents_if_whole: true
-    )
+# frozen_string_literal: true
 
-    if interval(price) == 'day' && interval_count(price) == 1
-      _('or {{amount}} daily', amount: amount)
-    elsif interval(price) == 'week' && interval_count(price) == 1
-      _('or {{amount}} weekly', amount: amount)
-    elsif interval(price) == 'month' && interval_count(price) == 1
-      _('or {{amount}} monthly', amount: amount)
-    elsif interval(price) == 'year' && interval_count(price) == 1
-      _('or {{amount}} annually', amount: amount)
-    else
-      _('or {{amount}} every {{interval}}',
-        amount: amount,
-        interval: pluralize_interval(price))
+module AlaveteliPro
+  # Renders the alternative per-interval price text (e.g. "or $X monthly")
+  # shown alongside the headline price on Pro plan pages.
+  module AlternativePriceTextHelper
+    def alternative_price_text(price)
+      amount = format_currency(
+        price.unit_amount_with_tax, no_cents_if_whole: true
+      )
+
+      if interval(price) == 'day' && interval_count(price) == 1
+        _('or {{amount}} daily', amount: amount)
+      elsif interval(price) == 'week' && interval_count(price) == 1
+        _('or {{amount}} weekly', amount: amount)
+      elsif interval(price) == 'month' && interval_count(price) == 1
+        _('or {{amount}} monthly', amount: amount)
+      elsif interval(price) == 'year' && interval_count(price) == 1
+        _('or {{amount}} annually', amount: amount)
+      else
+        _('or {{amount}} every {{interval}}',
+          amount: amount,
+          interval: pluralize_interval(price))
+      end
     end
   end
 end

--- a/lib/views/alaveteli_pro/plans/_pricing_tiers.html.erb
+++ b/lib/views/alaveteli_pro/plans/_pricing_tiers.html.erb
@@ -1,3 +1,4 @@
+<% prices = Array(@prices).compact %>
 <div class="pricing__tiers">
   <div class="pricing__tier pricing__tier--primary">
     <div class="pricing__tier__heading">
@@ -7,18 +8,18 @@
         <%= _('For journalists, academics and power users') %>
       </p>
 
-      <% if @prices&.any? %>
+      <% if prices.any? %>
         <p class="price-label">
           <span class="price-label__amount">
-            <%= format_currency(@prices.first.unit_amount_with_tax, no_cents_if_whole: true) %>
+            <%= format_currency(prices.first.unit_amount_with_tax, no_cents_if_whole: true) %>
           </span>
 
-          <%= billing_interval(@prices.first) %>
+          <%= billing_interval(prices.first) %>
         </p>
 
-        <% if @prices.second %>
+        <% if prices.second %>
           <p class="price-label-option">
-            <%= link_to alternative_price_text(@prices.second), plan_path(@prices.second) %>
+            <%= link_to alternative_price_text(prices.second), plan_path(prices.second) %>
           </p>
         <% end %>
       <% end %>
@@ -34,8 +35,8 @@
         <li><%= _('Friendly support') %></li>
       </ul>
 
-      <% if @prices&.any? %>
-        <%= link_to _('Sign up'), plan_path(@prices.first), class: 'button button-pop' %>
+      <% if prices.any? %>
+        <%= link_to _('Sign up'), plan_path(prices.first), class: 'button button-pop' %>
       <% end %>
     </div>
   </div>

--- a/lib/views/alaveteli_pro/plans/_pricing_tiers.html.erb
+++ b/lib/views/alaveteli_pro/plans/_pricing_tiers.html.erb
@@ -7,17 +7,21 @@
         <%= _('For journalists, academics and power users') %>
       </p>
 
-      <p class="price-label">
-        <span class="price-label__amount">
-          <%= format_currency(@prices[0].unit_amount_with_tax, no_cents_if_whole: true) %>
-        </span>
+      <% if @prices&.any? %>
+        <p class="price-label">
+          <span class="price-label__amount">
+            <%= format_currency(@prices.first.unit_amount_with_tax, no_cents_if_whole: true) %>
+          </span>
 
-        <%= billing_interval(@prices[0]) %>
-      </p>
+          <%= billing_interval(@prices.first) %>
+        </p>
 
-      <p class="price-label-option">
-        <%= link_to alternative_price_text(@prices[1]), plan_path(@prices[1]) %>
-      </p>
+        <% if @prices.second %>
+          <p class="price-label-option">
+            <%= link_to alternative_price_text(@prices.second), plan_path(@prices.second) %>
+          </p>
+        <% end %>
+      <% end %>
     </div>
 
     <div class="pricing__tier__content">
@@ -30,7 +34,9 @@
         <li><%= _('Friendly support') %></li>
       </ul>
 
-      <%= link_to _('Sign up'), plan_path(@prices[0]), class: 'button button-pop' %>
+      <% if @prices&.any? %>
+        <%= link_to _('Sign up'), plan_path(@prices.first), class: 'button button-pop' %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/lib/views/alaveteli_pro/plans/_pricing_tiers.html.erb
+++ b/lib/views/alaveteli_pro/plans/_pricing_tiers.html.erb
@@ -1,0 +1,36 @@
+<div class="pricing__tiers">
+  <div class="pricing__tier pricing__tier--primary">
+    <div class="pricing__tier__heading">
+      <h2><%= _('Professional') %></h2>
+
+      <p class="pricing__tier__subhead">
+        <%= _('For journalists, academics and power users') %>
+      </p>
+
+      <p class="price-label">
+        <span class="price-label__amount">
+          <%= format_currency(@prices[0].unit_amount_with_tax, no_cents_if_whole: true) %>
+        </span>
+
+        <%= billing_interval(@prices[0]) %>
+      </p>
+
+      <p class="price-label-option">
+        <%= link_to alternative_price_text(@prices[1]), plan_path(@prices[1]) %>
+      </p>
+    </div>
+
+    <div class="pricing__tier__content">
+      <h3><%= _('Featuring') %></h3>
+
+      <ul class="pricing__tier__features">
+        <li><%= _('Public requests for information') %></li>
+        <li><%= _('Private requests for information') %></li>
+        <li><%= _('Dashboard and workflow features') %></li>
+        <li><%= _('Friendly support') %></li>
+      </ul>
+
+      <%= link_to _('Sign up'), plan_path(@prices[0]), class: 'button button-pop' %>
+    </div>
+  </div>
+</div>

--- a/lib/views/alaveteli_pro/plans/index.html.erb
+++ b/lib/views/alaveteli_pro/plans/index.html.erb
@@ -1,42 +1,10 @@
 <h1 class="pricing__title centered"><%= _('Pricing') %></h1>
 
-<div class="pricing__tiers">
-  <div class="pricing__tier pricing__tier--primary">
-
-    <div class="pricing__tier__heading">
-      <h2><%= _('Professional') %></h2>
-      <p class="pricing__tier__subhead"><%= _('For journalists, academics and power users') %></p>
-      <p class="price-label">
-        <% if @plan.interval == 'month' %>
-          <%= _('<span class="price-label__amount">{{monthly_price}}</span> ' \
-                'per user, per month',
-                monthly_price: format_currency(
-                                 @plan.amount_with_tax,
-                                 no_cents_if_whole: true)) %>
-        <% elsif @plan.interval == 'year' %>
-          <%= _('<span class="price-label__amount">{{yearly_price}}</span> ' \
-                'per user, per year',
-                yearly_price: format_currency(
-                                @plan.amount_with_tax,
-                                no_cents_if_whole: true)) %>
-        <% end %>
-      </p>
-      <p class="pricing__tier__subhead pricing__tier__subhead--intro_pricing"><%= _('Introductory Pricing') %></p>
-    </div>
-
-    <div class="pricing__tier__content">
-      <h3><%= _('Featuring') %></h3>
-      <ul class="pricing__tier__features">
-        <li><%= _('Public requests for information') %></li>
-        <li><%= _('Private requests for information') %></li>
-        <li><%= _('Dashboard and workflow features') %></li>
-        <li><%= _('Friendly support') %></li>
-      </ul>
-      <%= link_to _('Sign up'), plan_path('pro'), :class => 'button button-pop' %>
-    </div>
-
-  </div>
-</div>
+<%# Adopt the core @prices partial (0.45 Prices API). The previous bespoke tier %>
+<%# block read @plan (0.44 Plans API), which PlansController#index no longer sets, %>
+<%# so it raised on nil. Core _pricing_tiers iterates @prices, rendering one tier %>
+<%# per STRIPE_PRICES entry (monthly + annual). %>
+<%= render partial: 'alaveteli_pro/plans/pricing_tiers' %>
 
 <p class="pricing__free-message">
   <%= _('Don’t worry – <a href="{{signup_link}}">our free accounts</a> are still available and always will be.',

--- a/lib/views/alaveteli_pro/plans/index.html.erb
+++ b/lib/views/alaveteli_pro/plans/index.html.erb
@@ -1,9 +1,9 @@
 <h1 class="pricing__title centered"><%= _('Pricing') %></h1>
 
-<%# Adopt the core @prices partial (0.45 Prices API). The previous bespoke tier %>
-<%# block read @plan (0.44 Plans API), which PlansController#index no longer sets, %>
-<%# so it raised on nil. Core _pricing_tiers iterates @prices, rendering one tier %>
-<%# per STRIPE_PRICES entry (monthly + annual). %>
+<%# Theme _pricing_tiers partial (0.45 Prices API): renders a single Professional %>
+<%# tier from @prices[0] (monthly) with an "or {{amount}} annually" link to %>
+<%# @prices[1] (annual), matching the WhatDoTheyKnow pricing layout. STRIPE_PRICES %>
+<%# is ordered monthly-then-annual in every environment. %>
 <%= render partial: 'alaveteli_pro/plans/pricing_tiers' %>
 
 <p class="pricing__free-message">

--- a/lib/views/alaveteli_pro/plans/show.html.erb
+++ b/lib/views/alaveteli_pro/plans/show.html.erb
@@ -1,0 +1,120 @@
+<%# Theme override of core alaveteli_pro/plans/show. Adds a live coupon price %>
+<%# preview: DOM hooks on the plan overview + coupon field, driven by %>
+<%# alaveteli_pro/coupon_preview.js against the plan_coupon_preview endpoint. %>
+<%# NOTE: this is a wholesale copy of the core view, so future core edits to %>
+<%# show.html.erb will not flow through automatically. %>
+<% content_for :javascript_head do %>
+  <script src="https://js.stripe.com/v3/"></script>
+<% end %>
+
+<% content_for :javascript do %>
+  <%= javascript_tag do %>
+    AlaveteliPro.stripe_publishable_key = '<%= AlaveteliConfiguration.stripe_publishable_key %>';
+    AlaveteliPro.stripe_local = '<%= stripe_locale %>';
+  <% end %>
+
+  <%= javascript_include_tag 'alaveteli_pro/stripe' %>
+  <%= javascript_include_tag 'alaveteli_pro/coupon_preview' %>
+<% end %>
+
+<div class="inner-canvas settings">
+
+  <div class="inner-canvas-header">
+    <div class="row">
+      <h1><%= _('Upgrade account') %></h1>
+    </div>
+  </div>
+
+  <div class="inner-canvas-body">
+    <div class="row">
+      <div class="settings-left-column">
+      </div>
+      <div class="settings-right-column">
+        <%= form_tag(subscriptions_path, id: 'js-stripe-subscription-form', class: 'stripe-form') do %>
+        <div class="settings__section">
+          <h3><%= _('Selected plan') %></h3>
+          <div class="plan-overview">
+            <div class="plan-overview__desc">
+              <%= @price.product.name %>
+            </div>
+            <div class="plan-overview__amount"
+                 id="js-plan-amount"
+                 data-original="<%= format_currency(@price.unit_amount_with_tax, no_cents_if_whole: true) %>">
+              <span class="plan-overview__original" id="js-plan-original" hidden></span>
+              <span class="plan-overview__price" id="js-plan-price"><%= format_currency(@price.unit_amount_with_tax, no_cents_if_whole: true) %></span>
+              <%= billing_frequency(@price) %>
+              <p class="plan-overview__saving" id="js-plan-saving" hidden></p>
+            </div>
+          </div>
+        </div>
+
+        <div class="settings__section">
+          <div class="plan-coupon" data-preview-url="<%= plan_coupon_preview_path(@price.to_param) %>">
+            <label class="form_label" for="coupon_code"><%= _('Do you have a coupon code?') %></label>
+            <%= text_field_tag 'coupon_code', params[:coupon_code] %>
+            <p class="plan-coupon__feedback" id="js-coupon-feedback" role="status" aria-live="polite"></p>
+          </div>
+          <div class="card-details">
+            <label class="form_label"><%= _('Card details') %></label>
+            <div id="card-element"></div>
+          </div>
+        </div>
+
+        <div class="settings__section">
+          <h3><%= _('Terms and conditions') %></h3>
+          <div class="settings__terms">
+            <div class="settings__terms-content">
+              <%= render partial: 'alaveteli_pro/pages/legal' %>
+            </div>
+          </div>
+          <div class="settings__terms__accept">
+            <label for="js-pro-signup-terms">
+              <input type="checkbox" id="js-pro-signup-terms" required />
+               <%= _('I have read and accepted these terms and conditions') %>
+             </label>
+           </div>
+        </div>
+
+        <div class="settings__section">
+          <%= hidden_field_tag 'price_id', @price.to_param %>
+          <%= submit_tag _('Subscribe'), id: 'js-stripe-submit', disabled: true, data: { disable_with: 'Processing...' } %>
+          <%= link_to _('Cancel'), pro_plans_path, class: 'settings__cancel-button' %>
+          <p id="card-errors"></p>
+
+          <noscript>
+            <div id="error">
+              <p>
+                <%= _('Continuing with checkout requires your browser to have ' \
+                      'JavaScript enabled.') %>
+              </p>
+            </div>
+          </noscript>
+        </div>
+        <% end %>
+
+        <% if feature_enabled?(:pro_pricing_faqs) %>
+          <div class="settings__section">
+            <div class="pricing__faqs settings__faqs">
+              <h3>Frequently Asked Questions</h3>
+              <dl class="pricing__faqs__list">
+                <dt class="faqs__term">How do I cancel my account?</dt>
+                <dd class="faqs__def">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at porttitor orci, nec sollicitudin turpis. Donec vel nisl justo. Praesent blandit ex ut massa faucibus, cursus tincidunt dui consectetur. In suscipit lorem felis. Sed elementum, augue euismod dignissim vulputate, ligula elit blandit sem, non vehicula nisl turpis ultricies nisi. Integer accumsan luctus hendrerit.</dd>
+
+                 <dt class="faqs__term">What does my subscription fee go towards?</dt>
+                 <dd class="faqs__def">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at porttitor orci, nec sollicitudin turpis. Donec vel nisl justo. Praesent blandit ex ut massa faucibus, cursus tincidunt dui consectetur. In suscipit lorem felis. Sed elementum, augue euismod dignissim vulputate, ligula elit blandit sem, non vehicula nisl turpis ultricies nisi. Integer accumsan luctus hendrerit.</dd>
+
+                <dt class="faqs__term">How do I change my payment details?</dt>
+                <dd class="faqs__def">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at porttitor orci, nec sollicitudin turpis. Donec vel nisl justo. Praesent blandit ex ut massa faucibus, cursus tincidunt dui consectetur. In suscipit lorem felis. Sed elementum, augue euismod dignissim vulputate, ligula elit blandit sem, non vehicula nisl turpis ultricies nisi. Integer accumsan luctus hendrerit.</dd>
+
+                <dt class="faqs__term">I’ve got a voucher code</dt>
+                <dd class="faqs__def">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at porttitor orci, nec sollicitudin turpis. Donec vel nisl justo. Praesent blandit ex ut massa faucibus, cursus tincidunt dui consectetur. In suscipit lorem felis. Sed elementum, augue euismod dignissim vulputate, ligula elit blandit sem, non vehicula nisl turpis ultricies nisi. Integer accumsan luctus hendrerit.</dd>
+              </dl>
+            </div>
+          </div>
+        <% end %>
+
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -29,7 +29,7 @@ to your request '<%=request_link(@info_request) %>'?
 <p>In an internal review the request goes back to the original authority but gets handled by a different, often more senior, officer.</p>
 <p>
 <% if !@info_request.nil? %>
-    <%= link_to "Request an internal review", new_request_followup_path(:request_id => @info_request.id) + "?internal_review=1#followup", :class => 'link_button_green request-internal-review-action' %> and then write a message asking the authority to review your request.
+    <%= link_to "Request an internal review", new_request_followup_path(:request_url_title => @info_request.url_title) + "?internal_review=1#followup", :class => 'link_button_green request-internal-review-action' %> and then write a message asking the authority to review your request.
 <% else %>
     At the bottom of the relevant request page on <%= site_name %> choose
     "request an internal review". Then write a message asking for an internal

--- a/lib/views/request/_act.html.erb
+++ b/lib/views/request/_act.html.erb
@@ -13,7 +13,7 @@
 <% if AlaveteliConfiguration::enable_widgets %>
   <div class="act_link">
     <i class="act-link-icon act-link-icon--widget"></i>
-    <%= link_to _("Create a widget for this request"), new_request_widget_path(info_request) %>
+    <%= link_to _("Create a widget for this request"), new_request_widget_path(info_request.url_title) %>
   </div>
 <% end %>
 

--- a/spec/coupon_preview_parity_spec.rb
+++ b/spec/coupon_preview_parity_spec.rb
@@ -131,12 +131,19 @@ RSpec.describe AlaveteliPro::PlansController, type: :controller do
   # THE discriminating case. With an Integer percent_off, Ruby's integer division
   # already truncates, so rounding the result is a no-op and a rounding bug hides
   # completely. Real Stripe sends a fractional percent_off (percent_off_precise),
-  # and only then do "round the reduction" and "don't" give different answers:
-  # 4499 * 12.5 / 100 is 562.375, which rounds to 562.
+  # and only then do "round the reduction" and "don't" diverge.
+  #
+  # 900 at 12.5% off with 10% tax is chosen deliberately: it is one of the price
+  # points where the divergence survives formatting and a person sees a different
+  # price. Rounding the reduction gives 866 (£8.66); not rounding gives 866.5,
+  # which formats as £8.67. Most price points hide the difference behind
+  # format_currency's rounding to the cent, so a spec that only asserted the
+  # rendered string would pass on the wrong arithmetic at most values - hence the
+  # numeric assertion as well.
   context 'with a fractional percent_off' do
     let!(:price) do
       stripe_helper.create_price(
-        id: 'pro', product: product.id, unit_amount: 4499
+        id: 'pro', product: product.id, unit_amount: 900
       )
     end
 
@@ -149,6 +156,21 @@ RSpec.describe AlaveteliPro::PlansController, type: :controller do
     it 'computes the same amount upstream would display' do
       @coupon_code = 'TWELVEHALF'
       expect(theme_gross('pro', @coupon_code)).to eq upstream_gross('pro')
+    end
+
+    it 'renders the same price a person would be shown after purchase' do
+      @coupon_code = 'TWELVEHALF'
+      get :coupon_preview,
+          params: { price_id: 'pro', coupon_code: @coupon_code }
+
+      expected = controller.helpers
+                           .format_currency(upstream_gross('pro'), no_cents_if_whole: true)
+
+      expect(JSON.parse(response.body).fetch('amount')).to eq expected
+      # £ because iso_currency_code is stubbed to GBP above. Rounding the
+      # reduction would render £8.66 here - a different price, not a rounding
+      # curiosity.
+      expect(expected).to eq '£8.67'
     end
   end
 

--- a/spec/coupon_preview_parity_spec.rb
+++ b/spec/coupon_preview_parity_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+# Guards the one thing the rest of coupon_preview_spec.rb cannot: that the
+# theme's pre-purchase preview arithmetic agrees with the figure Alaveteli itself
+# shows for the same price and coupon after purchase.
+#
+# The preview has to re-implement the maths because
+# AlaveteliPro::Subscription::Discount mixes into a Subscription and cannot be
+# called against a bare Price + Coupon. Duplicated arithmetic drifts, and the
+# other specs pin literal expected amounts, so they would keep passing while the
+# two implementations diverged. This spec compares them directly instead: if
+# upstream changes coupon_reduction or Taxable, this fails.
+#
+# A full "preview == amount Stripe charges" test is not achievable under
+# stripe-ruby-mock 4.0.0: its invoice maths ignores tax_percent and inverts
+# percent-coupon discounts, and latest_invoice is built from empty line items.
+# So this compares the two application-side calculations, and the real
+# end-to-end check belongs on staging with a Stripe test card.
+#
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(
+  File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper')
+)
+require 'stripe_mock'
+
+RSpec.describe AlaveteliPro::PlansController, type: :controller do
+  before { StripeMock.start }
+  after { StripeMock.stop }
+
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  let(:product) { stripe_helper.create_product }
+  let(:currency) { 'GBP' }
+  let(:user) { FactoryBot.create(:user) }
+
+  # Upstream's calculation, reached the way upstream reaches it: an object that
+  # mixes in AlaveteliPro::Subscription::Discount and exposes the same `plan` and
+  # `discount` a real Subscription would. Including the module brings Taxable and
+  # `tax :discounted_amount` with it, so #discounted_amount_with_tax here is the
+  # identical code path used by
+  # app/views/alaveteli_pro/subscriptions/_subscription.html.erb.
+  #
+  # Note `plan`, not `price`. AlaveteliPro::Subscription defines #price but not
+  # #plan, so Discount#discounted_amount's `plan.amount` falls through
+  # method_missing to Stripe's legacy single-item subscription.plan, where the
+  # attribute is `amount` rather than `unit_amount`. For a single-price
+  # subscription the two hold the same value, which is why the theme reading
+  # price.unit_amount is equivalent - this spec is what proves that stays true.
+  let(:upstream_calculator) do
+    Class.new do
+      include AlaveteliPro::Subscription::Discount
+
+      attr_reader :plan, :discount, :trial_start, :trial_end
+
+      def initialize(amount, coupon)
+        @plan = Struct.new(:amount).new(amount)
+        @discount = Struct.new(:coupon).new(coupon)
+      end
+    end
+  end
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:stripe_tax_rate).and_return('0.10')
+    allow(AlaveteliConfiguration)
+      .to receive(:iso_currency_code).and_return(currency)
+    sign_in user
+  end
+
+  # Compare the raw minor-unit numbers, NOT the strings the endpoint renders.
+  # format_currency rounds to the cent, which masks exactly the sub-cent
+  # divergence this spec exists to catch.
+  def theme_gross(price_id, coupon_code)
+    get :coupon_preview,
+        params: { price_id: price_id, coupon_code: coupon_code }
+    controller.send(:coupon_discounted_gross,
+                    AlaveteliPro::Price.retrieve(price_id),
+                    AlaveteliPro::Coupon.retrieve(coupon_code))
+  end
+
+  def upstream_gross(price_id)
+    price = AlaveteliPro::Price.retrieve(price_id)
+    coupon = AlaveteliPro::Coupon.retrieve(@coupon_code)
+    upstream_calculator
+      .new(price.unit_amount, coupon).discounted_amount_with_tax
+  end
+
+  # 4500 with a 50% coupon divides evenly, so this passes either side of the
+  # rounding question. It is here to prove the harness itself is sound - if this
+  # fails, the comparison is wrong rather than the arithmetic.
+  context 'with a discount that divides evenly' do
+    let!(:price) do
+      stripe_helper.create_price(
+        id: 'pro', product: product.id, unit_amount: 4500
+      )
+    end
+
+    let!(:coupon) do
+      stripe_helper.create_coupon(
+        id: 'HALF', percent_off: 50, amount_off: nil, currency: nil
+      )
+    end
+
+    it 'computes the same amount upstream would display' do
+      @coupon_code = 'HALF'
+      expect(theme_gross('pro', @coupon_code)).to eq upstream_gross('pro')
+    end
+  end
+
+  # The discriminating case. 4499 * 50 / 100 is 2249.5, so an implementation that
+  # rounds the reduction and one that does not disagree by a cent. This is what
+  # caught the original divergence, and what will catch it coming back.
+  context 'with a discount that does not divide evenly' do
+    let!(:price) do
+      stripe_helper.create_price(
+        id: 'pro', product: product.id, unit_amount: 4499
+      )
+    end
+
+    let!(:coupon) do
+      stripe_helper.create_coupon(
+        id: 'HALF', percent_off: 50, amount_off: nil, currency: nil
+      )
+    end
+
+    it 'computes the same amount upstream would display' do
+      @coupon_code = 'HALF'
+      expect(theme_gross('pro', @coupon_code)).to eq upstream_gross('pro')
+    end
+  end
+
+  # THE discriminating case. With an Integer percent_off, Ruby's integer division
+  # already truncates, so rounding the result is a no-op and a rounding bug hides
+  # completely. Real Stripe sends a fractional percent_off (percent_off_precise),
+  # and only then do "round the reduction" and "don't" give different answers:
+  # 4499 * 12.5 / 100 is 562.375, which rounds to 562.
+  context 'with a fractional percent_off' do
+    let!(:price) do
+      stripe_helper.create_price(
+        id: 'pro', product: product.id, unit_amount: 4499
+      )
+    end
+
+    let!(:coupon) do
+      stripe_helper.create_coupon(
+        id: 'TWELVEHALF', percent_off: 12.5, amount_off: nil, currency: nil
+      )
+    end
+
+    it 'computes the same amount upstream would display' do
+      @coupon_code = 'TWELVEHALF'
+      expect(theme_gross('pro', @coupon_code)).to eq upstream_gross('pro')
+    end
+  end
+
+  # amount_off takes a different branch of coupon_reduction, and is the one
+  # coupon shape where no division happens at all.
+  context 'with a fixed amount_off coupon' do
+    let!(:price) do
+      stripe_helper.create_price(
+        id: 'pro', product: product.id, unit_amount: 4499
+      )
+    end
+
+    let!(:coupon) do
+      stripe_helper.create_coupon(
+        id: 'TENOFF', amount_off: 1000, currency: currency.downcase
+      )
+    end
+
+    it 'computes the same amount upstream would display' do
+      @coupon_code = 'TENOFF'
+      expect(theme_gross('pro', @coupon_code)).to eq upstream_gross('pro')
+    end
+  end
+end

--- a/spec/coupon_preview_rate_limit_spec.rb
+++ b/spec/coupon_preview_rate_limit_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Throttling for the theme's coupon preview endpoint.
+#
+# The endpoint reports valid / invalid / expired per request and calls Stripe
+# each time, so without a limit it enumerates the coupon namespace cheaply and
+# amplifies against Stripe's rate limit. Limiting is per user rather than per IP
+# because the action requires a login, and an IP key would penalise everyone
+# behind a shared address.
+#
+# The limiter is stubbed rather than exercised for real: it is PStore backed and
+# spec_helper only cleans up the signup limiter, so a real one would leave state
+# behind between examples and could make this order-dependent.
+#
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(
+  File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper')
+)
+require 'stripe_mock'
+
+RSpec.describe AlaveteliPro::PlansController, type: :controller do
+  before { StripeMock.start }
+  after { StripeMock.stop }
+
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  let(:product) { stripe_helper.create_product }
+  let(:user) { FactoryBot.create(:user) }
+  let(:limiter) { double(AlaveteliRateLimiter::RateLimiter) }
+
+  let!(:pro_price) do
+    stripe_helper.create_price(
+      id: 'pro', product: product.id, unit_amount: 4500
+    )
+  end
+
+  def json
+    JSON.parse(response.body)
+  end
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:stripe_tax_rate).and_return('0.10')
+    allow(AlaveteliConfiguration).to receive(:iso_currency_code)
+      .and_return('GBP')
+    sign_in user
+    allow(controller).to receive(:coupon_preview_rate_limiter)
+      .and_return(limiter)
+    allow(limiter).to receive(:record!)
+  end
+
+  describe 'GET #coupon_preview' do
+    context 'when the user is under the limit' do
+      before do
+        allow(limiter).to receive(:limit?).and_return(false)
+        get :coupon_preview, params: { price_id: 'pro', coupon_code: 'NOPE' }
+      end
+
+      it 'answers normally' do
+        expect(response).to have_http_status(:ok)
+        expect(json['status']).to eq('invalid')
+      end
+
+      it 'counts the attempt against the user' do
+        expect(limiter).to have_received(:record!).with(user.id)
+      end
+    end
+
+    context 'when the user is over the limit' do
+      before do
+        allow(limiter).to receive(:limit?).and_return(true)
+        get :coupon_preview, params: { price_id: 'pro', coupon_code: 'NOPE' }
+      end
+
+      it 'refuses with 429 and a parseable body' do
+        expect(response).to have_http_status(:too_many_requests)
+        expect(json['status']).to eq('error')
+        expect(json['message']).to be_present
+      end
+
+      it 'does not reveal whether the code exists' do
+        expect(json).not_to have_key('amount')
+        expect(json['status']).not_to eq('invalid')
+      end
+    end
+
+    # The field is cleared and retyped in ordinary use, and a blank code is
+    # answered from the price alone without touching Stripe, so it must not
+    # consume the allowance.
+    context 'with a blank coupon code' do
+      before do
+        allow(limiter).to receive(:limit?).and_return(false)
+        get :coupon_preview, params: { price_id: 'pro', coupon_code: '' }
+      end
+
+      it 'does not count against the limit' do
+        expect(limiter).not_to have_received(:record!)
+      end
+    end
+  end
+end

--- a/spec/coupon_preview_spec.rb
+++ b/spec/coupon_preview_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+# Exercises the theme's live coupon price preview endpoint, added to
+# AlaveteliPro::PlansController in lib/controller_patches.rb and routed in
+# config/custom-routes.rb.
+#
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(
+  File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper')
+)
+require 'stripe_mock'
+
+RSpec.describe AlaveteliPro::PlansController, type: :controller do # rubocop:disable Metrics/BlockLength
+  before { StripeMock.start }
+  after { StripeMock.stop }
+
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  let(:product) { stripe_helper.create_product }
+  let(:currency) { 'GBP' }
+
+  let!(:pro_price) do
+    stripe_helper.create_price(
+      id: 'pro', product: product.id, unit_amount: 4500
+    )
+  end
+
+  let(:user) { FactoryBot.create(:user) }
+
+  def json
+    JSON.parse(response.body)
+  end
+
+  # Format via the app's own helper so expectations track exactly what the
+  # endpoint produces (rather than reimplementing Money formatting here).
+  def money(cents)
+    controller.helpers.format_currency(cents, no_cents_if_whole: true)
+  end
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:stripe_tax_rate).and_return('0.10')
+    allow(AlaveteliConfiguration)
+      .to receive(:iso_currency_code).and_return(currency)
+  end
+
+  # Verifies the theme's show.html.erb override renders the DOM hooks the
+  # coupon preview JS binds to, and that the plan_coupon_preview route helper
+  # resolves (i.e. the custom route is loaded).
+  describe 'GET #show' do
+    render_views
+
+    before do
+      sign_in FactoryBot.create(:user)
+      get :show, params: { id: 'pro' }
+    end
+
+    it 'renders the coupon preview hooks and endpoint URL' do
+      expect(response.body)
+        .to include('data-preview-url="/plans/pro/coupon_preview"')
+      expect(response.body).to include('id="js-plan-price"')
+      expect(response.body).to include('id="js-coupon-feedback"')
+    end
+
+    it 'includes the coupon preview script' do
+      expect(response.body).to include('alaveteli_pro/coupon_preview')
+    end
+  end
+
+  describe 'GET #coupon_preview' do
+    context 'without a signed-in user' do
+      before do
+        get :coupon_preview, params: { price_id: 'pro', coupon_code: 'X' }
+      end
+
+      it 'redirects to the login form' do
+        expect(response).to redirect_to(signin_path(token: PostRedirect.last.token))
+      end
+    end
+
+    context 'with a signed-in user' do
+      before { sign_in user }
+
+      context 'with a blank coupon code' do
+        before do
+          get :coupon_preview, params: { price_id: 'pro', coupon_code: '' }
+        end
+
+        it 'returns the list price unchanged' do
+          expect(json['status']).to eq('empty')
+          expect(json['amount']).to eq(money(4950)) # 4500 + 10% tax
+        end
+      end
+
+      context 'with a valid percent_off coupon' do
+        before do
+          # StripeMock's default coupon carries amount_off/currency too; null
+          # them so this is a pure percent_off coupon like real Stripe returns.
+          stripe_helper.create_coupon(
+            id: 'HALF', percent_off: 50, amount_off: nil, currency: nil
+          )
+          get :coupon_preview, params: { price_id: 'pro', coupon_code: 'HALF' }
+        end
+
+        it 'returns the discounted price with tax on the post-discount net' do
+          # net 4500 - 50% = 2250; + 10% tax = 2475. Original 4950. Saving 2475.
+          expect(json['status']).to eq('valid')
+          expect(json['amount']).to eq(money(2475))
+          expect(json['original']).to eq(money(4950))
+          expect(json['saving']).to eq("You save #{money(2475)}")
+        end
+      end
+
+      context 'with a valid amount_off coupon' do
+        before do
+          stripe_helper.create_coupon(
+            id: 'TENOFF', amount_off: 1000, currency: currency.downcase
+          )
+          get :coupon_preview, params: { price_id: 'pro', coupon_code: 'TENOFF' }
+        end
+
+        it 'subtracts the amount then applies tax' do
+          # net 4500 - 1000 = 3500; + 10% tax = 3850.
+          expect(json['status']).to eq('valid')
+          expect(json['amount']).to eq(money(3850))
+        end
+      end
+
+      context 'with a coupon that discounts the whole price' do
+        before do
+          stripe_helper.create_coupon(
+            id: 'FREE', percent_off: 100, amount_off: nil, currency: nil
+          )
+          get :coupon_preview, params: { price_id: 'pro', coupon_code: 'FREE' }
+        end
+
+        it 'clamps at zero rather than going negative' do
+          expect(json['status']).to eq('valid')
+          expect(json['amount']).to eq(money(0))
+        end
+      end
+
+      context 'with an unknown coupon code' do
+        before do
+          get :coupon_preview, params: { price_id: 'pro', coupon_code: 'NOPE' }
+        end
+
+        it 'reports the code as invalid' do
+          expect(json['status']).to eq('invalid')
+          expect(json['message']).to eq('Coupon code is invalid.')
+        end
+      end
+
+      context 'with a coupon that exists but is no longer valid' do
+        before do
+          allow(AlaveteliPro::Coupon).to receive(:retrieve)
+            .and_return(double(valid: false))
+          get :coupon_preview, params: { price_id: 'pro', coupon_code: 'EXPIRED' }
+        end
+
+        it 'reports the code as expired' do
+          expect(json['status']).to eq('expired')
+          expect(json['message']).to eq('Coupon code has expired.')
+        end
+      end
+
+      context 'with an amount_off coupon in a different currency' do
+        before do
+          stripe_helper.create_coupon(
+            id: 'USDOFF', amount_off: 1000, currency: 'usd'
+          )
+          get :coupon_preview, params: { price_id: 'pro', coupon_code: 'USDOFF' }
+        end
+
+        it 'refuses to apply a mismatched-currency discount' do
+          expect(json['status']).to eq('invalid')
+        end
+      end
+
+      context 'with an unknown price_id' do
+        before do
+          get :coupon_preview, params: { price_id: 'nope', coupon_code: 'HALF' }
+        end
+
+        it 'returns not found' do
+          expect(response).to have_http_status(:not_found)
+          expect(json['status']).to eq('error')
+        end
+      end
+    end
+  end
+end

--- a/spec/coupon_preview_spec.rb
+++ b/spec/coupon_preview_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe AlaveteliPro::PlansController, type: :controller do # rubocop:dis
     end
   end
 
-  describe 'GET #coupon_preview' do
+  describe 'GET #coupon_preview' do # rubocop:disable Metrics/BlockLength
     context 'without a signed-in user' do
       before do
         get :coupon_preview, params: { price_id: 'pro', coupon_code: 'X' }
@@ -173,6 +173,56 @@ RSpec.describe AlaveteliPro::PlansController, type: :controller do # rubocop:dis
 
         it 'refuses to apply a mismatched-currency discount' do
           expect(json['status']).to eq('invalid')
+        end
+      end
+
+      # A coupon carrying an `interval` metadata restriction (e.g. a
+      # monthly-only coupon) must only preview against a price with a matching
+      # billing interval. Stripe's product-scoped applies_to can't distinguish
+      # the monthly and annual prices within the Pro product, so the restriction
+      # lives in coupon metadata and is enforced here and at checkout (see
+      # lib/controller_patches.rb).
+      context 'with a coupon restricted to the matching interval' do
+        before do
+          # pro_price is monthly (StripeMock defaults recurring.interval to
+          # "month").
+          stripe_helper.create_coupon(
+            id: 'MONTHLYONLY', percent_off: 50, amount_off: nil, currency: nil,
+            metadata: { interval: 'month' }
+          )
+          get :coupon_preview,
+              params: { price_id: 'pro', coupon_code: 'MONTHLYONLY' }
+        end
+
+        it 'previews the discount' do
+          expect(json['status']).to eq('valid')
+          expect(json['amount']).to eq(money(2475)) # 4500 - 50% + 10% tax
+        end
+      end
+
+      context 'with a coupon restricted to a non-matching interval' do
+        let!(:annual_price) do
+          stripe_helper.create_price(
+            id: 'annual_price', product: product.id, unit_amount: 45_000,
+            recurring: { interval: 'year', interval_count: 1 }
+          )
+        end
+
+        before do
+          allow(AlaveteliConfiguration).to receive(:stripe_prices)
+            .and_return('pro' => 'pro', 'annual_price' => 'annual')
+          stripe_helper.create_coupon(
+            id: 'MONTHLYONLY', percent_off: 50, amount_off: nil, currency: nil,
+            metadata: { interval: 'month' }
+          )
+          get :coupon_preview,
+              params: { price_id: 'annual', coupon_code: 'MONTHLYONLY' }
+        end
+
+        it 'refuses to apply the coupon to the wrong plan' do
+          expect(json['status']).to eq('invalid')
+          expect(json['message'])
+            .to eq('This coupon code cannot be used with this plan.')
         end
       end
 

--- a/spec/coupon_price_restriction_spec.rb
+++ b/spec/coupon_price_restriction_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# Exercises the theme's checkout-side enforcement of coupon `interval` metadata
+# restrictions, added to AlaveteliPro::SubscriptionsController in
+# lib/controller_patches.rb.
+#
+# Stripe's coupon applies_to is product-scoped only, so it cannot stop a
+# monthly-only coupon from discounting the annual price within the same product.
+# The theme carries the restriction in coupon metadata (`interval`) and blocks
+# the mismatch before a subscription is created.
+#
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(
+  File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper')
+)
+require 'stripe_mock'
+
+RSpec.describe AlaveteliPro::SubscriptionsController,
+               type: :controller, feature: :pro_pricing do
+  before { StripeMock.start }
+  after { StripeMock.stop }
+
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  let(:product) { stripe_helper.create_product }
+  let(:token) { stripe_helper.generate_card_token }
+  let(:user) { FactoryBot.create(:user) }
+
+  # StripeMock defaults recurring.interval to "month".
+  let!(:monthly_price) do
+    stripe_helper.create_price(
+      id: 'pro', product: product.id, unit_amount: 1000
+    )
+  end
+
+  let!(:annual_price) do
+    stripe_helper.create_price(
+      id: 'annual_price', product: product.id, unit_amount: 10_000,
+      recurring: { interval: 'year', interval_count: 1 }
+    )
+  end
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:stripe_prices)
+      .and_return('pro' => 'pro', 'annual_price' => 'annual')
+    allow(AlaveteliConfiguration).to receive(:stripe_tax_rate).and_return('0.0')
+
+    # Restricted to the monthly interval, like a monthly-only coupon.
+    stripe_helper.create_coupon(
+      id: 'MONTHLYONLY', percent_off: 50, amount_off: nil, currency: nil,
+      metadata: { interval: 'month' }
+    )
+
+    sign_in user
+  end
+
+  describe 'POST #create with an interval-restricted coupon' do
+    context 'on the matching (monthly) price' do
+      before do
+        post :create, params: {
+          'stripe_token' => token,
+          'price_id' => 'pro',
+          'coupon_code' => 'MONTHLYONLY'
+        }
+      end
+
+      it 'applies the coupon' do
+        expect(assigns(:subscription).discount.coupon.id).to eq('MONTHLYONLY')
+      end
+
+      it 'subscribes the user' do
+        expect(response).to redirect_to(
+          authorise_subscription_path(assigns(:subscription).id)
+        )
+      end
+    end
+
+    context 'on a non-matching (annual) price' do
+      before do
+        post :create, params: {
+          'stripe_token' => token,
+          'price_id' => 'annual',
+          'coupon_code' => 'MONTHLYONLY'
+        }
+      end
+
+      it 'does not create a subscription' do
+        expect(assigns(:subscription)).to be_nil
+      end
+
+      it 'redirects back to the plan with an error' do
+        expect(flash[:error])
+          .to eq('This coupon code cannot be used with this plan.')
+        expect(response).to redirect_to(plan_path('annual'))
+      end
+    end
+  end
+
+  describe 'POST #create with an unrestricted coupon' do
+    before do
+      stripe_helper.create_coupon(
+        id: 'ANYPLAN', percent_off: 10, amount_off: nil, currency: nil
+      )
+      post :create, params: {
+        'stripe_token' => token,
+        'price_id' => 'annual',
+        'coupon_code' => 'ANYPLAN'
+      }
+    end
+
+    it 'applies to any interval' do
+      expect(assigns(:subscription).discount.coupon.id).to eq('ANYPLAN')
+    end
+  end
+end

--- a/spec/plans_pricing_tiers_spec.rb
+++ b/spec/plans_pricing_tiers_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Exercises the theme's _pricing_tiers.html.erb override (rendered by the
+# plans#index view) against the 0.45 Prices API.
+#
+# The partial builds a single Professional tier from AlaveteliPro::Price.list:
+# the headline price from the first entry and an "or {{amount}} ..." link to
+# the second. Price.list returns nil for any configured Stripe price id that no
+# longer resolves (Stripe::InvalidRequestError), so the view must tolerate both
+# a short list and nil entries rather than raising NoMethodError on the public
+# pricing page.
+#
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(
+  File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper')
+)
+require 'stripe_mock'
+
+RSpec.describe AlaveteliPro::PlansController, type: :controller do
+  render_views
+
+  before { StripeMock.start }
+  after { StripeMock.stop }
+
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  let(:product) { stripe_helper.create_product }
+
+  # StripeMock defaults recurring.interval to "month".
+  let!(:monthly_price) do
+    stripe_helper.create_price(
+      id: 'pro', product: product.id, unit_amount: 1000
+    )
+  end
+
+  let!(:annual_price) do
+    stripe_helper.create_price(
+      id: 'annual_price', product: product.id, unit_amount: 10_000,
+      recurring: { interval: 'year', interval_count: 1 }
+    )
+  end
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:stripe_tax_rate).and_return('0.0')
+    allow(AlaveteliConfiguration)
+      .to receive(:iso_currency_code).and_return('GBP')
+  end
+
+  describe 'GET #index' do
+    context 'with monthly and annual prices configured' do
+      before do
+        allow(AlaveteliConfiguration).to receive(:stripe_prices)
+          .and_return('pro' => 'pro', 'annual_price' => 'annual')
+        get :index
+      end
+
+      it 'renders the headline price' do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to have_css('.price-label__amount')
+      end
+
+      it 'renders the alternative price option linking to the second plan' do
+        expect(response.body)
+          .to have_css('.price-label-option a', text: /annually/)
+      end
+
+      it 'renders the sign up button' do
+        expect(response.body).to have_css('a.button-pop', text: 'Sign up')
+      end
+    end
+
+    context 'with only a single price configured' do
+      before do
+        allow(AlaveteliConfiguration).to receive(:stripe_prices)
+          .and_return('pro' => 'pro')
+        get :index
+      end
+
+      it 'renders the headline price without an alternative option' do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to have_css('.price-label__amount')
+        expect(response.body).to have_no_css('.price-label-option')
+      end
+    end
+
+    context 'when the first configured price no longer resolves in Stripe' do
+      before do
+        # 'missing' has no matching Stripe price, so Price.list yields
+        # [nil, annual_price]; the view must compact it rather than raise.
+        allow(AlaveteliConfiguration).to receive(:stripe_prices)
+          .and_return('missing' => 'pro', 'annual_price' => 'annual')
+        get :index
+      end
+
+      it 'renders the surviving price without raising' do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to have_css('.price-label__amount')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

RTK Issue: https://github.com/openaustralia/righttoknow/issues/999

Stack 3 of 3, split out of `999-feat/release/0.45.8.0`. The new Pro pricing / coupons feature:

- Fix the Pro pricing page for the 0.45 Prices API
- Add a pricing helper and update the pricing-tiers layout
- Add a live coupon price preview on the plan page (JS + controller + route + specs)
- Add a test-data seeding script and document it
- Restrict coupons to a billing interval (+ specs)

Includes RSpec coverage: `spec/coupon_preview_spec.rb`, `spec/coupon_price_restriction_spec.rb`.

## Motivation and Context

Top layer of the split `release/0.45.8.0` stack:

1. Housekeeping → `staging`
2. Theme visual refresh → housekeeping
3. **This PR** (Pro pricing & coupons) → `rtk/release-0.45.8.0/2-theme-refresh`

Requires the Alaveteli 0.45 Prices API, which `staging` is already on — this PR is the theme-side match to that upgrade. Depends on stacks 1/3 and 2/3; bases cascade back toward `staging` as the lower PRs merge (via `gh stack sync`). Merge **bottom-up**.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system — verified this layer's SCSS compiles standalone via the theme's standalone Sass gate.
- [x] Ran automated tests on my own system 
- [x] Confirmed it passed the GitHub actions tests — draft; RuboCop CI runs on PRs targeting `staging`.

## Screenshots (if appropriate):
Not Captured

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
AI use: commit-splitting into this stack and PR authoring were assisted by Claude (claude-opus-4-8). All changes reviewed by a human before merge.
