### PR TITLE
Reframe home page copy around the request library

### DIFF
--- a/lib/views/general/_frontpage_hero.html.erb
+++ b/lib/views/general/_frontpage_hero.html.erb
@@ -1,0 +1,24 @@
+<div class="homepage-hero">
+  <div class="row">
+    <div class="hero__intro">
+      <%= render :partial => "frontpage_intro_sentence" %>
+
+      <p class="intro__browse">
+        <%= _("Browse <a href=\"{{requests_url}}\">" \
+              "{{number_of_requests}} requests</a> to " \
+              "<a href=\"{{authorities_url}}\">" \
+              "{{number_of_authorities}} authorities</a>",
+            :requests_url => request_list_successful_path,
+            :number_of_requests => number_with_delimiter(@number_of_requests),
+            :authorities_url => list_public_bodies_default_path,
+            :number_of_authorities => number_with_delimiter(@number_of_authorities)) %>
+      </p>
+    </div>
+
+    <div class="hero__new-request">
+      <div class="new-request__content">
+        <%= render :partial => "new_request" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/views/general/_frontpage_hero.html.erb
+++ b/lib/views/general/_frontpage_hero.html.erb
@@ -4,7 +4,7 @@
       <%= render :partial => "frontpage_intro_sentence" %>
 
       <p class="intro__browse">
