### PR TITLE
Add Dev Container and Docker dev environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,42 @@
+# Development image for working on the Right to Know theme against
+# openaustralia/alaveteli.
+#
+# Replicates alaveteli's docker/Dockerfile (which we can't build directly
+# because Alaveteli is cloned *inside* this container by setup.sh, after the
+# image is built). If alaveteli's Dockerfile changes, mirror the change here.
+
+ARG RUBY_VERSION=3.2
+FROM ruby:${RUBY_VERSION}-bullseye
+
+ENV DOCKER=1
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && \
+    apt-get install -y \
+    elinks \
+    ghostscript \
+    libmagic-dev \
+    pdftk \
+    poppler-utils \
+    postgresql-client \
+    sendmail \
+    tnef \
+    unrtf \
+    mutt
+
+# Wait-for-it
+RUN git clone https://github.com/vishnubob/wait-for-it.git /tmp/wait-for-it && \
+    chmod +x /tmp/wait-for-it/wait-for-it.sh && \
+    ln -s /tmp/wait-for-it/wait-for-it.sh /bin/wait-for-it
+
+WORKDIR /alaveteli
+RUN git config --global --add safe.directory /alaveteli && \
+    git config --global --add safe.directory /alaveteli/commonlib && \
+    git config --global --add safe.directory /alaveteli-themes/righttoknow
+
+# Pin to the last RubyGems 3.x release. RubyGems 4.0 removed the deprecated
+# Gem::Specification#has_rdoc= method, which the mysociety/ruby-msg fork's
+# gemspec still calls, breaking `bundle`/`Bundler.setup` at boot.
+RUN gem update --system 3.7.2
+
+EXPOSE 3000

--- a/.devcontainer/Dockerfile-postgres
+++ b/.devcontainer/Dockerfile-postgres
@@ -1,0 +1,8 @@
+# Replicates alaveteli's docker/Dockerfile-postgres so the database matches
+# what Alaveteli's own Docker environment provides (en_GB.UTF-8 locale and a
+# UTF-8 template database).
+
+FROM postgres:13.5
+RUN localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
+ENV LANG=en_GB.utf8
+ADD ./createdb.sh /docker-entrypoint-initdb.d/

