### PR TITLE
Reframe Pro feature list in library terms

### DIFF
--- a/lib/views/alaveteli_pro/account_request/_marketing_standard_features.html.erb
+++ b/lib/views/alaveteli_pro/account_request/_marketing_standard_features.html.erb
@@ -1,0 +1,46 @@
+<div class="marketing__section">
+  <div class="marketing__section__heading">
+    <h2>
+      <%= _('Plus, all the power of {{site_name}}', site_name: site_name) %>
+    </h2>
+
+    <p>
+      <%= _('<strong>{{pro_site_name}}</strong> runs on the UK’s ' \
+            'best-known FOI service',
+            pro_site_name: pro_site_name) %>
+    </p>
+  </div>
+
+  <div class="marketing__section__content">
+    <div class="marketing__section__content-items">
+      <ul class="marketing__section__feature-list">
+        <li>
+          <%= _('Up-to-date database of <strong class="marketing-highlight">' \
+                'contact details</strong> for {{authority_count}} authorities',
+                authority_count: PublicBody.is_requestable.count) %>
+        </li>
+
+        <li>
+          <%= _('A <strong class="marketing-highlight">searchable archive' \
+                '</strong> of Freedom of Information requests') %>
+        </li>
+
+        <li>
+          <%= _('<strong class="marketing-highlight">Delivery verification' \
+                '</strong> for proof of receipt') %>
+        </li>
+
+        <li>
+          <%= _('A permanent, searchable, ' \
+                '<strong class="marketing-highlight">public record</strong> ' \
+                'of your request and the responses') %>
+        </li>
+
+        <li>
+          <%= _('<strong class="marketing-highlight">Streamlined process' \
+                '</strong> for requesting internal reviews') %>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/lib/views/alaveteli_pro/account_request/_marketing_standard_features.html.erb
+++ b/lib/views/alaveteli_pro/account_request/_marketing_standard_features.html.erb
@@ -5,8 +5,8 @@
     </h2>
 
     <p>
