### PR TITLE
Fix spelling and grammar on public help pages

### DIFF
--- a/lib/views/alaveteli_pro/plans/index.html.erb
+++ b/lib/views/alaveteli_pro/plans/index.html.erb
@@ -156,7 +156,7 @@
       <dt class="faqs__term">How do I change my payment details?</dt>
       <dd class="faqs__def">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at porttitor orci, nec sollicitudin turpis. Donec vel nisl justo. Praesent blandit ex ut massa faucibus, cursus tincidunt dui consectetur. In suscipit lorem felis. Sed elementum, augue euismod dignissim vulputate, ligula elit blandit sem, non vehicula nisl turpis ultricies nisi. Integer accumsan luctus hendrerit.</dd>
 
-      <dt class="faqs__term">I’ve got a vouncher code</dt>
+      <dt class="faqs__term">I’ve got a voucher code</dt>
       <dd class="faqs__def">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at porttitor orci, nec sollicitudin turpis. Donec vel nisl justo. Praesent blandit ex ut massa faucibus, cursus tincidunt dui consectetur. In suscipit lorem felis. Sed elementum, augue euismod dignissim vulputate, ligula elit blandit sem, non vehicula nisl turpis ultricies nisi. Integer accumsan luctus hendrerit.</dd>
     </dl>
   </div>

--- a/lib/views/help/_history.html.erb
+++ b/lib/views/help/_history.html.erb
@@ -5,7 +5,7 @@
     </h2>
 
     <p>
-      We may make changes to this this page from time to time. You can find a
+      We may make changes to this page from time to time. You can find a
       synopsis of changes we've made at our <%= link_to 'GitHub repository',
         @history.commits_url,
         alt: "Link to version history for Right To Know #{@title} (hosted on GitHub)" %>

--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -34,7 +34,7 @@ These are the <%= link_to "parameters", "http://en.wikipedia.org/wiki/URL", :tit
 
 <p>Text added to these URLs must be <em><%= link_to "URL encoded", "http://en.wikipedia.org/wiki/Percent-encoding", :title => "Wikipedia entry for Percent-Encoding" %></em>. You can use the <%= link_to "URL Decoder/Encoder at meyerweb.com", "http://meyerweb.com/eric/tools/dencoder/", :title => "URL Decoder/Encoder" %> as a tool to help encode your text.</p>
 
-<p>Within a URL, multiple parameters are divided with ampersand "&amp;". For example, the following link uses both the <strong>title</strong> and <strong>default_letter</strong> paramaters: <%= link_to new_request_to_body_url(:url_name => "defence", :title => "Test Request", :default_letter => "Test request body"), new_request_to_body_url(:url_name => "defence", :title => "Test Request", :default_letter => "Test request body") %> </p>
+<p>Within a URL, multiple parameters are divided with ampersand "&amp;". For example, the following link uses both the <strong>title</strong> and <strong>default_letter</strong> parameters: <%= link_to new_request_to_body_url(:url_name => "defence", :title => "Test Request", :default_letter => "Test request body"), new_request_to_body_url(:url_name => "defence", :title => "Test Request", :default_letter => "Test request body") %> </p>
 
 <hr>
 

--- a/lib/views/help/credits.html.erb
+++ b/lib/views/help/credits.html.erb
@@ -14,17 +14,17 @@
     Matthew Landauer, Henare Degan, Katherine Szuminska and Alexander Sadleir set up the software that runs Right To Know, collected and collated the information, adapted the help text and generally pushed, prodded and poked until things worked.
 </li>
 <li>
-    Ben Fairless is a volunteer that almost single-handedly took care of the site administration for much of it's early life. He also played a big part in expanding Right To Know to cover states and territories along with Richard Taylor, who did a sterling job of collecting public authority information.
+    Ben Fairless is a volunteer who almost single-handedly took care of the site administration for much of its early life. He also played a big part in expanding Right To Know to cover states and territories along with Richard Taylor, who did a sterling job of collecting public authority information.
 </li>
 <li>
     Guy King's <a href="https://www.openaustraliafoundation.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation to the OpenAustralia Foundation</a>, made building and running this site possible.
 </li>
 <li>
     Our early testers, for checking over all the legal help text and making sure that things worked as expected.