--- a/.devcontainer/createdb.sh
+++ b/.devcontainer/createdb.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Replicates alaveteli's docker/createdb.sh: creates a UTF-8 template database
+# and the development/test databases Alaveteli expects.
+
+createdb -T template0 -E UTF-8 template_utf8
+psql <<- EOSQL
+  UPDATE pg_database
+  SET datistemplate=true, datallowconn=false
+  WHERE datname='template_utf8';
+EOSQL
+
+createdb -T template_utf8 alaveteli_development
+createdb -T template_utf8 alaveteli_test

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "Right to Know (Alaveteli theme)",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/alaveteli-themes/righttoknow",
+  "onCreateCommand": "/alaveteli-themes/righttoknow/.devcontainer/setup.sh",
+  "forwardPorts": [3000, 1080],
+  "portsAttributes": {
+    "3000": { "label": "Rails (Right to Know)", "onAutoForward": "notify" },
+    "1080": { "label": "MailHog (email)", "onAutoForward": "silent" }
+  },
+  "postAttachCommand": "echo 'Start the site with: cd /alaveteli && bin/rails server -b 0.0.0.0 — then open http://localhost:3000'",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Shopify.ruby-lsp",
+        "manuelpuyol.erb-linter",
+        "EditorConfig.EditorConfig"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,89 @@
+# Development stack for the Right to Know theme.
+#
+# Mirrors the services in openaustralia/alaveteli's docker-compose.yml, but is
+# self-contained: Alaveteli itself is cloned into the `alaveteli` volume by
+# .devcontainer/setup.sh, so the only checkout you need is this repository.
+#
+# Used by both the Dev Container (.devcontainer/devcontainer.json) and the
+# plain Docker workflow (Makefile in the repository root).
+
+name: righttoknow
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        RUBY_VERSION: '${RUBY_VERSION:-3.2}'
+    command: sleep infinity
+    tty: true
+    stdin_open: true
+    environment:
+      - BUNDLE_PATH=/bundle/vendor
+      - DATABASE_URL=postgres://postgres:password@db/
+      - REDIS_URL=redis://redis:6379
+      - SMTP_URL=smtp://smtp:1025
+      - ALAVETELI_REPO=${ALAVETELI_REPO:-https://github.com/openaustralia/alaveteli.git}
+      - ALAVETELI_BRANCH=${ALAVETELI_BRANCH:-staging}
+    ports:
+      - '${RAILS_PORT:-3000}:3000'
+    volumes:
+      - ..:/alaveteli-themes/righttoknow:cached
+      - alaveteli:/alaveteli
+      - bundle:/bundle
+    depends_on:
+      - db
+      - redis
+      - smtp
+
+  sidekiq:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        RUBY_VERSION: '${RUBY_VERSION:-3.2}'
+    command: >
+      sh -c 'wait-for-it db:5432 --strict --timeout=60 --
+             sh -c "cd /alaveteli &&
+                    until bundle check >/dev/null 2>&1; do sleep 5; done &&
+                    bundle exec sidekiq"'
+    environment:
+      - BUNDLE_PATH=/bundle/vendor
+      - DATABASE_URL=postgres://postgres:password@db/
+      - REDIS_URL=redis://redis:6379
+      - SMTP_URL=smtp://smtp:1025
+    volumes:
+      - ..:/alaveteli-themes/righttoknow:cached
+      - alaveteli:/alaveteli
+      - bundle:/bundle
+    depends_on:
+      - db
+      - redis
+      - smtp
+
+  db:
+    build:
+      context: .
+      dockerfile: Dockerfile-postgres
+    environment:
+      - POSTGRES_PASSWORD=password
+    volumes:
+      - postgres:/var/lib/postgresql/data
+
+  redis:
+    image: library/redis
+    command: redis-server
+    volumes:
+      - redis:/data
+
+  smtp:
+    image: mailhog/mailhog
+    ports:
+      - '${MAILHOG_PORT:-1080}:8025'
+
+volumes:
+  alaveteli: {}
+  bundle: {}
+  postgres: {}
+  redis: {}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+# Bootstrap a Right to Know development environment inside the app container.
+#
+# Idempotent: safe to re-run at any time. On first run it clones the
+# openaustralia/alaveteli fork into /alaveteli (a Docker volume), wires this
+# theme in with Alaveteli's switch-theme script, then migrates and seeds the
+# databases and builds the search index. Subsequent runs only update gems and
+# re-link the theme.
+#
+# Runs as the Dev Container onCreateCommand, and via `make setup` for the
+# plain Docker workflow. Mirrors the steps in alaveteli's docker/bootstrap and
+# docker/setup scripts.
+
+set -e
+
+ALAVETELI_DIR=/alaveteli
+THEME_DIR=/alaveteli-themes/righttoknow
+ALAVETELI_REPO="${ALAVETELI_REPO:-https://github.com/openaustralia/alaveteli.git}"
+ALAVETELI_BRANCH="${ALAVETELI_BRANCH:-staging}"
+
+error_msg() { printf "\033[31m%s\033[0m\n" "$*"; }
+notice_msg() { printf "\033[33m%s\033[0m " "$*"; }
+success_msg() { printf "\033[32m%s\033[0m\n" "$*"; }
+
+notice_msg "Waiting for the database..."
+wait-for-it db:5432 --strict --timeout=120 -- true
+success_msg 'done'
+
+if [ ! -d "$ALAVETELI_DIR/.git" ]; then
+  notice_msg "Cloning $ALAVETELI_REPO ($ALAVETELI_BRANCH)..."
+  git clone --branch "$ALAVETELI_BRANCH" "$ALAVETELI_REPO" "$ALAVETELI_DIR"
+  success_msg 'done'
+fi
+
+cd "$ALAVETELI_DIR"
+
+notice_msg "Syncing git submodules..."
+git submodule update --init
+success_msg 'done'
+
+notice_msg "Copying example config files..."
+[ ! -f config/database.yml ] && cp config/database.yml-example config/database.yml
+[ ! -f config/sidekiq.yml ] && cp config/sidekiq.yml-example config/sidekiq.yml
+[ ! -f config/storage.yml ] && cp config/storage.yml-example config/storage.yml
+[ ! -f config/general-righttoknow.yml ] &&
+  cp "$THEME_DIR/config/general-righttoknow.yml.example" config/general-righttoknow.yml
+success_msg 'done'
+
+notice_msg 'Installing Ruby gems...'
+bundle check >/dev/null || bundle install
+success_msg 'done'
+
+notice_msg 'Switching to the righttoknow theme...'
+# Same symlinks as alaveteli's script/switch-theme.rb, done directly because
+# that script skips checkouts whose .git is a gitfile (e.g. git worktrees).
+ln -sfn general-righttoknow.yml config/general.yml
+ln -sfn "$THEME_DIR/public" public/alavetelitheme
+mkdir -p lib/themes
+ln -sfn "$THEME_DIR" lib/themes/righttoknow
+bin/rails assets:clean >/dev/null
+success_msg 'done'
+
+# If the database has never been seeded, load schema and data (matching
+# alaveteli's docker/setup). Pass --reset-data to force a reload.
+set +e
+bin/rails runner 'User.find(1)' >/dev/null 2>&1
+RESET_DATA_FLAG=$?
+set -e
+for arg in "$@"; do
+  case $arg in
+    --reset-data) RESET_DATA_FLAG=1;;
+    *);;
+  esac
+done
+
+if [ $RESET_DATA_FLAG -eq 0 ]; then
+  success_msg 'Database already set up; skipping migrations and sample data'
+  success_msg 'Setup finished'
+  exit 0
+fi
+
+notice_msg 'Migrating development and test databases...'
+bin/rails db:migrate db:seed >/dev/null
+bin/rails db:migrate RAILS_ENV=test >/dev/null
+success_msg 'done'
+
+notice_msg 'Loading sample data...'
+bundle exec script/load-sample-data >/dev/null
+success_msg 'done'
+
+notice_msg 'Removing external requests...'
+bin/rails runner 'InfoRequest.external.destroy_all'
+success_msg 'done'
+
+notice_msg 'Rebuilding Xapian index...'
+bundle exec script/destroy-and-rebuild-xapian-index >/dev/null
+success_msg 'done'
+
+success_msg 'Setup finished'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# Docker-based development workflow for the Right to Know theme.
+#
+# Uses the same compose stack as the Dev Container (.devcontainer/), so you
+# can develop with plain Docker and any editor — no VS Code required.
+# Run `make setup` once, then `make server` and open http://localhost:3000.
+
+COMPOSE := docker compose -f .devcontainer/docker-compose.yml
+APP     := $(COMPOSE) exec app
+IN_APP  := $(APP) sh -c
+
+.PHONY: help setup server console test seed shell logs stop down reset
+
+help: ## Show this help
+	@grep -E '^[a-z][a-zA-Z_-]*:.*## ' $(MAKEFILE_LIST) | \
+	  awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
+
+setup: ## Build images, start services and bootstrap Alaveteli + this theme
+	$(COMPOSE) build
+	$(COMPOSE) up -d
+	$(APP) /alaveteli-themes/righttoknow/.devcontainer/setup.sh
+
+server: ## Run the Rails server (then open http://localhost:3000)
+	$(COMPOSE) up -d
+	$(IN_APP) 'cd /alaveteli && rm -f tmp/pids/server.pid && bin/rails server -b 0.0.0.0'
+
+console: ## Open a Rails console
+	$(IN_APP) 'cd /alaveteli && bin/rails console'
+
+test: ## Run this theme's specs
+	$(IN_APP) 'cd /alaveteli && bundle exec rspec lib/themes/righttoknow/spec'
+
+seed: ## Load realistic AU authorities and requests (see script/seed_test_data.rb)
+	$(IN_APP) 'cd /alaveteli && SEED_REBUILD_INDEX=1 bundle exec rails runner \
+	  /alaveteli-themes/righttoknow/script/seed_test_data.rb'
+
+shell: ## Open a shell in the app container
+	$(APP) bash
+
+logs: ## Tail service logs
+	$(COMPOSE) logs -f
+
+stop: ## Stop services (keeps data)
+	$(COMPOSE) stop
+
+down: ## Stop and remove containers (keeps data volumes)
+	$(COMPOSE) down
+
+reset: ## Destroy everything (containers AND data volumes) and set up again
+	$(COMPOSE) down --volumes
+	$(MAKE) setup

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 - [Right To Know](#right-to-know)
   - [Development](#development)
-  - [Development Environment - Simple Steps](#development-environment---simple-steps)
+  - [Development environment](#development-environment)
+    - [Option 1: Dev Container (recommended)](#option-1-dev-container-recommended)
+    - [Option 2: Docker + Make](#option-2-docker--make)
+    - [Option 3: Manual setup](#option-3-manual-setup)
   - [Seeding test data](#seeding-test-data)
   - [Pro subscriptions](#pro-subscriptions)
     - [Restricting a coupon to a billing interval](#restricting-a-coupon-to-a-billing-interval)
@@ -49,17 +52,81 @@ If there is a fix or enhancement that is not specific to Right to Know/Australia
 
 However if you'd like to adjust the look and feel of Right To Know, or to update copy like that found on the help pages, this is the place to make those changes.
 
-## Development Environment - Simple Steps
+## Development environment
 
-We use Docker to create an Alaveteli instance. You can find more information on the [Alaveteli Website](https://alaveteli.org/docs/installing/docker/)
+This repository is an Alaveteli *theme* — it runs inside
+[our fork of Alaveteli](https://github.com/openaustralia/alaveteli). You don't
+need to check anything else out, though: the development environment below
+clones Alaveteli for you (the `staging` branch by default) and wires this
+theme into it, along with a working development configuration.
 
-A shortened version:
+The stack matches Alaveteli's own Docker environment: Rails app, Sidekiq,
+PostgreSQL, Redis, and [MailHog](https://github.com/mailhog/MailHog) to catch
+outgoing email (at <http://localhost:1080>).
 
-1. Pull a copy of our [Alaveteli Fork](https://github.com/openaustralia/alaveteli) onto your machine
-2. Create a sub-folder at the same level as the Alaveteli folder called `alaveteli-themes`
-3. Pull a copy of the Right to Know repository into the `alaveteli-themes` directory.
-4. Copy `alaveteli\config\general.yml.example` to `alaveteli\config\general-righttoknow.yml` and modify the file. An exmaple of our current `general.yml` file can be found in the [infrastructure repository](https://github.com/openaustralia/infrastructure/blob/main/roles/internal/righttoknow/templates/general.yml).
-5. Continue following the instructions on the [Alaveteli Website](https://alaveteli.org/docs/installing/docker/)
+### Option 1: Dev Container (recommended)
+
+Works with [VS Code](https://code.visualstudio.com/docs/devcontainers/containers)
+(needs Docker installed) or [GitHub Codespaces](https://github.com/features/codespaces)
+(needs nothing installed at all).
+
+1. Open this repository in VS Code and choose **Reopen in Container** when
+   prompted (or create a Codespace on GitHub).
+2. Wait for setup to finish — the first run clones Alaveteli, installs gems,
+   and migrates and seeds the databases, so it takes a while.
+3. Start the server from the integrated terminal:
+
+   ```bash
+   cd /alaveteli && bin/rails server -b 0.0.0.0
+   ```
+
+4. Open <http://localhost:3000>. Log in as the development admin with the
+   username and password from `config/general-righttoknow.yml.example`
+   (`adminxxxx` / `passwordx`).
+
+Inside the container, Alaveteli lives at `/alaveteli` and this theme is
+mounted at `/alaveteli-themes/righttoknow` (your workspace folder). Theme
+changes take effect on reload; changes to Ruby files under `lib/` need a
+server restart.
+
+### Option 2: Docker + Make
+
+The same stack without VS Code — just Docker and `make`:
+
+```bash
+make setup    # first run: build, clone Alaveteli, migrate, seed (takes a while)
+make server   # start the site at http://localhost:3000
+```
+
+Other useful targets (`make help` lists them all):
+
+```bash
+make console  # Rails console
+make test     # run this theme's specs
+make seed     # load realistic AU test data (see "Seeding test data")
+make shell    # shell in the app container
+make reset    # destroy containers and data, set up from scratch
+```
+
+To develop against a different Alaveteli branch or fork, set
+`ALAVETELI_BRANCH` / `ALAVETELI_REPO` before the first `make setup`. If ports
+3000 or 1080 are already in use on your machine, set `RAILS_PORT` /
+`MAILHOG_PORT`.
+
+### Option 3: Manual setup
+
+If you can't use containers, follow the
+[Alaveteli manual installation docs](http://alaveteli.org/docs/installing/)
+with our [Alaveteli fork](https://github.com/openaustralia/alaveteli), using
+the layout Alaveteli's theme tooling expects:
+
+1. Check out the fork, and create a sibling directory called
+   `alaveteli-themes` with this repository inside it
+   (`alaveteli/` and `alaveteli-themes/righttoknow/` side by side).
+2. Copy this repository's `config/general-righttoknow.yml.example` to
+   `alaveteli/config/general-righttoknow.yml`.
+3. From the `alaveteli` directory run
+   `bundle exec script/switch-theme.rb righttoknow`.
 
 ## Seeding test data
 
@@ -82,24 +149,24 @@ It creates:
 
 The script refuses to run in `production`.
 
-Run it against the Alaveteli **app** (not this theme repo) with `rails runner`:
+Run it against the Alaveteli **app** (not this theme repo) with `rails runner`.
+In the development environment above it's one command:
+
+```bash
+make seed
+```
+
+or manually (from the `alaveteli` directory):
 
 ```bash
 bundle exec rails runner \
   ../alaveteli-themes/righttoknow/script/seed_test_data.rb
 ```
 
-or inside Docker:
-
-```bash
-docker compose run --rm app \
-  bundle exec rails runner \
-  alaveteli-themes/righttoknow/script/seed_test_data.rb
-```
-
 Authorities and the browse-by-category page work immediately. Search and the
 request listings are Xapian-backed and will **not** show seeded data until the
-index is updated — either re-run with `SEED_REBUILD_INDEX=1`, or run:
+index is updated — `make seed` does this for you; otherwise either re-run with
+`SEED_REBUILD_INDEX=1`, or run:
 
 ```bash
 bundle exec rake xapian:destroy_and_rebuild_index \

--- a/config/general-righttoknow.yml.example
+++ b/config/general-righttoknow.yml.example
@@ -1,0 +1,58 @@
+# Development configuration for running Alaveteli with the Right to Know
+# theme. Copied to alaveteli/config/general-righttoknow.yml by
+# .devcontainer/setup.sh (Alaveteli's switch-theme script then symlinks
+# config/general.yml to it).
+#
+# Only contains settings that differ from Alaveteli's defaults — see
+# alaveteli/config/general.yml-example for the full list. Production settings
+# live in the infrastructure repository, not here.
+
+SITE_NAME: 'Right To Know'
+DOMAIN: 'localhost:3000'
+FORCE_SSL: false
+
+ISO_COUNTRY_CODE: AU
+ISO_CURRENCY_CODE: AUD
+TIME_ZONE: Australia/Sydney
+
+AVAILABLE_LOCALES: 'en'
+DEFAULT_LOCALE: 'en'
+
+# FOI law behaviour in Australia (jurisdiction-specific overrides live in the
+# theme itself — see lib/model_patches.rb).
+AUTHORITY_MUST_RESPOND: true
+REPLY_LATE_AFTER_DAYS: 30
+REPLY_VERY_LATE_AFTER_DAYS: 60
+WORKING_OR_CALENDAR_DAYS: calendar
+
+THEME_URLS:
+  - 'https://github.com/openaustralia/righttoknow.git'
+
+INCOMING_EMAIL_DOMAIN: 'localhost'
+INCOMING_EMAIL_PREFIX: 'foi+'
+INCOMING_EMAIL_SECRET: 'dev-secret-not-for-production'
+
+# Development admin login (matches the sample data's emergency user).
+ADMIN_USERNAME: 'adminxxxx'
+ADMIN_PASSWORD: 'passwordx'
+
+CONTACT_EMAIL: 'contact@localhost'
+CONTACT_NAME: 'Right To Know'
+TRACK_SENDER_EMAIL: 'contact@localhost'
+TRACK_SENDER_NAME: 'Right To Know'
+
+SECRET_KEY_BASE: 'dev-secret-key-base-not-for-production'
+
+# Marks this as a development site (shows the test banner, uses the emergency
+# user, etc.).
+STAGING_SITE: 1
+
+DONATION_URL: 'https://donate.oaf.org.au/'
+
+# Keep everything that would contact the outside world or require API keys
+# switched off in development.
+ENABLE_ANTI_SPAM: false
+NEW_REQUEST_RECAPTCHA: false
+CONTACT_FORM_RECAPTCHA: false
+USER_CONTACT_FORM_RECAPTCHA: false
+ENABLE_ALAVETELI_PRO: false


### PR DESCRIPTION
## Description

Adds a self-contained development environment so a contributor can go from cloning this repo to a running Right to Know site with documented commands — no manual multi-repo layout or hand-written config.

- **`.devcontainer/`** — a [Dev Container](https://containers.dev/) that works in VS Code and GitHub Codespaces. The compose stack mirrors Alaveteli's own Docker environment (Rails app, Sidekiq, PostgreSQL with UTF-8 template, Redis, MailHog), but is self-contained: an idempotent in-container setup script clones the [Alaveteli fork](https://github.com/openaustralia/alaveteli) (`staging` by default, overridable via `ALAVETELI_REPO`/`ALAVETELI_BRANCH`) into a Docker volume, installs a working dev config, wires the theme in, and migrates/seeds the databases on first run.
- **`config/general-righttoknow.yml.example`** — a development configuration with the Right to Know deltas (AU country/currency/timezone, calendar days, 30/60-day reply periods, dev-safe defaults), replacing the old "adapt the production template from the infrastructure repo" step.
- **`Makefile`** — the same stack for contributors not using VS Code: `make setup` / `server` / `console` / `test` / `seed` / `reset`. Host ports are overridable via `RAILS_PORT`/`MAILHOG_PORT` if 3000 or 1080 are taken.
- **`README.md`** — the development environment section now documents three paths in priority order: Dev Container, Docker + Make, and a manual fallback.

Implementation notes:

- The app/db Dockerfiles replicate alaveteli's `docker/` ones (source noted in comments) because Alaveteli isn't cloned until after the images are built.
- The theme is wired with the same symlinks as Alaveteli's `script/switch-theme.rb`, done directly because that script skips checkouts whose `.git` is a gitfile (e.g. git worktrees).

## Motivation and Context

Local setup previously required checking out multiple repositories in a specific sibling layout and hand-creating `general-righttoknow.yml` from the production template — difficult for new contributors and easy to get wrong.

Resolves #1012

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

All verified end-to-end on macOS (Docker 29.6.2), from clean volumes:

- `npx @devcontainers/cli up --workspace-folder .` → `outcome: success`; setup runs as `onCreateCommand` and shares the same compose project as the Make path
- `make setup` from scratch: clones alaveteli `staging`, installs 239 gems, migrates dev+test, loads sample data, builds the Xapian index
- `make server`: homepage returns 200 with the Right To Know title; theme views/help pages render AU content; Sidekiq boots; MailHog reachable
- Re-running `make setup` is idempotent (skips migration/seed steps)
- `make test`: 34 theme specs, 0 failures
- `make seed`: 41 AU authorities and 231 requests loaded and visible on `/body/list/all` and in search

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

Assisted-by: Claude Code/anthropic.claude-fable-5
