### PR TITLE
Remove inactive Lorem Ipsum from Pro Index Page

### DIFF
--- a/lib/views/alaveteli_pro/plans/index.html.erb
+++ b/lib/views/alaveteli_pro/plans/index.html.erb
@@ -142,22 +142,3 @@
     </ul>
   </div>
 <% end %>
-
-<% if feature_enabled?(:pro_pricing_faqs) %>
-  <div class="pricing__faqs">
-    <h2 class="pricing__faqs__title">Frequently Asked Questions</h2>
-    <dl class="pricing__faqs__list">
-      <dt class="faqs__term">How do I cancel my account?</dt>
-      <dd class="faqs__def">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at porttitor orci, nec sollicitudin turpis. Donec vel nisl justo. Praesent blandit ex ut massa faucibus, cursus tincidunt dui consectetur. In suscipit lorem felis. Sed elementum, augue euismod dignissim vulputate, ligula elit blandit sem, non vehicula nisl turpis ultricies nisi. Integer accumsan luctus hendrerit.</dd>
-
-      <dt class="faqs__term">What does my subscription fee go towards?</dt>
-      <dd class="faqs__def">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at porttitor orci, nec sollicitudin turpis. Donec vel nisl justo. Praesent blandit ex ut massa faucibus, cursus tincidunt dui consectetur. In suscipit lorem felis. Sed elementum, augue euismod dignissim vulputate, ligula elit blandit sem, non vehicula nisl turpis ultricies nisi. Integer accumsan luctus hendrerit.</dd>
-
-      <dt class="faqs__term">How do I change my payment details?</dt>
-      <dd class="faqs__def">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at porttitor orci, nec sollicitudin turpis. Donec vel nisl justo. Praesent blandit ex ut massa faucibus, cursus tincidunt dui consectetur. In suscipit lorem felis. Sed elementum, augue euismod dignissim vulputate, ligula elit blandit sem, non vehicula nisl turpis ultricies nisi. Integer accumsan luctus hendrerit.</dd>
-
-      <dt class="faqs__term">I’ve got a voucher code</dt>
-      <dd class="faqs__def">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at porttitor orci, nec sollicitudin turpis. Donec vel nisl justo. Praesent blandit ex ut massa faucibus, cursus tincidunt dui consectetur. In suscipit lorem felis. Sed elementum, augue euismod dignissim vulputate, ligula elit blandit sem, non vehicula nisl turpis ultricies nisi. Integer accumsan luctus hendrerit.</dd>
-    </dl>
-  </div>
-<% end %>


### PR DESCRIPTION
## Description
Removes Lorem Ipsum material from `lib/views/alaveteli_pro/plans/index.html.erb`

## Motivation and Context
The material is from upstream, but is gated against the `pro_pricing_faqs` feature which does not exist. 

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system

Verified that this works on my own system running in Docker

- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):
N/A - This content didn't appear anywhere to begin with

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
