### PR TITLE
Theme updates for Alaveteli 0.46.7.0

### DIFF
--- a/lib/views/general/frontpage.html.erb
+++ b/lib/views/general/frontpage.html.erb
@@ -1,4 +1,4 @@
-<% cache_if_caching_fragments("frontpage-#{@locale}", :expires_in => 5.minutes) do %>
+<% cache_if_caching_fragments("frontpage", expires_in: 5.minutes) do %>
   <%= render :partial => "frontpage_how_it_works" %>
 
   <div id="frontpage_examples" class="frontpage_examples">

--- a/lib/views/request/_state_transition.html.erb
+++ b/lib/views/request/_state_transition.html.erb
@@ -1,8 +1,0 @@
-<% state, text = state_transition %>
-<% id_suffix ||= nil %>
-
-<div class="input-label-aligned">
-  <%= classification_radio_button state, id_suffix: id_suffix %>
-  <i class="icon-standalone icon_<%= state %>"></i>
-  <%= classification_label state, text, id_suffix: id_suffix %>
-</div>


### PR DESCRIPTION
## Description

Theme updates for Alaveteli 0.46.7.0 (openaustralia/alaveteli#55). Two changes:

- `lib/views/general/frontpage.html.erb`: sync the fragment cache key with core — `cache_if_caching_fragments` now appends the locale to the key itself (locale preference moved to a separate cookie in 0.46.0.0), so the override no longer embeds `@locale`.
- `lib/views/request/_state_transition.html.erb`: deleted. Core 0.46.0.0 added icons to classification forms — `classification_label` now renders the `icon-standalone icon_<state>` element this override existed to add, so keeping it would render the icon twice. The theme's `.input-label-aligned` styles use descendant selectors and continue to apply to core's markup.

A completeness check of all 40 theme overrides against the core `0.45.8.0..0.46.7.0` diff found no other overrides needing changes: the remaining "changed" core counterparts are placeholder files whose only change is a typo fix in text the theme replaces, plus a Pro marketing partial whose changed string the theme doesn't carry. Every monkey-patched core symbol (`html_response`, the Pro plans/subscriptions callbacks and ivars, the custom-state hooks, `Legislation.find!`, `Holiday.due_date_from`) was grepped against the 0.46.7.0 tag and survives unchanged, so no patch changes are needed.

## Motivation and Context

Final stage of the staged upgrade tracked in #1005; this jump is #1031.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system

Docker dev stack against openaustralia/alaveteli#55: full theme spec suite green (34 examples, 0 failures — including the four coupon specs under stripe 13 / stripe-ruby-mock 5), and smoke tests of frontpage, help pages, `/help/house_rules`, a request page, body list and search all pass.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.

---
Prepared with AI assistance (Claude Code, claude-fable-5).
