### PR TITLE
Update production theme with library reframing and external link fixes

### DIFF
--- a/lib/views/alaveteli_pro/account_request/_marketing_standard_features.html.erb
+++ b/lib/views/alaveteli_pro/account_request/_marketing_standard_features.html.erb
@@ -1,0 +1,46 @@
+<div class="marketing__section">
+  <div class="marketing__section__heading">
+    <h2>
+      <%= _('Plus, all the power of {{site_name}}', site_name: site_name) %>
+    </h2>
+
+    <p>
+      <%= _('<strong>{{pro_site_name}}</strong> runs on the UK’s ' \
+            'best-known FOI service',
+            pro_site_name: pro_site_name) %>
+    </p>
+  </div>
+
+  <div class="marketing__section__content">
+    <div class="marketing__section__content-items">
+      <ul class="marketing__section__feature-list">
+        <li>
+          <%= _('Up-to-date database of <strong class="marketing-highlight">' \
+                'contact details</strong> for {{authority_count}} authorities',
+                authority_count: PublicBody.is_requestable.count) %>
+        </li>
+
+        <li>
+          <%= _('A <strong class="marketing-highlight">searchable archive' \
+                '</strong> of Freedom of Information requests') %>
+        </li>
+
+        <li>
+          <%= _('<strong class="marketing-highlight">Delivery verification' \
+                '</strong> for proof of receipt') %>
+        </li>
+
+        <li>
+          <%= _('A permanent, searchable, ' \
+                '<strong class="marketing-highlight">public record</strong> ' \
+                'of your request and the responses') %>
+        </li>
+
+        <li>
+          <%= _('<strong class="marketing-highlight">Streamlined process' \
+                '</strong> for requesting internal reviews') %>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/lib/views/alaveteli_pro/account_request/_marketing_standard_features.html.erb
+++ b/lib/views/alaveteli_pro/account_request/_marketing_standard_features.html.erb
@@ -5,8 +5,8 @@
     </h2>
 
     <p>
