### PR TITLE
Update dead external links across help pages

### DIFF
--- a/lib/views/alaveteli_pro/plans/index.html.erb
+++ b/lib/views/alaveteli_pro/plans/index.html.erb
@@ -90,7 +90,7 @@
         <div class="testimonial">
           <blockquote class="testimonial__content">
             <p>WhatDoTheyKnowPro has transformed my workflow. Managing big stories is so much easier now</p>
-            <cite class="testimonial__source"><img src="http://placehold.it/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
+            <cite class="testimonial__source"><img src="https://placehold.co/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
           </blockquote>
         </div>
       </li>
@@ -99,7 +99,7 @@
         <div class="testimonial">
           <blockquote class="testimonial__content">
             <p>WhatDoTheyKnowPro has transformed my workflow. Managing big stories is so much easier now</p>
-            <cite class="testimonial__source"><img src="http://placehold.it/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
+            <cite class="testimonial__source"><img src="https://placehold.co/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
           </blockquote>
         </div>
       </li>
@@ -108,7 +108,7 @@
         <div class="testimonial">
           <blockquote class="testimonial__content">
             <p>WhatDoTheyKnowPro has transformed my workflow. Managing big stories is so much easier now</p>
-            <cite class="testimonial__source"><img src="http://placehold.it/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
+            <cite class="testimonial__source"><img src="https://placehold.co/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
           </blockquote>
         </div>
       </li>
@@ -117,7 +117,7 @@
         <div class="testimonial">
           <blockquote class="testimonial__content">
             <p>WhatDoTheyKnowPro has transformed my workflow. Managing big stories is so much easier now</p>
-            <cite class="testimonial__source"><img src="http://placehold.it/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
+            <cite class="testimonial__source"><img src="https://placehold.co/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
           </blockquote>
         </div>
       </li>
@@ -126,7 +126,7 @@
         <div class="testimonial">
           <blockquote class="testimonial__content">
             <p>WhatDoTheyKnowPro has transformed my workflow. Managing big stories is so much easier now</p>
-            <cite class="testimonial__source"><img src="http://placehold.it/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
+            <cite class="testimonial__source"><img src="https://placehold.co/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
           </blockquote>
         </div>
       </li>
@@ -135,7 +135,7 @@
         <div class="testimonial">
           <blockquote class="testimonial__content">
             <p>WhatDoTheyKnowPro has transformed my workflow. Managing big stories is so much easier now</p>
-            <cite class="testimonial__source"><img src="http://placehold.it/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
+            <cite class="testimonial__source"><img src="https://placehold.co/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
           </blockquote>
         </div>
       </li>

--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -40,7 +40,7 @@
   </dd>
 
   <dt id="who">Who makes <%= site_name %>? <a href="#who">#</a> </dt>
-  <dd><%= site_name %> is a project of the OpenAustralia Foundation, a charity, and was developed with software by the UK organisation mySociety. It was made possible by a <a href="https://www.openaustraliafoundation.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation from Guy King</a>. If you like what we're doing, then you can <a href="https://donate.oaf.org.au">make a donation</a>.
+  <dd><%= site_name %> is a project of the OpenAustralia Foundation, a charity, and was developed with software by the UK organisation mySociety. It was made possible by a <a href="https://oaf.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation from Guy King</a>. If you like what we're doing, then you can <a href="https://donate.oaf.org.au">make a donation</a>.
   </dd>
 
   <dt id="reporting">

--- a/lib/views/help/credits.html.erb
+++ b/lib/views/help/credits.html.erb
@@ -17,14 +17,14 @@
     Ben Fairless is a volunteer who almost single-handedly took care of the site administration for much of its early life. He also played a big part in expanding Right To Know to cover states and territories along with Richard Taylor, who did a sterling job of collecting public authority information.
 </li>
 <li>
-    Guy King's <a href="https://www.openaustraliafoundation.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation to the OpenAustralia Foundation</a>, made building and running this site possible.
+    Guy King's <a href="https://oaf.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation to the OpenAustralia Foundation</a>, made building and running this site possible.
 </li>
 <li>
     Our early testers, for checking over all the legal help text and making sure that things worked as expected.
     And since our launch, the amazingly helpful growing community of people who help each other on this site by leaving annotations on requests.
 </li>
 <li>