-    And since our launch, the amazingly helpful growing community of people that help each other on this site by leaving annotations on requests.
+    And since our launch, the amazingly helpful growing community of people who help each other on this site by leaving annotations on requests.
 </li>
 <li>
-    Peter Timmins, Australia's foremost authority on Freedom of Information law, has kept us informed through the years with his indespensable blog <a href="http://foi-privacy.blogspot.com.au/">Open and Shut</a>.
+    Peter Timmins, Australia's foremost authority on Freedom of Information law, has kept us informed through the years with his indispensable blog <a href="http://foi-privacy.blogspot.com.au/">Open and Shut</a>.
 </li>
 <li>
     Everyone who has helped look up Freedom of Information email addresses.
@@ -38,7 +38,7 @@
 </li>
 <li>
     Finally, all the officers who will and have answered the requests
-    made through the site. Their diligence, patience and professionalism is
+    made through the site. Their diligence, patience and professionalism are
     what has actually made the information that you see here. Thank them for
     helping make Government more transparent.
 </li>
@@ -93,7 +93,7 @@
         No money changes hands.
     </p>
     <p>
-        <%= link_to "Contact us", help_contact_path %> to become a suppporting organisation.
+        <%= link_to "Contact us", help_contact_path %> to become a supporting organisation.
     </p>
 </dd>
 

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -83,7 +83,7 @@ get in touch with you to assist you with your research or to campaign with you.
   they had already.
 </p>
 <p>
-  If they claim it's becase they want to send you large files, like a video
+  If they claim it's because they want to send you large files, like a video
   file, tell them that they can <a href="/help/officers#large_file">upload it
   directly to a request</a>. If you need a hand then
   <a href="/help/contact">get in touch</a> and we can help out.

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -94,7 +94,7 @@ requesting, which means you will get a reply more quickly.
 If you want information to support an argument or campaign, Freedom of
 Information is a powerful tool. Although you may not use this site to
 run your campaign, we encourage you to use it to get the information you