-        <%= _("Browse <a href=\"{{requests_url}}\">" \
+        <%= _("Browse a collection of <a href=\"{{requests_url}}\">" \
               "{{number_of_requests}} requests</a> to " \
               "<a href=\"{{authorities_url}}\">" \
               "{{number_of_authorities}} authorities</a>",

--- a/lib/views/general/_frontpage_how_it_works.html.erb
+++ b/lib/views/general/_frontpage_how_it_works.html.erb
@@ -1,0 +1,47 @@
+<div class="homepage-how-it-works" id="learn-more">
+  <div class="row">
+    <div class="homepage-how-it-works__hiw-content">
+      <div class="hiw-content__headings">
+        <h2><%= _("How it works") %></h2>
+        <p class="hiw__subtitle">
+          <%= _("You have the <strong>right</strong> to request information " \
+                "from any publicly-funded body, and get answers. " \
+                "{{site_name}} helps you make a Freedom of Information " \
+                "request. It also publishes all requests online.",
+                :site_name => site_name) %>
+        </p>
+      </div>
+      <div class="hiw-content__steps">
+        <ol class="steps__list row">
+          <li>
+            <div class="steps__step-box">
+              <p><%= _("Use this site to make your request for information – we'll show you how.") %></p>
+            </div>
+            <div class="steps__step-number" aria-hidden="true">
+              <p>1</p>
+            </div>
+          </li>
+          <li>
+            <div class="steps__step-box">
+              <p><%= _("We'll drop you an email as soon as your request gets a response.") %></p>
+            </div>
+            <div class="steps__step-number" aria-hidden="true">
+              <p>2</p>
+            </div>
+          </li>
+          <li>
+            <div class="steps__step-box">
+              <p><%= _("We publish it all online. Great! Now you have your answer, and everybody else can access it too.") %></p>
+            </div>
+            <div class="steps__step-number" aria-hidden="true">
+              <p>3</p>
+            </div>
+          </li>
+        </ol>
+        <div class="learn-more-foi">
+          <%= link_to _("Learn more &rarr;"), help_about_path %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/views/general/_frontpage_how_it_works.html.erb
+++ b/lib/views/general/_frontpage_how_it_works.html.erb
@@ -7,7 +7,8 @@
           <%= _("You have the <strong>right</strong> to request information " \
                 "from any publicly-funded body, and get answers. " \
                 "{{site_name}} helps you make a Freedom of Information " \
-                "request. It also publishes all requests online.",
+                "request. Your request will also become part of our " \
+                "growing library of requests and responses.",
                 :site_name => site_name) %>
         </p>
       </div>

--- a/lib/views/general/_frontpage_requests_list.html.erb
+++ b/lib/views/general/_frontpage_requests_list.html.erb
@@ -1,0 +1,45 @@
+<div id="examples_1" class="latest-requests">
+  <h3>
+    <% if @request_events_all_successful %>
+      <%= _("What information has been released?") %>
+    <% else %>
+      <%= _("What information has been requested?") %>
+    <% end %>
+  </h3>
+
+  <h4>
+    <%= n_("{{site_name}} users have made {{number_of_requests}} request, including:",
+        "{{site_name}} users have made {{number_of_requests}} requests, including:",
+        @number_of_requests,
+        :site_name => site_name,
+        :number_of_requests => number_with_delimiter(@number_of_requests)) %>
+  </h4>
+
+  <ul>
+    <% @request_events.each do |event| %>
+      <li class="request-listing">
+        <div class="request-listing__request-status-icon bottomline icon_<%= event.info_request.calculate_status %> icon-standalone"></div>
+        <div class="request-listing__request-body">
+          <p>
+            <% if @request_events_all_successful %>
+              <%= _("{{public_body_link}} answered a request about",
+                    :public_body_link => public_body_link(event.info_request.public_body)) %>
+            <% else %>
+              <%= _("{{public_body_link}} was sent a request about",
+                    :public_body_link => public_body_link(event.info_request.public_body)) %>
+            <% end %>
+
+            <%= link_to h(event.info_request.title), request_path(event.info_request) %>
+          </p>
+
+          <p class="request-body__time-ago">
+            <%= _('{{length_of_time}} ago',
+                  :length_of_time => time_ago_in_words(event.described_at)) %>
+          </p>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+
+  <%= link_to _("Browse all requests &rarr;"), request_list_path, :class => 'button-secondary' %>
+</div>

--- a/lib/views/general/_frontpage_requests_list.html.erb
+++ b/lib/views/general/_frontpage_requests_list.html.erb
@@ -8,8 +8,8 @@
   </h3>
 
   <h4>
-    <%= n_("{{site_name}} users have made {{number_of_requests}} request, including:",
-        "{{site_name}} users have made {{number_of_requests}} requests, including:",
+    <%= n_("{{site_name}} hosts a collection of {{number_of_requests}} user request, including:",
+        "{{site_name}} hosts a collection of {{number_of_requests}} user requests, including:",
         @number_of_requests,
         :site_name => site_name,
         :number_of_requests => number_with_delimiter(@number_of_requests)) %>


### PR DESCRIPTION
## Description

Reframes the home page copy around Right to Know being a library/collection of requests and responses, per the three blocks in #1035:

1. **Browse line (hero):** "Browse a collection of N requests to N authorities"
2. **"How it works" intro:** "It also publishes all requests online." → "Your request will also become part of our growing library of requests and responses."
3. **Requests list lead-in:** "Right to Know users have made N requests, including:" → "Right to Know hosts a collection of N user requests, including:" (both `n_()` plural forms)

The three core partials (`_frontpage_hero`, `_frontpage_how_it_works`, `_frontpage_requests_list`) are copied verbatim from Alaveteli core (release/0.45.8.0) into `lib/views/general/` in the first commit, then edited in the second, so the diff from core is easy to review. The theme's `prepend_view_path` makes them override core, following the existing `frontpage.html.erb` pattern.

Notes:
- Headings ("How it works", "What information has been released?") are unchanged, so the shared msgid rendered on the Pro marketing pages is unaffected.
- Markup and interpolation are preserved (`<strong>right</strong>`, `{{site_name}}`, link URLs, counts).
- All three partials are byte-identical between 0.45.8.0 and 0.46.7.0, so the pending core upgrade (#1031) is unaffected. They will need re-diffing against core at each future upgrade.
- The two lower blocks sit inside the 5-minute frontpage fragment cache, so allow for that when checking after deploy.

## Motivation and Context

Continues the library reframing started in #823 (which only changed the footer) and is part of #1006. The publication-notice question flagged in the issue was settled by keeping the suggested wording, which still tells requesters their request becomes part of a public collection.

Resolves #1035.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system (ERB templates compile; interpolation keys and markup verified unchanged)
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

**1. Browse line (hero)**

| Before | After |
|---|---|
| <img width="1280" height="360" alt="before-1-browse" src="https://github.com/user-attachments/assets/8831b222-cbd7-4ac3-bac1-1a1a969437d1" /> | <img width="1280" height="360" alt="after-1-browse" src="https://github.com/user-attachments/assets/77558a93-df05-4682-a02c-4ca97edd8f38" /> |

**2. "How it works" intro**

| Before | After |
|---|---|
| <img width="1280" height="210" alt="before-2-how-it-works" src="https://github.com/user-attachments/assets/0e85e638-7f46-4a01-9b36-95d431f85073" /> | <img width="1280" height="210" alt="after-2-how-it-works" src="https://github.com/user-attachments/assets/2d6b80ba-c11a-45ec-a8d6-04a3e8508cce" /> |

**3. Requests list lead-in**

| Before | After |
|---|---|
| <img width="1280" height="250" alt="before-3-requests-list" src="https://github.com/user-attachments/assets/838ef487-76d7-4136-9d21-45d713798e38" /> | <img width="1280" height="250" alt="after-3-requests-list" src="https://github.com/user-attachments/assets/22cc7133-4b62-4ea9-9644-b85ac43b0503" /> |

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

_Assisted-by: OpenCode/anthropic.claude-fable-5_