-    Peter Timmins, Australia's foremost authority on Freedom of Information law, has kept us informed through the years with his indispensable blog <a href="http://foi-privacy.blogspot.com.au/">Open and Shut</a>.
+    Peter Timmins, Australia's foremost authority on Freedom of Information law, has kept us informed through the years with his indispensable blog <a href="https://foi-privacy.blogspot.com/">Open and Shut</a>.
 </li>
 <li>
     Everyone who has helped look up Freedom of Information email addresses.
@@ -51,7 +51,7 @@
 <dd>
     <p>Yes please! We're built out of our supporters and volunteers.</p>
     <ul>
-    <li>You can <a href="https://www.openaustraliafoundation.org.au/donate/righttoknow/">make a donation</a>.</li>
+    <li>You can <a href="https://oaf.org.au/donate/righttoknow/">make a donation</a>.</li>
     <li>Help people find successful requests, and monitor performance of authorities, by
     <a href="/categorise/play">playing the categorisation game</a>. </li>
     <li>Help people get the documents they’re after by annotating their requests with suggestions for improvements and ways to overcome objections.</li>
@@ -99,7 +99,7 @@
 
 <dt id="attribution">Attribution <a href="#attribution">#</a> </dt>
 <dd>
-    Some descriptions of public authorities were sourced and adapted from <a href="http://australia.gov.au">australia.gov.au</a> in which the <a href="http://australia.gov.au/about/copyright">text content is licensed</a> under <a href="http://creativecommons.org/licenses/by/3.0/au/">Creative Commons Attribution 3.0 Australia</a>.
+    Some descriptions of public authorities were sourced and adapted from australia.gov.au (now retired) in which the <a href="https://web.archive.org/web/20150214001745/http://www.australia.gov.au/about/copyright">text content was licensed</a> under <a href="https://creativecommons.org/licenses/by/3.0/au/">Creative Commons Attribution 3.0 Australia</a>.
 </dd>
 
 

--- a/lib/views/help/house_rules/_list_of_house_rules.html.erb
+++ b/lib/views/help/house_rules/_list_of_house_rules.html.erb
@@ -35,7 +35,7 @@
     Do not make vexatious requests. This means requests with no real purpose,
     or requests intended to disrupt a public body. The Office of the
     Australian Information Commissioner has
-    <a href="https://www.oaic.gov.au/freedom-of-information/foi-guidelines/part-12-vexatious-applicant-declarations#grounds-for-declaration">
+    <a href="https://www.oaic.gov.au/freedom-of-information/freedom-of-information-guidance-for-government-agencies/foi-guidelines/part-12-vexatious-applicant-declarations">
     published guidance on vexatious behaviour</a>.
   </li>
   <li>

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -42,9 +42,9 @@ publish it widely.
 
 <dt id="pdf">Why should I not send PDF documents in FOI responses? <a href="#pdf">#</a> </dt>
 <dd>
-  The <a href="http://webguide.gov.au/accessibility-usability/accessibility/pdf-accessibility/">Australian Government Webguide</a> makes it very clear that PDF is not an acceptable format for you to use in the delivery of government information:
+  The <a href="https://www.stylemanual.gov.au/content-types/pdf-portable-document-format">Australian Government Style Manual</a> makes it very clear that PDF is not an acceptable format for you to use in the delivery of government information:
   <blockquote>
-    PDF does not yet have approved Sufficient Techniques to claim WCAG 2.0 conformance, so it cannot be ‘relied upon’ in the provision of government information.
+    Only create PDFs if your research shows there are specific needs for this format. &hellip; Create content in HTML pages instead of PDFs.
   </blockquote>
   Write a response in an email as plain text. This is not only a simple and efficient way for you to conform to government guidelines, it is easier and quicker for the recipient to read.
 </dd>

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -26,7 +26,7 @@ email address to them so they can reply to you. You will be told that this is go
 relating to a request you made, an email alert that you have signed up for,
 or for other reasons that you specifically authorise. </p>
 
-<p>You will also receive emails from the <a href="https://www.openaustraliafoundation.org.au/">OpenAustralia Foundation</a>,
+<p>You will also receive emails from the <a href="https://oaf.org.au/">OpenAustralia Foundation</a>,
 the charity that runs <%= site_name %>. You can unsubscribe from these emails without affecting any alerts from <%= site_name %>. </p>
 
 <p> We will never give or sell your email addresses to anyone else, unless we are obliged