-need. We also encourage to run your campaign elsewhere - one effective
+need. We also encourage you to run your campaign elsewhere - one effective
 and very easy way is to <%= link_to 'start your own blog',
 "https://wordpress.com/"%>. You are welcome to link to your campaign
 from this site in an annotation to your request (you can make
@@ -136,7 +136,7 @@ keep your request focused</a> and ask for specific existing documents.
 
 <p>
   Making a Freedom of Information request to a Federal or ACT authority is always free.
-  For other states and territories there is an application fee around $30.
+  For other states and territories there is an application fee of around $30.
   However most jurisdictions encourage informal or administrative requests.
 </p>
 

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -21,7 +21,7 @@ to your request '<%=request_link(@info_request) %>'?
 
 <ol>
 <li>Ask for an <strong>internal review</strong> at the public authority.</li>
-<li>Or go to an <strong>external reviewer</strong> such as an an Information Commissioner, Ombudsman, or Tribunal to review the decision or make a complaint.</li>
+<li>Or go to an <strong>external reviewer</strong> such as an Information Commissioner, Ombudsman, or Tribunal to review the decision or make a complaint.</li>
 <li>Either way, also <strong>use other means</strong> to answer your question.</li>
 </ol>
 
@@ -112,7 +112,7 @@ in your complaint or print out the whole page of your request and all attachment
 
 <h1 id="other_means">3. Using other means to answer your question <a class="hover_a" href="#other_means">#</a> </h1>
 
-<p>You can try persuing your problem or your research in other ways.
+<p>You can try pursuing your problem or your research in other ways.
 
 <ul>
 <li>Make a <strong>new Freedom of Information request</strong> for summary information, or for

--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -166,7 +166,7 @@
           </p>
 
           <ul>
-            <li><%= _('Air, water, soil, land, flora and fauna (including how these effect human beings)') %></li>
+            <li><%= _('Air, water, soil, land, flora and fauna (including how these affect human beings)') %></li>
             <li><%= _('Information on emissions and discharges (e.g. noise, ' \
                       'energy, radiation, waste materials)') %></li>
             <li><%= _('Human health and safety') %></li>


### PR DESCRIPTION
## Description

Fixes the spelling and grammar mistakes catalogued in #1023. All 13 items from the issue are addressed, and I have also fixed two person-referring "that" that should read "who" on the credits page (see "Beyond the issue" below).

Everything here is user-visible copy. No logic, no Ruby, no behaviour change.

**Definite typos**

| Page | Fix |
| --- | --- |
| `/help/privacy` | "it's becase they want" to "because" |
| `/help/unhappy` | "such as an an Information Commissioner" to a single "an" |
| `/help/unhappy` | "try persuing your problem" to "pursuing" |
| `/help/credits` | "much of it's early life" to the possessive "its" |
| `/help/credits` | "his indespensable blog" to "indispensable" |
| `/help/credits` | "a suppporting organisation" to "supporting" |
| `/help/api` | "default_letter paramaters" to "parameters" |
| Help page "Changes" footer | "changes to this this page" to a single "this" |
| `/help/requesting` | "We also encourage to run your campaign" to "encourage you to run" |

**Lower confidence items from the issue, all fixed**

| Page | Fix |
| --- | --- |
| `/help/requesting` | "an application fee around $30" to "an application fee of around $30" |
| `/help/credits` | "diligence, patience and professionalism is" to "are", since it is a compound subject. I left the following "what has actually made" alone to keep the change to what the issue asked for |
| New request form | "how these effect human beings" to "affect" |
| Pro plans page | "vouncher" to "voucher" |

**Beyond the issue**

Two more on the credits page, same class of error:

- "Ben Fairless is a volunteer that almost single-handedly took care" to "a volunteer who"
- "the amazingly helpful growing community of people that help each other" to "people who"

A grep across `lib/views/` for person-referring "that" turned up only these two, so this is the complete set rather than an arbitrary sample.

No American spellings were found, and `-ise`/`-isation` spellings were left alone. The theme is consistently Australian English.

## Motivation and Context

Resolves #1023. These are all visible to the public on our help pages. Australian English is our standard.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Tested against the local Docker Alaveteli dev stack (Alaveteli 0.45.8.0, Ruby 3.2.9), with the theme symlink pointed at this branch.

**Confirmed in the served page:** `/help/credits`, `/help/unhappy`, `/help/privacy`, `/help/requesting`, `/help/api`. I fetched each page from the dev stack and checked the rendered HTML: every corrected sentence is present, and a grep for each original typo string returns nothing. The "Changes" footer renders on `/help/credits`, so that fix is confirmed in the page rather than only in source.

**Confirmed by other means, disclosed rather than glossed over:**

- **New request form, "affect human beings".** This is a `_()` string, so I changed the msgid in the theme's `lib/views/request/new.html.erb` and confirmed the gettext fallback returns the corrected text verbatim (`_(new_string) == new_string` is true under locale `en`). The surrounding block only renders for authorities tagged `eir_only`. No Australian authority carries that tag, so this is effectively dead copy on Right To Know and I could not reach it on a real page without tagging a body in the dev database.
- **Pro plans "voucher".** Verified by source inspection only. That block sits behind the `pro_pricing_faqs` feature flag, which is off (confirmed `AlaveteliFeatures.backend.enabled?(:pro_pricing_faqs)` returns false), and the surrounding content is still lorem ipsum placeholder text.

Both of those two pages were loaded anyway (`/new/tgq` and `/pro/pricing`, both 200) to confirm the templates still compile, and both gated blocks were absent from the output as expected.

**Automated tests:** the full theme spec suite passes, 34 examples, 0 failures (`bundle exec rspec lib/themes/righttoknow/spec --exclude-pattern "features/**/*"`). All GitHub Actions checks on this pull request pass too, though it is worth noting that RuboCop lints no ERB and there are no Ruby changes in this branch, so a green RuboCop run says nothing about these changes either way.

## Screenshots (if appropriate):

Not included. The changes are single words inside body copy, so a diff reads more clearly than a screenshot.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Follow-up: two of these originate upstream

Two of the typos are inherited from core Alaveteli rather than introduced here, and our theme files are copies of core's:

- "how these effect human beings" is in `app/views/request/new.html.erb` and `locale/en/app.po` in mysociety/alaveteli.
- "vouncher" is in `app/views/alaveteli_pro/plans/index.html.erb` in mysociety/alaveteli.

Fixing them properly means a PR upstream. This branch only corrects our own copies so the public site reads correctly now. Happy to raise the upstream fixes separately.

## AI use

The changes in this pull request were drafted with AI assistance (Claude Code) and reviewed by me before submitting. I have checked each edit against the source and the rendered pages.

Assisted-by: Claude Code/claude-opus-5
