### PR TITLE
Rename request browse wording to "request library"

### DIFF
--- a/lib/views/general/_nav_items.html.erb
+++ b/lib/views/general/_nav_items.html.erb
@@ -3,7 +3,7 @@
 </li>
 
 <li class="<%= 'selected' if controller?('request') && !action?('new', 'select_authority') %>">
-  <%= link_to _("View requests"), request_list_successful_path %>
+  <%= link_to _("View request library"), request_list_successful_path %>
 </li>
 
 <li class="<%= 'selected' if controller?('public_body') %>">

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -13,7 +13,7 @@
       <nav class="oaf-footer__links">
         <ul>
           <li><%= link_to 'Make a request', select_authority_path %></li>
-          <li><%= link_to 'Browse requests', request_list_successful_path %></li>
+          <li><%= link_to 'Browse request library', request_list_successful_path %></li>
           <li><%= link_to 'View authorities', list_public_bodies_default_path %></li>
           <% if feature_enabled?(:alaveteli_pro) %>
             <li><%= link_to 'Journalist?', account_request_index_path %></li>

--- a/lib/views/request/list.html.erb
+++ b/lib/views/request/list.html.erb
@@ -1,0 +1,32 @@
+<%= render partial: 'tabs' %>
+
+<div id="header_left" class="header_left">
+  <h1><%= @title %></h1>
+  <%= render :partial => 'request/request_search_form',
+             :locals => { :after_form_fields => render(:partial => 'request/request_filter_form') } %>
+
+  <%= render partial: 'category' if @category %>
+</div>
+
+<div id="header_right" class="sidebar header_right">
+  <h2><%= _("Follow these requests") %></h2>
+  <% if @track_thing %>
+    <%= render :partial => 'track/tracking_links', :locals => { :track_thing => @track_thing, :own_request => false, :location => 'main' } %>
+    <%= render :partial => 'track/rss_feed', :locals => { :track_thing => @track_thing, :location => 'main' } %>
+  <% end %>
+
+  <%= render partial: 'general/search_latest' %>
+  <%= render partial: 'general/help_requests' %>
+</div>
+
+<div style="clear:both"></div>
+
+<div class="results_section">
+  <% if key = request_list_cache_key %>
+    <% cache_if_caching_fragments(key, :expires_in => 5.minutes) do %>
+      <%= render :partial => 'list_results' %>
+    <% end %>
+  <% else %>
+    <%= render :partial => 'list_results' %>
+  <% end %>
+</div>

--- a/lib/views/request/list.html.erb
+++ b/lib/views/request/list.html.erb
@@ -1,3 +1,12 @@
+<%# Override the core "Search requests" title to make clear this is a
+    library of requests (issue #1036). Tag/category listings keep the
+    title set by RequestController#list. %>
+<% unless @tag %>
+  <% @title = @page > 1 ?
+       _("Search request library (page {{count}})", count: @page) :
+       _("Search request library") %>
+<% end %>
+
 <%= render partial: 'tabs' %>
 
 <div id="header_left" class="header_left">


### PR DESCRIPTION
## Description

Renames the wording that points at the request browse page so all three labels agree that what you are browsing is a **library** of requests:

- **Page heading and browser title**: "Search requests" → "Search request library", including the paginated variant ("Search request library (page 2)"). Tag and category listings keep the title set by core's `RequestController#list`.
- **Main navigation**: "View requests" → "View request library" (keeps the verb-first parallelism with "View authorities").
- **Footer**: "Browse requests" → "Browse request library".

The heading string lives in Alaveteli core (set in the controller), so per our convention the core view `app/views/request/list.html.erb` was copied verbatim into the theme at `lib/views/request/list.html.erb` (first commit, from `openaustralia/alaveteli` production branch @ `263b3bc30`, 0.45.8.0-161) and then modified to override `@title` (second commit). A locale (`.po`) override was deliberately not used.

⚠️ Note for the #1031 core upgrade (0.45.8.0 → 0.46.7.0): `lib/views/request/list.html.erb` is now a frozen copy of the core view and will need re-diffing against the new core version.

## Motivation and Context

Feedback proposed making clear that the browse page is a library of requests, continuing the work started in #823 ("update site content to identify OAF as a library"). The issue flagged that the nav, footer, and heading should be decided together rather than changing only the heading.

Resolves #1036. Part of #1006.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system (RuboCop: 32 files inspected, no offenses; ERB templates compile)
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

Before:
<img width="1280" height="900" alt="before-footer" src="https://github.com/user-attachments/assets/fa76fb9b-6463-4314-a859-8f3b55534142" />
<img width="1280" height="900" alt="before-heading-nav" src="https://github.com/user-attachments/assets/1b3e97ff-c671-482b-b1f8-e74c48b7d9a2" />
<img width="1280" height="900" alt="before-page2" src="https://github.com/user-attachments/assets/b7211537-e713-4879-a1b8-2d14ebcff28a" />

After:
<img width="1280" height="900" alt="after-footer" src="https://github.com/user-attachments/assets/a6066c3c-f67d-4abb-bd28-60bd61526e39" />
<img width="1280" height="900" alt="after-heading-nav" src="https://github.com/user-attachments/assets/dfe7a27a-9c93-460c-9156-3a40d5a7006d" />
<img width="1280" height="900" alt="after-page2" src="https://github.com/user-attachments/assets/f354d84a-a9e9-4269-ae9f-1995107fe9fa" />



## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Assisted-by: Claude Code/anthropic.claude-fable-5