@@ -57,7 +57,7 @@ get in touch with you to assist you with your research or to campaign with you.
 <dd>
 <p>Yes, you can use a pseudonym. Be careful though. It might make it impossible to follow up if you think a decision needs to be reviewed.</p>
 
-<p>The Federal Information Commissioner guidelines <a href="http://www.oaic.gov.au/freedom-of-information/applying-the-foi-act/foi-guidelines/part-3-processing-requests-for-access#right">say</a> that "The FOI Act does not require an applicant to disclose or provide proof of their identity" but that the "agency or minister should consider whether collection of information about the applicant's identity is required to assess the request".</p>
+<p>The Federal Information Commissioner guidelines <a href="https://www.oaic.gov.au/freedom-of-information/freedom-of-information-guidance-for-government-agencies/foi-guidelines/part-3-processing-and-deciding-on-requests-foi-access">say</a> that "The FOI Act does not require an applicant to disclose or provide proof of their identity" but that the "agency or minister should consider whether collection of information about the applicant's identity is required to assess the request".</p>
 
 <p>Please do not try to impersonate someone else.</p>
 
@@ -68,7 +68,7 @@ get in touch with you to assist you with your research or to campaign with you.
 <dd>
 <p>An email address is sufficient by law. You don't need to give your postal address.</p>
 <p>
-  If a public authority insists on your full, physical address, <a href="/help/contact">let us know</a>. This website is specifically mentioned in the Federal Information Commissioner's <a href="http://www.oaic.gov.au/freedom-of-information/applying-the-foi-act/foi-guidelines/part-3-processing-requests-for-access#formal">FOI Guidelines</a> because we've been through this before.
+  If a public authority insists on your full, physical address, <a href="/help/contact">let us know</a>. This website is specifically mentioned in the Federal Information Commissioner's <a href="https://www.oaic.gov.au/freedom-of-information/freedom-of-information-guidance-for-government-agencies/foi-guidelines/part-3-processing-and-deciding-on-requests-foi-access">FOI Guidelines</a> because we've been through this before.
 </p>
 </dd>
 

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -227,7 +227,7 @@ then read our page '<a href="/help/unhappy">Unhappy about the response you got?<
   Authorities often add legal boilerplate about Copyright, which at first
   glance implies you may not be able do anything with the information. This is
   likely to be incorrect. For example, the latest
-  <a href="https://www.communications.gov.au/documents/intellectual-property-principles-commonwealth-entities">
+  <a href="https://www.ag.gov.au/rights-and-protections/publications/intellectual-property-principles-commonwealth-entities">
     Intellectual property principles for Commonwealth entities
   </a>
   explicitly encourages reuse.
@@ -262,14 +262,14 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
     <li>
       For <%= link_to "Federal Authorities", list_public_bodies_path(:tag => "federal") %>,
       have a look at the Freedom of Information
-      <a href="https://www.oaic.gov.au/freedom-of-information/foi-guidelines/">guidelines</a>
-      and <a href="https://www.oaic.gov.au/freedom-of-information/guidance-and-advice/fact-sheet-for-foi-practitioners-to-provide-to-agency-staff/">fact sheets that agency staff see</a>
+      <a href="https://www.oaic.gov.au/freedom-of-information/freedom-of-information-guidance-for-government-agencies/foi-guidelines">guidelines</a>
+      and <a href="https://www.oaic.gov.au/freedom-of-information/freedom-of-information-guidance-for-government-agencies/guidance-on-handling-a-freedom-of-information-request">guidance that agency staff see</a>
       on the Information Commissioner's website.
     </li>
     <li>
       For <%= link_to "ACT Authorities", list_public_bodies_path(:tag => "ACT") %>,
       see the website for the Directorate in charge of
-      <a href="http://www.cmd.act.gov.au/functions/foi">Freedom of Information</a>.
+      <a href="https://www.cmtedd.act.gov.au/functions/foi">Freedom of Information</a>.
     </li>
     <li>
       For <%= link_to "NT Authorities", list_public_bodies_path(:tag => "NT") %>,
@@ -279,27 +279,27 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
     <li>
       For <%= link_to "NSW Authorities", list_public_bodies_path(:tag => "NSW") %>,
       information can be found on the
-      <a href="http://www.ipc.nsw.gov.au/resources-public">NSW Information Commissioner website</a>.
+      <a href="https://www.ipc.nsw.gov.au/information-access/individuals">NSW Information Commissioner website</a>.
     </li>
     <li>
       For <%= link_to "Victorian Authorities", list_public_bodies_path(:tag => "VIC") %>,
       information can be found on the