-      <%= _('<strong>{{pro_site_name}}</strong> runs on the UK’s ' \
-            'best-known FOI service',
+      <%= _('<strong>{{pro_site_name}}</strong> runs on Australia’s ' \
+            'best-known FOI library',
             pro_site_name: pro_site_name) %>
     </p>
   </div>
@@ -15,13 +15,14 @@
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
         <li>
-          <%= _('Up-to-date database of <strong class="marketing-highlight">' \
-                'contact details</strong> for {{authority_count}} authorities',
+          <%= _('Up-to-date <strong class="marketing-highlight">collection ' \
+                'of contact details</strong> for {{authority_count}} ' \
+                'authorities',
                 authority_count: PublicBody.is_requestable.count) %>
         </li>
 
         <li>
-          <%= _('A <strong class="marketing-highlight">searchable archive' \
+          <%= _('A <strong class="marketing-highlight">searchable library' \
                 '</strong> of Freedom of Information requests') %>
         </li>
 

--- a/lib/views/alaveteli_pro/plans/index.html.erb
+++ b/lib/views/alaveteli_pro/plans/index.html.erb
@@ -38,17 +38,17 @@
 <div class="marketing__section">
   <div class="marketing__section__heading">
     <h2><%= _('Plus, all the power of {{site_name}}', site_name: site_name) %></h2>
-    <p><%= _('<strong>{{pro_site_name}}</strong> runs on the UK’s ' \
-             'best-known FOI service',
+    <p><%= _('<strong>{{pro_site_name}}</strong> runs on Australia’s ' \
+             'best-known FOI library',
              pro_site_name: @pro_site_name.html_safe) %></p>
   </div>
   <div class="marketing__section__content">
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
-        <li><%= _('Up-to-date database of <strong class="marketing-highlight">' \
-                  'contact details</strong> for {{authority_count}} authorities',
+        <li><%= _('Up-to-date <strong class="marketing-highlight">collection ' \
+                  'of contact details</strong> for {{authority_count}} authorities',
                   authority_count: PublicBody.is_requestable.count) %></li>
-        <li><%= _('A <strong class="marketing-highlight">searchable archive</strong> of Freedom of Information requests') %></li>
+        <li><%= _('A <strong class="marketing-highlight">searchable library</strong> of Freedom of Information requests') %></li>
         <li><%= _('<strong class="marketing-highlight">Delivery verification</strong> for proof of receipt') %></li>
         <li><%= _('A permanent, searchable, <strong class="marketing-highlight">public record</strong> of your request and the responses') %></li>
         <li><%= _('<strong class="marketing-highlight">Streamlined process</strong> for requesting internal reviews') %></li>

--- a/spec/pro_marketing_wording_spec.rb
+++ b/spec/pro_marketing_wording_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# Guards the "Plus, all the power of Right to Know" marketing section,
+# reframed in library terms (issue #1038). The section renders from two
+# places: the theme's account_request/_marketing_standard_features.html.erb
+# override on /pro, and the theme's plans/index.html.erb on /pro/pricing.
+# Both are asserted here so the pages can't silently diverge.
+#
+# The "public record" bullet is deliberately unchanged: it preserves the
+# notice that requests and responses become public.
+#
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(
+  File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper')
+)
+require 'stripe_mock'
+
+RSpec.shared_examples 'library-framed standard features' do
+  it 'describes the service as a library' do
+    expect(response.body).to include('Australia’s best-known FOI library')
+    expect(response.body).not_to include('best-known FOI service')
+  end
+
+  it 'describes contact details as a collection' do
+    expect(response.body).to include(
+      '<strong class="marketing-highlight">collection of contact ' \
+      'details</strong>'
+    )
+    expect(response.body).not_to include('database of')
+  end
+
+  it 'describes requests as a searchable library' do
+    expect(response.body).to include(
+      '<strong class="marketing-highlight">searchable library</strong>'
+    )
+    expect(response.body).not_to include('searchable archive')
+  end
+
+  it 'keeps the public record notice' do
+    expect(response.body).to include(
+      '<strong class="marketing-highlight">public record</strong>'
+    )
+  end
+end
+
+RSpec.describe AlaveteliPro::AccountRequestController, type: :controller do
+  render_views
+
+  describe 'GET #index' do
+    before { get :index }
+
+    include_examples 'library-framed standard features'
+  end
+end
+
+RSpec.describe AlaveteliPro::PlansController, type: :controller do
+  render_views
+
+  before { StripeMock.start }
+  after { StripeMock.stop }
+
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  let(:product) { stripe_helper.create_product }
+
+  let!(:monthly_price) do
+    stripe_helper.create_price(
+      id: 'pro', product: product.id, unit_amount: 1000
+    )
+  end
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:stripe_tax_rate).and_return('0.0')
+    allow(AlaveteliConfiguration)
+      .to receive(:iso_currency_code).and_return('GBP')
+    allow(AlaveteliConfiguration).to receive(:stripe_prices)
+      .and_return('pro' => 'pro')
+  end
+
+  describe 'GET #index' do
+    before { get :index }
+
+    include_examples 'library-framed standard features'
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reframes the "Plus, all the power of Right to Know" marketing section in library terms, on both pages that render it:

- `/pro` — via a new theme override of core's `alaveteli_pro/account_request/_marketing_standard_features.html.erb`, copied verbatim from core at `263b3bc30` (0.45.8.0-161) in the first commit, then patched in the second so the wording change reviews as a clean diff against core
- `/pro/pricing` — the theme's existing `lib/views/alaveteli_pro/plans/index.html.erb`

Wording changes:

- "runs on the UK's best-known FOI service" → "runs on **Australia's best-known FOI library**" (now hardcoded in the ERBs)
- "Up-to-date database of **contact details**" → "Up-to-date **collection of contact details**" (highlight span widens; the `{{authority_count}}` interpolation is kept)
- "A **searchable archive** of Freedom of Information requests" → "A **searchable library** …"

Deliberate deviations from the issue's suggested text, for reviewer sign-off:

- The "permanent, searchable, **public record** of your request and the responses" bullet is **kept unchanged** rather than softened to "public archive of your requests", to preserve the notice that requests become public.
- As a consequence, "archive" disappears from this section entirely (the suggestion had moved it into the public-record bullet).

Implementation notes:

- The issue recommended overriding these strings in `locale-theme/en/app.po`; per maintainer direction this PR patches the ERBs instead. The theme now owns a copy of the core partial, so future core changes to it won't flow through automatically.
- The `locale-theme/en/app.po:59-60` override of the old `…UK's best-known FOI service` msgid no longer matches anything and is now dead. Left in place as agreed; can be cleaned up separately.
- A new spec asserts both pages render the library wording identically (and pins the kept public-record bullet), so `/pro` and `/pro/pricing` can't silently diverge again.

## Motivation and Context

Continues the work of describing Right to Know as a library rather than a database/archive/record (#823, part of #1006).

Resolves #1038

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system — `bundle exec rspec lib/themes/righttoknow/spec` from an alaveteli core checkout at `263b3bc30` with this branch installed as the theme: 42 examples, 0 failures (includes the 8 new examples in `spec/pro_marketing_wording_spec.rb`)
- [ ] Confirmed it passed the GitHub actions tests

Rubocop passes locally on the new spec file (the only Ruby file touched).

## Screenshots (if appropriate):

Before:
<img width="1280" height="384" alt="before-pro-pricing-section" src="https://github.com/user-attachments/assets/b03c4849-0db7-456b-a36d-cf774d8be766" />

<img width="1280" height="384" alt="before-pro-section" src="https://github.com/user-attachments/assets/4d5b79ab-a23f-45ad-ba37-51bf3ce6c220" />

After:
<img width="1280" height="384" alt="after-pro-pricing-section" src="https://github.com/user-attachments/assets/028fd58d-1de5-4cb0-ab1f-51b038c1179d" />

<img width="1280" height="384" alt="after-pro-section" src="https://github.com/user-attachments/assets/d88aafea-bda6-4514-a5cd-0e71ffd8c74f" />


## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

_Assisted by Claude Code (anthropic.claude-fable-5)._