### PR TITLE
Restore announcement banner text colour

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -143,9 +143,35 @@ a.link_button_green_large {
 
 /* Popups */
 
+// Core's responsive/_popups_style.scss styles .popup as a dark banner and forces
+// white text and white links. We keep the pale green banner, so mirror core's
+// full selector list to restore readable text. The theme loads after core
+// (all.scss:133 vs :20), so matching specificity wins. Keep in sync on upgrade.
 .popup {
   background-color: $notice-bg;
   border: 3px solid $notice-color;
+  color: $body-font-color;
+
+  a,
+  a:visited {
+    color: $link-color;
+  }
+
+  a:hover,
+  a:active,
+  a:focus,
+  a:visited:hover,
+  a:visited:active,
+  a:visited:focus {
+    color: $link-hover-color;
+  }
+
+  // Core's white `.popup a` rule (0,1,1) also captures the dismiss x, which core
+  // otherwise colours via `.popup__close` (0,1,0). Restore that colour so the x
+  // is not swept up by the link rules above.
+  a.popup__close {
+    color: $body-font-color;
+  }
 }
 
 


### PR DESCRIPTION
## Description

The site-wide announcement banner rendered white text on the theme's pale green background, making announcements effectively unreadable.

The theme's `.popup` rule now overrides the text and link colours as well as the background, restoring the colours production shows.

Upstream core commit `c246e8464` ("Popup black version", shipped in **0.45.0.0**) redesigned the banner as a dark panel and added forced colours to `.popup`:

```scss
.popup {
  background-color: #333;
  color: #FFF;                     // new
  a, a:hover, a:active, a:focus, a:visited,
  a:visited:hover, a:visited:active, a:visited:focus { color: #FFF; }   // new
}
```

The theme's `.popup` rule predates that change and overrode **background and border only**. The theme loads after core (`responsive/all.scss:133` vs `:20`), so it won the background — turning `#333` into `$notice-bg` (`#c7dec4`) — but never touched `color`, leaving core's `color: #FFF` unopposed.

Two details worth noting for review:

- **`a:visited` is load-bearing.** Core's `.popup a:visited` has specificity `(0,2,1)`, which beats a lone `.popup a` at `(0,1,1)`. Omitting `:visited` would leave visited links white — the common case for a returning visitor. All eight of core's selectors are mirrored.
- **The dismiss `×` needed restoring too.** Core's white `.popup a` rule `(0,1,1)` also captures `a.popup__close`, which core otherwise colours via `.popup__close` `(0,1,0)`. One known deviation from production: the `×` no longer changes colour on hover, because `.popup a.popup__close` `(0,2,1)` outranks the hover rules. A stable colour seemed preferable to further specificity juggling.

Fixing `.popup` rather than the `.popup--standard` hook also repairs the JS-injected country/locality banner (`general.js`), which shares the same class.

No new Sass variables — this reuses `$body-font-color`, `$link-color`, `$link-hover-color` from `responsive/_settings.scss`, so the banner now follows the same link styling as the rest of the site instead of being a special case.

Theme-only change; no Alaveteli core patch required, as noted in the issue.

## Motivation and Context

Resolves #1025

Measured contrast against the `#c7dec4` banner background:

| | Colour | Ratio | WCAG AA |
|---|---|---|---|
| Before (staging) text and links | `#ffffff` | **1.43:1** | fail |
| After — body text | `#333333` | 8.83:1 | pass |
| After — links | `#0f5e94` | 4.81:1 | pass |
| After — link hover | `#0a4166` | 7.48:1 | pass |

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Verified in four layers, on the local Docker dev stack with a real site-wide announcement (`visibility: everyone`) containing a link:

1. **Compile scope gate** — compiled `responsive/all.scss` with the standalone Sass CLI before and after. The only change in the ~10,300-line output is the popup declarations; nothing else moved.
2. **Served CSS** — confirmed the rules arrive through the real Sprockets pipeline, attributed to the theme file.
3. **Resolved computed styles** — read back over CDP with the cache disabled: background `rgb(199,222,196)`, text `rgb(51,51,51)`, border `3px rgb(98,179,86)`, link `rgb(15,94,148)`, `×` `rgb(51,51,51)`. The link was checked in the **visited** state specifically, to prove the `a:visited` point above.
4. **Compared against production's own stylesheets** — read `document.styleSheets` from the live site. Production has **no** `.popup` colour rule at all, so its text came from `$body-font-color` and its links from the global `a` rules. That is exactly what this change reinstates, rather than approximating it by eye.

Theme specs: `34 examples, 0 failures`.

```
docker compose exec -T app bundle exec rspec lib/themes/righttoknow/spec \
  --exclude-pattern "features/**/*"
```

## Screenshots (if appropriate):

**Before (staging, 0.45.8.0)** — from #1025:

<img width="432" alt="Announcement banner with white text on pale green, unreadable" src="https://github.com/user-attachments/assets/2c718b7e-1ec3-491c-8f7d-f231d544aae4" />

**Production reference** — the appearance being restored, from #1025:

<img width="1019" alt="Announcement banner with dark text and a blue link on pale green" src="https://github.com/user-attachments/assets/8e64f91a-7ff1-42ad-837b-c64f5e0a6900" />

**After (this branch, local dev):** dark text with a blue visited link and a grey dismiss `×`, matching the production reference above.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## AI use

This change was drafted with AI assistance (Claude Code, model `claude-opus-5`) and reviewed by a human before submission. The diagnosis, the CSS change and the verification steps above were produced with that assistance; the banner was then checked manually in a browser by the author. The commit carries an `Assisted-by: Claude Code:claude-opus-5` trailer.