-      <a href="http://www.foi.vic.gov.au/">Victorian Freedom of Information website</a>.
+      <a href="https://ovic.vic.gov.au/freedom-of-information/">Office of the Victorian Information Commissioner website</a>.
     </li>
     <li>
       For <%= link_to "Queensland Authorities", list_public_bodies_path(:tag => "QLD") %>,
       information can be found on the
-      <a href="https://www.oic.qld.gov.au/guidelines/for-community-members/information-sheets-access-and-amendment/accessing-information-held-by-government">Queensland Information Commissioner website</a>.
+      <a href="https://www.oic.qld.gov.au/community/how-to-access-information-from-qld-government">Queensland Information Commissioner website</a>.
     </li>
     <li>
       For <%= link_to "SA Authorities", list_public_bodies_path(:tag => "SA") %>,
       information can be found on the
-      <a href="http://www.archives.sa.gov.au/content/foi-in-sa">State Records' FOI in South Australia</a> pages.
+      <a href="https://www.archives.sa.gov.au/finding-information/sa-government-information/access-records-using-freedom-of-information">State Records' FOI in South Australia</a> pages.
     </li>
     <li>
       For <%= link_to "WA Authorities", list_public_bodies_path(:tag => "WA") %>,
       information can be found on the
-      <a href="http://foi.wa.gov.au/">WA Information Commissioner website</a>.
+      <a href="https://www.wa.gov.au/organisation/office-of-the-information-commissioner">WA Information Commissioner website</a>.
     </li>
     <li>
       For <%= link_to "Tasmanian Authorities", list_public_bodies_path(:tag => "TAS") %>,

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -58,39 +58,39 @@ to your request '<%=request_link(@info_request) %>'?
 <ul>
   <li>
     For <%= link_to "Federal Authorities", list_public_bodies_path(:tag => "federal") %>, contact the
-    <a href="http://www.oaic.gov.au/freedom-of-information/foi-reviews">Federal Information Commissioner</a>.
+    <a href="https://www.oaic.gov.au/freedom-of-information/your-freedom-of-information-rights/freedom-of-information-reviews">Federal Information Commissioner</a>.
   </li>
   <li>
     For <%= link_to "ACT Authorities", list_public_bodies_path(:tag => "ACT") %>, contact the
-    <a href="http://ombudsman.act.gov.au/pages/making-a-complaint/complaints-the-ombudsman-can-investigate/freedom-of-information.php">Ombudsman</a>.
+    <a href="https://www.ombudsman.act.gov.au/accountability-and-oversight/freedom-of-information/foi-complaints-and-reviews">Ombudsman</a>.
   </li>
   <li>
     For <%= link_to "NT Authorities", list_public_bodies_path(:tag => "NT") %>, contact the
-    <a href="http://www.infocomm.nt.gov.au/complaints/ca_1.htm">NT Information Commissioner</a>.
+    <a href="https://infocomm.nt.gov.au/complaints-and-appeals">NT Information Commissioner</a>.
   </li>
   <li>
     For <%= link_to "NSW Authorities", list_public_bodies_path(:tag => "NSW") %>, contact the
-    <a href="http://www.ipc.nsw.gov.au/gipa-reviews">NSW Information Commissioner</a>.
+    <a href="https://www.ipc.nsw.gov.au/information-access/citizens/lodge-review">NSW Information Commissioner</a>.
   </li>
   <li>
     For <%= link_to "Victorian Authorities", list_public_bodies_path(:tag => "VIC") %>, contact the
-    <a href="http://www.foicommissioner.vic.gov.au/home/reviews/">Freedom of Information Commissioner</a>.
+    <a href="https://ovic.vic.gov.au/freedom-of-information/for-the-public/foi-reviews/">Office of the Victorian Information Commissioner</a>.
   </li>
   <li>
     For <%= link_to "Queensland Authorities", list_public_bodies_path(:tag => "QLD") %>, contact the
-    <a href="https://www.oic.qld.gov.au/guidelines/for-community-members/information-sheets-access-and-amendment/explaining-your-review-rights-a-guide-for-applicants">Queensland Information Commissioner</a>.
+    <a href="https://www.oic.qld.gov.au/community/rti-internal-external-review">Queensland Information Commissioner</a>.
   </li>
   <li>
     For <%= link_to "SA Authorities", list_public_bodies_path(:tag => "SA") %>, contact
