### PR TITLE
Remove branch restriction for Rubocop workflow

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -8,8 +8,6 @@ name: "Rubocop"
 
 on:
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ["staging"]
 
 jobs:
   rubocop:


### PR DESCRIPTION
## Description

Eliminate the branch restriction for the Rubocop workflow on pull requests to allow checks on all branches. This change simplifies the CI process for contributions.

## Motivation and Context

Resolves #1024

This change is required to enable Rubocop checks on all branches, facilitating contributions without being limited to the staging branch.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

N/A

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