-      <%= _('<strong>{{pro_site_name}}</strong> runs on the UK’s ' \
-            'best-known FOI service',
+      <%= _('<strong>{{pro_site_name}}</strong> runs on Australia’s ' \
+            'best-known FOI library',
             pro_site_name: pro_site_name) %>
     </p>
   </div>
@@ -15,13 +15,14 @@
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
         <li>
-          <%= _('Up-to-date database of <strong class="marketing-highlight">' \
-                'contact details</strong> for {{authority_count}} authorities',
+          <%= _('Up-to-date <strong class="marketing-highlight">collection ' \
+                'of contact details</strong> for {{authority_count}} ' \
+                'authorities',
                 authority_count: PublicBody.is_requestable.count) %>
         </li>
 
         <li>
-          <%= _('A <strong class="marketing-highlight">searchable archive' \
+          <%= _('A <strong class="marketing-highlight">searchable library' \
                 '</strong> of Freedom of Information requests') %>
         </li>
 

--- a/lib/views/alaveteli_pro/plans/index.html.erb
+++ b/lib/views/alaveteli_pro/plans/index.html.erb
@@ -90,7 +90,7 @@
         <div class="testimonial">
           <blockquote class="testimonial__content">
             <p>WhatDoTheyKnowPro has transformed my workflow. Managing big stories is so much easier now</p>
-            <cite class="testimonial__source"><img src="http://placehold.it/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
+            <cite class="testimonial__source"><img src="https://placehold.co/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
           </blockquote>
         </div>
       </li>
@@ -99,7 +99,7 @@
         <div class="testimonial">
           <blockquote class="testimonial__content">
             <p>WhatDoTheyKnowPro has transformed my workflow. Managing big stories is so much easier now</p>
-            <cite class="testimonial__source"><img src="http://placehold.it/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
+            <cite class="testimonial__source"><img src="https://placehold.co/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
           </blockquote>
         </div>
       </li>
@@ -108,7 +108,7 @@
         <div class="testimonial">
           <blockquote class="testimonial__content">
             <p>WhatDoTheyKnowPro has transformed my workflow. Managing big stories is so much easier now</p>
-            <cite class="testimonial__source"><img src="http://placehold.it/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
+            <cite class="testimonial__source"><img src="https://placehold.co/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
           </blockquote>
         </div>
       </li>
@@ -117,7 +117,7 @@
         <div class="testimonial">
           <blockquote class="testimonial__content">
             <p>WhatDoTheyKnowPro has transformed my workflow. Managing big stories is so much easier now</p>
-            <cite class="testimonial__source"><img src="http://placehold.it/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
+            <cite class="testimonial__source"><img src="https://placehold.co/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
           </blockquote>
         </div>
       </li>
@@ -126,7 +126,7 @@
         <div class="testimonial">
           <blockquote class="testimonial__content">
             <p>WhatDoTheyKnowPro has transformed my workflow. Managing big stories is so much easier now</p>
-            <cite class="testimonial__source"><img src="http://placehold.it/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
+            <cite class="testimonial__source"><img src="https://placehold.co/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
           </blockquote>
         </div>
       </li>
@@ -135,7 +135,7 @@
         <div class="testimonial">
           <blockquote class="testimonial__content">
             <p>WhatDoTheyKnowPro has transformed my workflow. Managing big stories is so much easier now</p>
-            <cite class="testimonial__source"><img src="http://placehold.it/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
+            <cite class="testimonial__source"><img src="https://placehold.co/100x100" alt="" class="testimonial__source__thumbnail"/>Jenny Realuser</cite>
           </blockquote>
         </div>
       </li>

--- a/lib/views/alaveteli_pro/plans/index.html.erb
+++ b/lib/views/alaveteli_pro/plans/index.html.erb
@@ -38,17 +38,17 @@
 <div class="marketing__section">
   <div class="marketing__section__heading">
     <h2><%= _('Plus, all the power of {{site_name}}', site_name: site_name) %></h2>
-    <p><%= _('<strong>{{pro_site_name}}</strong> runs on the UK’s ' \
-             'best-known FOI service',
+    <p><%= _('<strong>{{pro_site_name}}</strong> runs on Australia’s ' \
+             'best-known FOI library',
              pro_site_name: @pro_site_name.html_safe) %></p>
   </div>
   <div class="marketing__section__content">
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
-        <li><%= _('Up-to-date database of <strong class="marketing-highlight">' \
-                  'contact details</strong> for {{authority_count}} authorities',
+        <li><%= _('Up-to-date <strong class="marketing-highlight">collection ' \
+                  'of contact details</strong> for {{authority_count}} authorities',
                   authority_count: PublicBody.is_requestable.count) %></li>
-        <li><%= _('A <strong class="marketing-highlight">searchable archive</strong> of Freedom of Information requests') %></li>
+        <li><%= _('A <strong class="marketing-highlight">searchable library</strong> of Freedom of Information requests') %></li>
         <li><%= _('<strong class="marketing-highlight">Delivery verification</strong> for proof of receipt') %></li>
         <li><%= _('A permanent, searchable, <strong class="marketing-highlight">public record</strong> of your request and the responses') %></li>
         <li><%= _('<strong class="marketing-highlight">Streamlined process</strong> for requesting internal reviews') %></li>

--- a/lib/views/general/_frontpage_hero.html.erb
+++ b/lib/views/general/_frontpage_hero.html.erb
@@ -1,0 +1,24 @@
+<div class="homepage-hero">
+  <div class="row">
+    <div class="hero__intro">
+      <%= render :partial => "frontpage_intro_sentence" %>
+
+      <p class="intro__browse">
+        <%= _("Browse <a href=\"{{requests_url}}\">" \
+              "{{number_of_requests}} requests</a> to " \
+              "<a href=\"{{authorities_url}}\">" \
+              "{{number_of_authorities}} authorities</a>",
+            :requests_url => request_list_successful_path,
+            :number_of_requests => number_with_delimiter(@number_of_requests),
+            :authorities_url => list_public_bodies_default_path,
+            :number_of_authorities => number_with_delimiter(@number_of_authorities)) %>
+      </p>
+    </div>
+
+    <div class="hero__new-request">
+      <div class="new-request__content">
+        <%= render :partial => "new_request" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/views/general/_frontpage_hero.html.erb
+++ b/lib/views/general/_frontpage_hero.html.erb
@@ -4,7 +4,7 @@
       <%= render :partial => "frontpage_intro_sentence" %>
 
       <p class="intro__browse">
-        <%= _("Browse <a href=\"{{requests_url}}\">" \
+        <%= _("Browse a collection of <a href=\"{{requests_url}}\">" \
               "{{number_of_requests}} requests</a> to " \
               "<a href=\"{{authorities_url}}\">" \
               "{{number_of_authorities}} authorities</a>",

--- a/lib/views/general/_frontpage_how_it_works.html.erb
+++ b/lib/views/general/_frontpage_how_it_works.html.erb
@@ -1,0 +1,47 @@
+<div class="homepage-how-it-works" id="learn-more">
+  <div class="row">
+    <div class="homepage-how-it-works__hiw-content">
+      <div class="hiw-content__headings">
+        <h2><%= _("How it works") %></h2>
+        <p class="hiw__subtitle">
+          <%= _("You have the <strong>right</strong> to request information " \
+                "from any publicly-funded body, and get answers. " \
+                "{{site_name}} helps you make a Freedom of Information " \
+                "request. It also publishes all requests online.",
+                :site_name => site_name) %>
+        </p>
+      </div>
+      <div class="hiw-content__steps">
+        <ol class="steps__list row">
+          <li>
+            <div class="steps__step-box">
+              <p><%= _("Use this site to make your request for information – we'll show you how.") %></p>
+            </div>
+            <div class="steps__step-number" aria-hidden="true">
+              <p>1</p>
+            </div>
+          </li>
+          <li>
+            <div class="steps__step-box">
+              <p><%= _("We'll drop you an email as soon as your request gets a response.") %></p>
+            </div>
+            <div class="steps__step-number" aria-hidden="true">
+              <p>2</p>
+            </div>
+          </li>
+          <li>
+            <div class="steps__step-box">
+              <p><%= _("We publish it all online. Great! Now you have your answer, and everybody else can access it too.") %></p>
+            </div>
+            <div class="steps__step-number" aria-hidden="true">
+              <p>3</p>
+            </div>
+          </li>
+        </ol>
+        <div class="learn-more-foi">
+          <%= link_to _("Learn more &rarr;"), help_about_path %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/views/general/_frontpage_how_it_works.html.erb
+++ b/lib/views/general/_frontpage_how_it_works.html.erb
@@ -7,7 +7,8 @@
           <%= _("You have the <strong>right</strong> to request information " \
                 "from any publicly-funded body, and get answers. " \
                 "{{site_name}} helps you make a Freedom of Information " \
-                "request. It also publishes all requests online.",
+                "request. Your request will also become part of our " \
+                "growing library of requests and responses.",
                 :site_name => site_name) %>
         </p>
       </div>

--- a/lib/views/general/_frontpage_requests_list.html.erb
+++ b/lib/views/general/_frontpage_requests_list.html.erb
@@ -1,0 +1,45 @@
+<div id="examples_1" class="latest-requests">
+  <h3>
+    <% if @request_events_all_successful %>
+      <%= _("What information has been released?") %>
+    <% else %>
+      <%= _("What information has been requested?") %>
+    <% end %>
+  </h3>
+
+  <h4>
+    <%= n_("{{site_name}} users have made {{number_of_requests}} request, including:",
+        "{{site_name}} users have made {{number_of_requests}} requests, including:",
+        @number_of_requests,
+        :site_name => site_name,
+        :number_of_requests => number_with_delimiter(@number_of_requests)) %>
+  </h4>
+
+  <ul>
+    <% @request_events.each do |event| %>
+      <li class="request-listing">
+        <div class="request-listing__request-status-icon bottomline icon_<%= event.info_request.calculate_status %> icon-standalone"></div>
+        <div class="request-listing__request-body">
+          <p>
+            <% if @request_events_all_successful %>
+              <%= _("{{public_body_link}} answered a request about",
+                    :public_body_link => public_body_link(event.info_request.public_body)) %>
+            <% else %>
+              <%= _("{{public_body_link}} was sent a request about",
+                    :public_body_link => public_body_link(event.info_request.public_body)) %>
+            <% end %>
+
+            <%= link_to h(event.info_request.title), request_path(event.info_request) %>
+          </p>
+
+          <p class="request-body__time-ago">
+            <%= _('{{length_of_time}} ago',
+                  :length_of_time => time_ago_in_words(event.described_at)) %>
+          </p>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+
+  <%= link_to _("Browse all requests &rarr;"), request_list_path, :class => 'button-secondary' %>
+</div>

--- a/lib/views/general/_frontpage_requests_list.html.erb
+++ b/lib/views/general/_frontpage_requests_list.html.erb
@@ -8,8 +8,8 @@
   </h3>
 
   <h4>
-    <%= n_("{{site_name}} users have made {{number_of_requests}} request, including:",
-        "{{site_name}} users have made {{number_of_requests}} requests, including:",
+    <%= n_("{{site_name}} hosts a collection of {{number_of_requests}} user request, including:",
+        "{{site_name}} hosts a collection of {{number_of_requests}} user requests, including:",
         @number_of_requests,
         :site_name => site_name,
         :number_of_requests => number_with_delimiter(@number_of_requests)) %>

--- a/lib/views/general/_nav_items.html.erb
+++ b/lib/views/general/_nav_items.html.erb
@@ -3,7 +3,7 @@
 </li>
 
 <li class="<%= 'selected' if controller?('request') && !action?('new', 'select_authority') %>">
-  <%= link_to _("View requests"), request_list_successful_path %>
+  <%= link_to _("View request library"), request_list_successful_path %>
 </li>
 
 <li class="<%= 'selected' if controller?('public_body') %>">

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -13,7 +13,7 @@
       <nav class="oaf-footer__links">
         <ul>
           <li><%= link_to 'Make a request', select_authority_path %></li>
-          <li><%= link_to 'Browse requests', request_list_successful_path %></li>
+          <li><%= link_to 'Browse request library', request_list_successful_path %></li>
           <li><%= link_to 'View authorities', list_public_bodies_default_path %></li>
           <% if feature_enabled?(:alaveteli_pro) %>
             <li><%= link_to 'Journalist?', account_request_index_path %></li>

--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -7,30 +7,30 @@
   <dl>
 
   <dt id="purpose">What is  <%= site_name %> for? <a href="#purpose">#</a> </dt>
-  <dd>To help you find out inside information about what Australian governments
-  are doing.
+  <dd>A collection of inside information to help you find out what Australian
+  governments are doing.
   </dd>
 
   <dt id="premise">How does the site work? <a href="#premise">#</a> </dt>
-  <dd>Choose the public authority you want information from, then write a brief note describing what you want to know. We will send your request to the public authority. Your request and any response are automatically published on the website for anyone to find and read.
+  <dd>Choose the public authority you want information from, then write a brief note describing what you want to know. We will send your request to the public authority. Your request and any response are automatically collected in the <%= site_name %> library and published on the website for anyone to find and read.
   </dd>
 
   <dt id="does_it_cost_money">
   Does it cost money to get an account on the site?
   <a href="#does_it_cost_money">#</a></dt>
   <dd><p>
-    No. You can create a free account on the site. Once you have an account, you can make up to five free Freedom of Information requests each day. The five-per-day limit is more than enough for almost all of our users.
+    No. Library membership is free. You can create an account on the site and make up to six free Freedom of Information requests each day. The six-per-day limit is more than enough for almost all of our members.
   </p>
   <p>
-    We offer a paid service called <a href="/pro"><%= site_name %> Pro</a> for journalists and others who may need to make more requests or have special requirements.
+    <a href="/pro"><%= site_name %> Pro</a> is a paid service the library offers for journalists and others who may need to make more requests or have special requirements.
   </p></dd>
 
   <dt id="whybother_me">Why would I bother to do this? <a href="#whybother_me">#</a> </dt>
   <dd><p>
-    The government is funded by public money, that is paid for by taxes. Since it's your money that they are spending, you might want to check that they are running efficiently, making good decisions, and doing their job.
+    The government is funded by public money, that is paid for by taxes. Since it's your money that they are spending, you might want to check that they are running efficiently, making good decisions, and doing their job. We work across various organisations to collect this information and make it as accessible as possible in the <%= site_name %> online library.
   </p>
   <p>
-    The more we find out about how government works, the better we can suggest ways to improve things that are done badly and celebrate things done well. Some people use the site for research, journalism, campaigning, or raising awareness. Others are simply curious.
+    The more we find out about how government works, the better we can suggest ways to improve things that are done badly and celebrate things done well. Some people use the collection for research, journalism, campaigning, or raising awareness. Others are simply curious.
   </p></dd>
 
   <dt id="whybother_them">Why would the public authority bother to reply? <a href="#whybother_them">#</a> </dt>
@@ -40,7 +40,7 @@
   </dd>
 
   <dt id="who">Who makes <%= site_name %>? <a href="#who">#</a> </dt>
-  <dd><%= site_name %> is a project of the OpenAustralia Foundation, a charity, and was developed with software by the UK organisation mySociety. It was made possible by a <a href="https://oaf.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation from Guy King</a>. If you like what we're doing, then you can <a href="https://donate.oaf.org.au">make a donation</a>.
+  <dd><%= site_name %> is part of the OpenAustralia Foundation collection. It was developed with software by the UK organisation mySociety and made possible by a <a href="https://oaf.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation from Guy King</a>. OpenAustralia Foundation is a charity, so if you like what we're doing, you can <a href="https://donate.oaf.org.au">make a donation</a>.
   </dd>
 
   <dt id="reporting">
@@ -49,28 +49,28 @@
   </dt>
   <dd>
   <p>
-    Requests for personal information and vexatious requests are not considered valid for FOI purposes. See our <a href="<%= help_house_rules_path %>">House Rules</a> for more on how we expect people to use this site.
+    Requests for personal information and vexatious requests are not considered valid for FOI (Freedom of Information) purposes. See our <a href="<%= help_house_rules_path %>">House Rules</a> for more on how we expect people to use this library.
   </p>
   <p>
-    If you believe a request is not suitable, you can report it for attention by the site administrators.
+    If you believe a request is not suitable, you can report it for attention by the collection administrators.
   </p> </dd>
 <dt id="reporting_unavailable">
   Why are there some requests I can't report?
   <a href="#reporting_unavailable">#</a></dt>
 <dd><p>
-    If a request has already been reported to the site administrators, you can't report it a second time. This prevents the administrators from being notified multiple times about the same issue before they've had a chance to review it.
+    If a request has already been reported to the collection administrators, you can't report it a second time. This prevents the administrators from being notified multiple times about the same issue before they've had a chance to review it.
   </p>
   <p>
-    If you think a request that's been previously reported should be taken down, but a decision has been made not to remove it from public view, you can use the form in the sidebar of the request page to contact the administrators.
+    If you think a request that's been previously reported should be taken down, but a decision has been made not to remove it from public view, you can use the form in the sidebar of the request page to contact the collection administrators.
   </p></dd>
 <dt id="how_many">
   How many people use <%= site_name %>?
   <a href="#how_many">#</a></dt>
   <dd><p>
-    We have over <%= number_with_delimiter(User.count.round(-4), locale: @locale) %> registered users. 
+    We have over <%= number_with_delimiter(User.count.round(-4), locale: @locale) %> registered members. 
   </p>
   <p>
-    But that's just the people who request information. Most visitors to our site don't make requests themselves. They benefit from being able to access information in the requests and responses of others. 
+    But that's just the people who request information. Most visitors to our site don't make requests themselves. They benefit from being able to access information in the library of requests and responses of others. 
   </p></dd>
 
   <dt id="updates">How can I keep up with news about <%= site_name %>? <a href="#updates">#</a> </dt>

--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -40,7 +40,7 @@
   </dd>
 
   <dt id="who">Who makes <%= site_name %>? <a href="#who">#</a> </dt>
-  <dd><%= site_name %> is a project of the OpenAustralia Foundation, a charity, and was developed with software by the UK organisation mySociety. It was made possible by a <a href="https://www.openaustraliafoundation.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation from Guy King</a>. If you like what we're doing, then you can <a href="https://donate.oaf.org.au">make a donation</a>.
+  <dd><%= site_name %> is a project of the OpenAustralia Foundation, a charity, and was developed with software by the UK organisation mySociety. It was made possible by a <a href="https://oaf.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation from Guy King</a>. If you like what we're doing, then you can <a href="https://donate.oaf.org.au">make a donation</a>.
   </dd>
 
   <dt id="reporting">

--- a/lib/views/help/credits.html.erb
+++ b/lib/views/help/credits.html.erb
@@ -17,14 +17,14 @@
     Ben Fairless is a volunteer who almost single-handedly took care of the site administration for much of its early life. He also played a big part in expanding Right To Know to cover states and territories along with Richard Taylor, who did a sterling job of collecting public authority information.
 </li>
 <li>
-    Guy King's <a href="https://www.openaustraliafoundation.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation to the OpenAustralia Foundation</a>, made building and running this site possible.
+    Guy King's <a href="https://oaf.org.au/2012/09/25/accelerating-to-the-future-of-online-democracy-in-australia/">donation to the OpenAustralia Foundation</a>, made building and running this site possible.
 </li>
 <li>
     Our early testers, for checking over all the legal help text and making sure that things worked as expected.
     And since our launch, the amazingly helpful growing community of people who help each other on this site by leaving annotations on requests.
 </li>
 <li>
-    Peter Timmins, Australia's foremost authority on Freedom of Information law, has kept us informed through the years with his indispensable blog <a href="http://foi-privacy.blogspot.com.au/">Open and Shut</a>.
+    Peter Timmins, Australia's foremost authority on Freedom of Information law, has kept us informed through the years with his indispensable blog <a href="https://foi-privacy.blogspot.com/">Open and Shut</a>.
 </li>
 <li>
     Everyone who has helped look up Freedom of Information email addresses.
@@ -51,7 +51,7 @@
 <dd>
     <p>Yes please! We're built out of our supporters and volunteers.</p>
     <ul>
-    <li>You can <a href="https://www.openaustraliafoundation.org.au/donate/righttoknow/">make a donation</a>.</li>
+    <li>You can <a href="https://oaf.org.au/donate/righttoknow/">make a donation</a>.</li>
     <li>Help people find successful requests, and monitor performance of authorities, by
     <a href="/categorise/play">playing the categorisation game</a>. </li>
     <li>Help people get the documents they’re after by annotating their requests with suggestions for improvements and ways to overcome objections.</li>
@@ -99,7 +99,7 @@
 
 <dt id="attribution">Attribution <a href="#attribution">#</a> </dt>
 <dd>
-    Some descriptions of public authorities were sourced and adapted from <a href="http://australia.gov.au">australia.gov.au</a> in which the <a href="http://australia.gov.au/about/copyright">text content is licensed</a> under <a href="http://creativecommons.org/licenses/by/3.0/au/">Creative Commons Attribution 3.0 Australia</a>.
+    Some descriptions of public authorities were sourced and adapted from australia.gov.au (now retired) in which the <a href="https://web.archive.org/web/20150214001745/http://www.australia.gov.au/about/copyright">text content was licensed</a> under <a href="https://creativecommons.org/licenses/by/3.0/au/">Creative Commons Attribution 3.0 Australia</a>.
 </dd>
 
 

--- a/lib/views/help/house_rules/_list_of_house_rules.html.erb
+++ b/lib/views/help/house_rules/_list_of_house_rules.html.erb
@@ -35,7 +35,7 @@
     Do not make vexatious requests. This means requests with no real purpose,
     or requests intended to disrupt a public body. The Office of the
     Australian Information Commissioner has
-    <a href="https://www.oaic.gov.au/freedom-of-information/foi-guidelines/part-12-vexatious-applicant-declarations#grounds-for-declaration">
+    <a href="https://www.oaic.gov.au/freedom-of-information/freedom-of-information-guidance-for-government-agencies/foi-guidelines/part-12-vexatious-applicant-declarations">
     published guidance on vexatious behaviour</a>.
   </li>
   <li>

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -42,9 +42,9 @@ publish it widely.
 
 <dt id="pdf">Why should I not send PDF documents in FOI responses? <a href="#pdf">#</a> </dt>
 <dd>
-  The <a href="http://webguide.gov.au/accessibility-usability/accessibility/pdf-accessibility/">Australian Government Webguide</a> makes it very clear that PDF is not an acceptable format for you to use in the delivery of government information:
+  The <a href="https://www.stylemanual.gov.au/content-types/pdf-portable-document-format">Australian Government Style Manual</a> makes it very clear that PDF is not an acceptable format for you to use in the delivery of government information:
   <blockquote>
-    PDF does not yet have approved Sufficient Techniques to claim WCAG 2.0 conformance, so it cannot be ‘relied upon’ in the provision of government information.
+    Only create PDFs if your research shows there are specific needs for this format. &hellip; Create content in HTML pages instead of PDFs.
   </blockquote>
   Write a response in an email as plain text. This is not only a simple and efficient way for you to conform to government guidelines, it is easier and quicker for the recipient to read.
 </dd>

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -26,7 +26,7 @@ email address to them so they can reply to you. You will be told that this is go
 relating to a request you made, an email alert that you have signed up for,
 or for other reasons that you specifically authorise. </p>
 
-<p>You will also receive emails from the <a href="https://www.openaustraliafoundation.org.au/">OpenAustralia Foundation</a>,
+<p>You will also receive emails from the <a href="https://oaf.org.au/">OpenAustralia Foundation</a>,
 the charity that runs <%= site_name %>. You can unsubscribe from these emails without affecting any alerts from <%= site_name %>. </p>
 
 <p> We will never give or sell your email addresses to anyone else, unless we are obliged
@@ -57,7 +57,7 @@ get in touch with you to assist you with your research or to campaign with you.
 <dd>
 <p>Yes, you can use a pseudonym. Be careful though. It might make it impossible to follow up if you think a decision needs to be reviewed.</p>
 
-<p>The Federal Information Commissioner guidelines <a href="http://www.oaic.gov.au/freedom-of-information/applying-the-foi-act/foi-guidelines/part-3-processing-requests-for-access#right">say</a> that "The FOI Act does not require an applicant to disclose or provide proof of their identity" but that the "agency or minister should consider whether collection of information about the applicant's identity is required to assess the request".</p>
+<p>The Federal Information Commissioner guidelines <a href="https://www.oaic.gov.au/freedom-of-information/freedom-of-information-guidance-for-government-agencies/foi-guidelines/part-3-processing-and-deciding-on-requests-foi-access">say</a> that "The FOI Act does not require an applicant to disclose or provide proof of their identity" but that the "agency or minister should consider whether collection of information about the applicant's identity is required to assess the request".</p>
 
 <p>Please do not try to impersonate someone else.</p>
 
@@ -68,7 +68,7 @@ get in touch with you to assist you with your research or to campaign with you.
 <dd>
 <p>An email address is sufficient by law. You don't need to give your postal address.</p>
 <p>
-  If a public authority insists on your full, physical address, <a href="/help/contact">let us know</a>. This website is specifically mentioned in the Federal Information Commissioner's <a href="http://www.oaic.gov.au/freedom-of-information/applying-the-foi-act/foi-guidelines/part-3-processing-requests-for-access#formal">FOI Guidelines</a> because we've been through this before.
+  If a public authority insists on your full, physical address, <a href="/help/contact">let us know</a>. This website is specifically mentioned in the Federal Information Commissioner's <a href="https://www.oaic.gov.au/freedom-of-information/freedom-of-information-guidance-for-government-agencies/foi-guidelines/part-3-processing-and-deciding-on-requests-foi-access">FOI Guidelines</a> because we've been through this before.
 </p>
 </dd>
 

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -227,7 +227,7 @@ then read our page '<a href="/help/unhappy">Unhappy about the response you got?<
   Authorities often add legal boilerplate about Copyright, which at first
   glance implies you may not be able do anything with the information. This is
   likely to be incorrect. For example, the latest
-  <a href="https://www.communications.gov.au/documents/intellectual-property-principles-commonwealth-entities">
+  <a href="https://www.ag.gov.au/rights-and-protections/publications/intellectual-property-principles-commonwealth-entities">
     Intellectual property principles for Commonwealth entities
   </a>
   explicitly encourages reuse.
@@ -262,14 +262,14 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
     <li>
       For <%= link_to "Federal Authorities", list_public_bodies_path(:tag => "federal") %>,
       have a look at the Freedom of Information
-      <a href="https://www.oaic.gov.au/freedom-of-information/foi-guidelines/">guidelines</a>
-      and <a href="https://www.oaic.gov.au/freedom-of-information/guidance-and-advice/fact-sheet-for-foi-practitioners-to-provide-to-agency-staff/">fact sheets that agency staff see</a>
+      <a href="https://www.oaic.gov.au/freedom-of-information/freedom-of-information-guidance-for-government-agencies/foi-guidelines">guidelines</a>
+      and <a href="https://www.oaic.gov.au/freedom-of-information/freedom-of-information-guidance-for-government-agencies/guidance-on-handling-a-freedom-of-information-request">guidance that agency staff see</a>
       on the Information Commissioner's website.
     </li>
     <li>
       For <%= link_to "ACT Authorities", list_public_bodies_path(:tag => "ACT") %>,
       see the website for the Directorate in charge of
-      <a href="http://www.cmd.act.gov.au/functions/foi">Freedom of Information</a>.
+      <a href="https://www.cmtedd.act.gov.au/functions/foi">Freedom of Information</a>.
     </li>
     <li>
       For <%= link_to "NT Authorities", list_public_bodies_path(:tag => "NT") %>,
@@ -279,27 +279,27 @@ allowed to do so.  See <a href="/help/officers#copyright">our policy on copyrigh
     <li>
       For <%= link_to "NSW Authorities", list_public_bodies_path(:tag => "NSW") %>,
       information can be found on the
-      <a href="http://www.ipc.nsw.gov.au/resources-public">NSW Information Commissioner website</a>.
+      <a href="https://www.ipc.nsw.gov.au/information-access/individuals">NSW Information Commissioner website</a>.
     </li>
     <li>
       For <%= link_to "Victorian Authorities", list_public_bodies_path(:tag => "VIC") %>,
       information can be found on the
-      <a href="http://www.foi.vic.gov.au/">Victorian Freedom of Information website</a>.
+      <a href="https://ovic.vic.gov.au/freedom-of-information/">Office of the Victorian Information Commissioner website</a>.
     </li>
     <li>
       For <%= link_to "Queensland Authorities", list_public_bodies_path(:tag => "QLD") %>,
       information can be found on the
-      <a href="https://www.oic.qld.gov.au/guidelines/for-community-members/information-sheets-access-and-amendment/accessing-information-held-by-government">Queensland Information Commissioner website</a>.
+      <a href="https://www.oic.qld.gov.au/community/how-to-access-information-from-qld-government">Queensland Information Commissioner website</a>.
     </li>
     <li>
       For <%= link_to "SA Authorities", list_public_bodies_path(:tag => "SA") %>,
       information can be found on the
-      <a href="http://www.archives.sa.gov.au/content/foi-in-sa">State Records' FOI in South Australia</a> pages.
+      <a href="https://www.archives.sa.gov.au/finding-information/sa-government-information/access-records-using-freedom-of-information">State Records' FOI in South Australia</a> pages.
     </li>
     <li>
       For <%= link_to "WA Authorities", list_public_bodies_path(:tag => "WA") %>,
       information can be found on the
-      <a href="http://foi.wa.gov.au/">WA Information Commissioner website</a>.
+      <a href="https://www.wa.gov.au/organisation/office-of-the-information-commissioner">WA Information Commissioner website</a>.
     </li>
     <li>
       For <%= link_to "Tasmanian Authorities", list_public_bodies_path(:tag => "TAS") %>,

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -58,39 +58,39 @@ to your request '<%=request_link(@info_request) %>'?
 <ul>
   <li>
     For <%= link_to "Federal Authorities", list_public_bodies_path(:tag => "federal") %>, contact the
-    <a href="http://www.oaic.gov.au/freedom-of-information/foi-reviews">Federal Information Commissioner</a>.
+    <a href="https://www.oaic.gov.au/freedom-of-information/your-freedom-of-information-rights/freedom-of-information-reviews">Federal Information Commissioner</a>.
   </li>
   <li>
     For <%= link_to "ACT Authorities", list_public_bodies_path(:tag => "ACT") %>, contact the
-    <a href="http://ombudsman.act.gov.au/pages/making-a-complaint/complaints-the-ombudsman-can-investigate/freedom-of-information.php">Ombudsman</a>.
+    <a href="https://www.ombudsman.act.gov.au/accountability-and-oversight/freedom-of-information/foi-complaints-and-reviews">Ombudsman</a>.
   </li>
   <li>
     For <%= link_to "NT Authorities", list_public_bodies_path(:tag => "NT") %>, contact the
-    <a href="http://www.infocomm.nt.gov.au/complaints/ca_1.htm">NT Information Commissioner</a>.
+    <a href="https://infocomm.nt.gov.au/complaints-and-appeals">NT Information Commissioner</a>.
   </li>
   <li>
     For <%= link_to "NSW Authorities", list_public_bodies_path(:tag => "NSW") %>, contact the
-    <a href="http://www.ipc.nsw.gov.au/gipa-reviews">NSW Information Commissioner</a>.
+    <a href="https://www.ipc.nsw.gov.au/information-access/citizens/lodge-review">NSW Information Commissioner</a>.
   </li>
   <li>
     For <%= link_to "Victorian Authorities", list_public_bodies_path(:tag => "VIC") %>, contact the
-    <a href="http://www.foicommissioner.vic.gov.au/home/reviews/">Freedom of Information Commissioner</a>.
+    <a href="https://ovic.vic.gov.au/freedom-of-information/for-the-public/foi-reviews/">Office of the Victorian Information Commissioner</a>.
   </li>
   <li>
     For <%= link_to "Queensland Authorities", list_public_bodies_path(:tag => "QLD") %>, contact the
-    <a href="https://www.oic.qld.gov.au/guidelines/for-community-members/information-sheets-access-and-amendment/explaining-your-review-rights-a-guide-for-applicants">Queensland Information Commissioner</a>.
+    <a href="https://www.oic.qld.gov.au/community/rti-internal-external-review">Queensland Information Commissioner</a>.
   </li>
   <li>
     For <%= link_to "SA Authorities", list_public_bodies_path(:tag => "SA") %>, contact
-    <a href="http://www.ombudsman.sa.gov.au/freedom-of-information/">Ombudsman SA</a>.
+    <a href="https://www.ombudsman.sa.gov.au/freedom-of-information">Ombudsman SA</a>.
   </li>
   <li>
     For <%= link_to "WA Authorities", list_public_bodies_path(:tag => "WA") %>, contact the
-    <a href="http://foi.wa.gov.au/FTP014">WA Information Commissioner</a>.
+    <a href="https://www.wa.gov.au/organisation/office-of-the-information-commissioner/apply-oic-wa-foi-external-review">WA Information Commissioner</a>.
   </li>
   <li>
     For <%= link_to "Tasmanian Authorities", list_public_bodies_path(:tag => "TAS") %>, contact
-    <a href="http://www.ombudsman.tas.gov.au/right_to_information/process">Ombudsman Tasmania</a>.
+    <a href="https://www.ombudsman.tas.gov.au/right-to-information">Ombudsman Tasmania</a>.
   </li>
 </ul>
 

--- a/lib/views/request/_act.html.erb
+++ b/lib/views/request/_act.html.erb
@@ -3,7 +3,7 @@
 <div class="act_link">
   <i class="act-link-icon act-link-icon--medium"></i>
   <%= link_to _("Write about this on Medium"),
-              "http://medium.com/",
+              "https://medium.com/",
               :onclick => track_analytics_event(
                 AnalyticsEvent::Category::OUTBOUND,
                 AnalyticsEvent::Action::MEDIUM_EXIT,

--- a/lib/views/request/list.html.erb
+++ b/lib/views/request/list.html.erb
@@ -1,0 +1,32 @@
+<%= render partial: 'tabs' %>
+
+<div id="header_left" class="header_left">
+  <h1><%= @title %></h1>
+  <%= render :partial => 'request/request_search_form',
+             :locals => { :after_form_fields => render(:partial => 'request/request_filter_form') } %>
+
+  <%= render partial: 'category' if @category %>
+</div>
+
+<div id="header_right" class="sidebar header_right">
+  <h2><%= _("Follow these requests") %></h2>
+  <% if @track_thing %>
+    <%= render :partial => 'track/tracking_links', :locals => { :track_thing => @track_thing, :own_request => false, :location => 'main' } %>
+    <%= render :partial => 'track/rss_feed', :locals => { :track_thing => @track_thing, :location => 'main' } %>
+  <% end %>
+
+  <%= render partial: 'general/search_latest' %>
+  <%= render partial: 'general/help_requests' %>
+</div>
+
+<div style="clear:both"></div>
+
+<div class="results_section">
+  <% if key = request_list_cache_key %>
+    <% cache_if_caching_fragments(key, :expires_in => 5.minutes) do %>
+      <%= render :partial => 'list_results' %>
+    <% end %>
+  <% else %>
+    <%= render :partial => 'list_results' %>
+  <% end %>
+</div>

--- a/lib/views/request/list.html.erb
+++ b/lib/views/request/list.html.erb
@@ -1,3 +1,12 @@
+<%# Override the core "Search requests" title to make clear this is a
+    library of requests (issue #1036). Tag/category listings keep the
+    title set by RequestController#list. %>
+<% unless @tag %>
+  <% @title = @page > 1 ?
+       _("Search request library (page {{count}})", count: @page) :
+       _("Search request library") %>
+<% end %>
+
 <%= render partial: 'tabs' %>
 
 <div id="header_left" class="header_left">

--- a/spec/pro_marketing_wording_spec.rb
+++ b/spec/pro_marketing_wording_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# Guards the "Plus, all the power of Right to Know" marketing section,
+# reframed in library terms (issue #1038). The section renders from two
+# places: the theme's account_request/_marketing_standard_features.html.erb
+# override on /pro, and the theme's plans/index.html.erb on /pro/pricing.
+# Both are asserted here so the pages can't silently diverge.
+#
+# The "public record" bullet is deliberately unchanged: it preserves the
+# notice that requests and responses become public.
+#
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(
+  File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper')
+)
+require 'stripe_mock'
+
+RSpec.shared_examples 'library-framed standard features' do
+  it 'describes the service as a library' do
+    expect(response.body).to include('Australia’s best-known FOI library')
+    expect(response.body).not_to include('best-known FOI service')
+  end
+
+  it 'describes contact details as a collection' do
+    expect(response.body).to include(
+      '<strong class="marketing-highlight">collection of contact ' \
+      'details</strong>'
+    )
+    expect(response.body).not_to include('database of')
+  end
+
+  it 'describes requests as a searchable library' do
+    expect(response.body).to include(
+      '<strong class="marketing-highlight">searchable library</strong>'
+    )
+    expect(response.body).not_to include('searchable archive')
+  end
+
+  it 'keeps the public record notice' do
+    expect(response.body).to include(
+      '<strong class="marketing-highlight">public record</strong>'
+    )
+  end
+end
+
+RSpec.describe AlaveteliPro::AccountRequestController, type: :controller do
+  render_views
+
+  describe 'GET #index' do
+    before { get :index }
+
+    include_examples 'library-framed standard features'
+  end
+end
+
+RSpec.describe AlaveteliPro::PlansController, type: :controller do
+  render_views
+
+  before { StripeMock.start }
+  after { StripeMock.stop }
+
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  let(:product) { stripe_helper.create_product }
+
+  let!(:monthly_price) do
+    stripe_helper.create_price(
+      id: 'pro', product: product.id, unit_amount: 1000
+    )
+  end
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:stripe_tax_rate).and_return('0.0')
+    allow(AlaveteliConfiguration)
+      .to receive(:iso_currency_code).and_return('GBP')
+    allow(AlaveteliConfiguration).to receive(:stripe_prices)
+      .and_return('pro' => 'pro')
+  end
+
+  describe 'GET #index' do
+    before { get :index }
+
+    include_examples 'library-framed standard features'
+  end
+end


### PR DESCRIPTION
## Description

Promotes the theme's `staging` branch to `production`.

Head at time of opening: `5ab18c0`.

Theme-only copy changes plus one new spec. Five PRs merged to `staging` since the 0.45.8.0
cutover (#1030):

- **#1039, rename request browse wording to "request library"** (resolves #1036). Page heading
  and browser title "Search requests" to "Search request library", main nav "View requests" to
  "View request library", footer "Browse requests" to "Browse request library". The heading lives
  in core's controller, so `app/views/request/list.html.erb` was copied into the theme and then
  patched to override `@title`.
- **#1040, rewrite Help > About in library terms** (resolves #1037). Eight Q&A blocks on
  "Introduction to Right to Know" rewritten around library and membership vocabulary. Also fixes
  the stated daily request limit from five to six, matching production's
  `MAX_REQUESTS_PER_USER_PER_DAY: 6`.
- **#1041, reframe home page copy around the request library** (resolves #1035). Hero browse
  line, "How it works" intro and requests list lead-in. Three core frontpage partials copied into
  the theme and then patched.
- **#1042, reframe Pro feature list in library terms** (resolves #1038). The "Plus, all the power
  of Right to Know" section on both `/pro` and `/pro/pricing`, with a new spec
  (`spec/pro_marketing_wording_spec.rb`) pinning the two pages together so they cannot silently
  diverge again.
- **#1034, update dead external links across help pages**. 22 dead or redirecting external URLs
  across 9 help view files, replaced with current equivalents. #870 stays open: it is about the
  ongoing cost of link maintenance, not this one sweep.

The four reframing PRs continue #823 and sit under the #1006 theme tracker; #1040 is also part of
the #865 help pages review.

## Motivation and Context

Unlike #1030, this is not a coordinated cutover. There is no core version bump and no
infrastructure change, so it ships with a single `cap production deploy` and nothing needs to
merge alongside it.

`git log origin/staging..origin/production` shows only the #1030 merge commit, so production
carries no direct hotfix that this promotion would revert.

### Things worth knowing about this diff

- **Six theme files are now frozen copies of Alaveteli core**, copied verbatim and then patched:
  `lib/views/request/list.html.erb`, `lib/views/general/_frontpage_hero.html.erb`,
  `_frontpage_how_it_works.html.erb`, `_frontpage_requests_list.html.erb`,
  `lib/views/alaveteli_pro/account_request/_marketing_standard_features.html.erb`, and the
  existing `lib/views/alaveteli_pro/plans/index.html.erb`. Core changes to any of them no longer
  flow through automatically. **#1031 (0.45.8.0 to 0.46.7.0, still open) must re-diff every one
  of these against the new core.** The frontpage partials are byte-identical between the two
  releases, so they are safe today, but that is a fact about 0.46.7.0 rather than a standing
  guarantee.
- **The frontpage fragment cache is 5 minutes.** Two of the three home page blocks sit inside it,
  so allow for that when smoke testing after deploy.
- **A dead gettext override ships with this.** `locale-theme/en/app.po:59-60` overrides the old
  `…UK's best-known FOI service` msgid, which no longer matches anything now that the string is
  hardcoded in the ERB. Left in place deliberately per #1042 and can be cleaned up separately.
- **The reframing is not finished.** Both Pro pages still carry the site description "…also
  publishes and archives requests and responses, building a massive archive of information",
  which no PR here touches. Follow-up work for #1006 rather than a blocker.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Each change was tested on the way into `staging`, and the Pro wording spec was run against a core
checkout at `263b3bc30` with this branch installed as the theme (42 examples, 0 failures).

Staging has been redeployed and is running all five changes together. Checked there:

- **Home page** (#1041): hero "Browse a collection of 15 requests to 6 authorities", "Your
  request will also become part of our growing library of requests and responses", and "hosts a
  collection of 15 user requests, including:"
- **Browse labels** (#1039): browser title "Search request library", nav "View request library",
  footer "Browse request library", all three agreeing
- **Help > About** (#1040): "Library membership is free", "registered members", "collection
  administrators", and the daily limit reading six in both sentences
- **`/pro` and `/pro/pricing`** (#1042): "Australia's best-known FOI library", "Up-to-date
  collection of contact details", "A searchable library of Freedom of Information requests", and
  the public-record bullet kept. The two pages render identically, which is what the new spec
  pins.
- **Help pages** (#1034): render fine with the replacement URLs in place, including the
  restructured OAIC review page and the state information commissioners.

One thing to read carefully rather than take from the tick boxes: **`spec/` never runs in CI.**
#1029 removed the branch restriction on `rubocop.yml`, so Rubocop now does run on a `staging` to
`production` PR, which was not true for #1030. There is still no RSpec workflow at all, so the
seven spec files including the new `spec/pro_marketing_wording_spec.rb` only ever run locally.

## Screenshots (if appropriate):

All four reframing PRs carry before and after screenshots. Rather than re-hosting them, see
#1039, #1040, #1041 and #1042.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

AI use: this description was written by Claude Code (Opus 5). The underlying commits were
reviewed in #1034, #1039, #1040, #1041 and #1042.

Assisted-by: Claude Code:claude-opus-5