-    <a href="http://www.ombudsman.sa.gov.au/freedom-of-information/">Ombudsman SA</a>.
+    <a href="https://www.ombudsman.sa.gov.au/freedom-of-information">Ombudsman SA</a>.
   </li>
   <li>
     For <%= link_to "WA Authorities", list_public_bodies_path(:tag => "WA") %>, contact the
-    <a href="http://foi.wa.gov.au/FTP014">WA Information Commissioner</a>.
+    <a href="https://www.wa.gov.au/organisation/office-of-the-information-commissioner/apply-oic-wa-foi-external-review">WA Information Commissioner</a>.
   </li>
   <li>
     For <%= link_to "Tasmanian Authorities", list_public_bodies_path(:tag => "TAS") %>, contact
-    <a href="http://www.ombudsman.tas.gov.au/right_to_information/process">Ombudsman Tasmania</a>.
+    <a href="https://www.ombudsman.tas.gov.au/right-to-information">Ombudsman Tasmania</a>.
   </li>
 </ul>
 

--- a/lib/views/request/_act.html.erb
+++ b/lib/views/request/_act.html.erb
@@ -3,7 +3,7 @@
 <div class="act_link">
   <i class="act-link-icon act-link-icon--medium"></i>
   <%= link_to _("Write about this on Medium"),
-              "http://medium.com/",
+              "https://medium.com/",
               :onclick => track_analytics_event(
                 AnalyticsEvent::Category::OUTBOUND,
                 AnalyticsEvent::Action::MEDIUM_EXIT,


### PR DESCRIPTION
## Description

Replaces 22 dead or broken external links across 9 theme view files. Every external URL in the theme was checked; links that returned 404, pointed at retired domains (NXDOMAIN), or redirected to unrelated content were updated with current equivalents sourced from each site's own live navigation.

Highlights:

- **OAIC** — FOI guidelines were restructured under `freedom-of-information-guidance-for-government-agencies/`. Updated the guidelines index, Part 3 (pseudonyms/postal address, ×2), Part 12 (vexatious applicants), and the FOI reviews page. The retired practitioner fact sheet is replaced with OAIC's current request-handling guidance.
- **State/territory FOI bodies** — updated moved pages for ACT (`cmd.act.gov.au` → `cmtedd.act.gov.au`, plus the ACT Ombudsman FOI complaints page), NT, NSW (IPC), VIC (`foicommissioner.vic.gov.au` domain retired → OVIC), QLD (OIC pages moved under `/community`), SA (State Records + Ombudsman SA), WA (`foi.wa.gov.au` retired → `wa.gov.au` OIC pages) and TAS (Ombudsman Tasmania RTI page).
- **officers help page** — `webguide.gov.au` no longer exists; the PDF guidance now lives in the [Australian Government Style Manual](https://www.stylemanual.gov.au/content-types/pdf-portable-document-format). The quoted passage was updated to match the current text, since the old WCAG 2.0 quote no longer exists anywhere live.
- **credits attribution** — `australia.gov.au/about/copyright` is retired (redirects to myGov), so the licensing attribution now points at a Wayback Machine snapshot and reads in the past tense.
- **Housekeeping** — `openaustraliafoundation.org.au` → canonical `oaf.org.au` (matching the footer), `placehold.it` (retired service) → `placehold.co`, `foi-privacy.blogspot.com.au` → `.com`, `medium.com` → https, and the Commonwealth IP principles moved from Communications to the Attorney-General's Department.

Links that are alive but block automated checkers (mySociety, WhatDoTheyKnow, Unsplash, Medium, several Cloudflare-protected gov.au sites) were verified in a real browser and left unchanged. Code-comment links were left out of scope.

## Motivation and Context

Dead links in our help pages are a poor user experience and undermine trust in the information we provide, particularly the state-by-state guidance on requesting information and seeking reviews. This addresses the current backlog of dead links identified in #870 (the broader question of ongoing automated link monitoring remains open on that issue).

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

Every URL in the diff was re-checked after the change: `curl` (following redirects, real user agent) for most, and a real browser session for sites behind Cloudflare/bot protection, confirming each replacement resolves to the intended page. All 9 modified ERB templates pass an ERB syntax check. No Ruby code was changed.

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Assisted-by: Claude Code/amazon-bedrock/anthropic.claude-fable-5
