### PR TITLE
Accept Stripe promotion codes at Pro signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   - [Seeding test data](#seeding-test-data)
   - [Pro subscriptions](#pro-subscriptions)
     - [Restricting a coupon to a billing interval](#restricting-a-coupon-to-a-billing-interval)
+    - [Promotion codes](#promotion-codes)
   - [Contributing](#contributing)
   - [Deployment](#deployment)
     - [Prerequisites](#prerequisites)
@@ -147,6 +148,45 @@ never advertised that checkout would then reject.
 For extra defence-in-depth you can also set the coupon's native `applies_to`
 products to the Pro product; this stops it discounting any other product, though
 it still can't separate monthly from annual.
+
+### Promotion codes
+
+The "Do you have a coupon code?" field on the plan page accepts a Stripe
+**promotion code** as well as a coupon id. A promotion code is a customer-facing
+string pointing at a coupon, and it carries restrictions a coupon cannot express:
+a redemption cap for that code alone, first-time subscribers only, and an expiry
+independent of the coupon's. Many codes can share one coupon, so a campaign can
+be tracked and retired without touching the discount itself.
+
+To add one, open the coupon in the Stripe dashboard and create a promotion code
+against it.
+
+Two things differ from coupons:
+
+- **Promotion codes are not namespaced.** Coupon ids are prefixed with
+  `STRIPE_NAMESPACE` (a typed `FOO` looks up the coupon `RTK-FOO`), but a
+  promotion code is matched exactly as typed. Create the code as the string you
+  want people to type.
+- **Coupons win a collision.** A typed code is looked up as a coupon first, then
+  as a promotion code, so a coupon `RTK-FOO` takes precedence over a promotion
+  code `FOO`. Avoid using the same string for both.
+
+Only **active** promotion codes resolve. Stripe deactivates a code when it
+expires or hits its redemption cap, and a deactivated code reads as invalid
+rather than expired.
+
+Who enforces what:
+
+| Restriction | Enforced by |
+| --- | --- |
+| `max_redemptions`, `expires_at`, per-customer | Stripe, on redemption |
+| `first_time_transaction` | Stripe, plus a check here before any charge |
+| `interval` metadata (see above) | This theme |
+| `minimum_amount` | Nobody - Stripe refuses these on subscriptions, so the code is rejected as invalid |
+
+The `interval` and `humanized_terms` metadata keys are read from the underlying
+coupon. You can override either on the promotion code's own metadata, so one
+coupon can back several codes that describe themselves differently.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -181,8 +181,12 @@ Who enforces what:
 | --- | --- |
 | `max_redemptions`, `expires_at`, per-customer | Stripe, on redemption |
 | `first_time_transaction` | Stripe, plus a check here before any charge |
+| `minimum_amount` | Stripe, plus a check here before any charge |
 | `interval` metadata (see above) | This theme |
-| `minimum_amount` | Nobody - Stripe refuses these on subscriptions, so the code is rejected as invalid |
+
+A `minimum_amount` is compared against the plan price **before tax and before
+the discount**, so a $10 monthly plan meets a minimum of 1000 but not 1050. A
+minimum set only in another currency is treated as unmeetable.
 
 The `interval` and `humanized_terms` metadata keys are read from the underlying
 coupon. You can override either on the promotion code's own metadata, so one

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -101,7 +101,7 @@ Rails.configuration.to_prepare do # rubocop:disable Metrics/BlockLength
         { status: 'invalid', message: _('Coupon code is invalid.') }
       elsif !coupon.valid
         { status: 'expired', message: _('Coupon code has expired.') }
-      elsif (message = promotion_code_error(coupon))
+      elsif (message = promotion_code_error(coupon, price))
         { status: 'invalid', message: message }
       elsif mismatched_currency?(coupon)
         { status: 'invalid', message: _('Coupon code is invalid.') }
@@ -249,7 +249,7 @@ Rails.configuration.to_prepare do # rubocop:disable Metrics/BlockLength
     def check_promotion_code_redeemable
       return unless @coupon && @price
 
-      message = promotion_code_error(@coupon)
+      message = promotion_code_error(@coupon, @price)
       return unless message
 
       flash[:error] = message

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'help_page_history'
+require 'models/alaveteli_pro/promotion_code'
+require 'models/alaveteli_pro/discount_code_resolution'
+require 'promotion_code_subscriptions'
 
 # Add a callback - to be executed before each request in development,
 # and at startup in production - to patch existing app classes.
@@ -8,7 +11,7 @@ require 'help_page_history'
 # classes are reloaded, but initialization is not run each time.
 # See http://stackoverflow.com/questions/7072758/plugin-not-reloading-in-development-mode
 #
-Rails.configuration.to_prepare do
+Rails.configuration.to_prepare do # rubocop:disable Metrics/BlockLength
   HelpController.class_eval do
     before_action :set_history
 
@@ -31,6 +34,8 @@ Rails.configuration.to_prepare do
   # PlansController#show (login required, pro membership not) and skips
   # html_response so it can render JSON.
   AlaveteliPro::PlansController.class_eval do
+    include AlaveteliPro::DiscountCodeResolution
+
     # raise: false so that an upstream rename of the html_response callback
     # degrades this action rather than failing to boot the whole application.
     skip_before_action :html_response, only: [:coupon_preview], raise: false
@@ -85,15 +90,19 @@ Rails.configuration.to_prepare do
     def coupon_preview_json(price, code)
       return empty_preview(price) if code.blank?
 
-      coupon = AlaveteliPro::Coupon.retrieve(code)
+      coupon = resolve_discount_code(code)
 
       # Existence is not validity: a coupon can exist in Stripe yet be rejected
       # at checkout (expired, max redemptions reached, etc). Mirror the two
-      # failure messages SubscriptionsController#create surfaces.
+      # failure messages SubscriptionsController#create surfaces, and the
+      # promotion code restrictions check_promotion_code_redeemable applies, so
+      # the preview never advertises a discount checkout then refuses.
       if coupon.nil?
         { status: 'invalid', message: _('Coupon code is invalid.') }
       elsif !coupon.valid
         { status: 'expired', message: _('Coupon code has expired.') }
+      elsif (message = promotion_code_error(coupon))
+        { status: 'invalid', message: message }
       elsif mismatched_currency?(coupon)
         { status: 'invalid', message: _('Coupon code is invalid.') }
       elsif mismatched_interval?(price, coupon)
@@ -206,9 +215,18 @@ Rails.configuration.to_prepare do
   # block unconditionally and only checks flash[:error] afterwards, so a late
   # error would still charge the customer at full price before redirecting.
   AlaveteliPro::SubscriptionsController.class_eval do
-    before_action :check_coupon_matches_price, only: [:create]
+    include AlaveteliPro::DiscountCodeResolution
+
+    before_action :check_coupon_matches_price,
+                  :check_promotion_code_redeemable, only: [:create]
 
     private
+
+    # Accept a Stripe promotion code as well as a coupon id. Core's version
+    # only tries AlaveteliPro::Coupon, which resolves a namespaced coupon id.
+    def load_coupon
+      @coupon = resolve_discount_code(params[:coupon_code])
+    end
 
     def check_coupon_matches_price
       return unless @coupon && @price
@@ -220,5 +238,24 @@ Rails.configuration.to_prepare do
       flash[:error] = _('This coupon code cannot be used with this plan.')
       json_redirect_to plan_path(@price)
     end
+
+    # Refuse a promotion code Stripe would reject, for the same reason
+    # check_coupon_matches_price halts here rather than setting flash[:error]
+    # late: create runs its subscription-creating block unconditionally, so a
+    # late error still charges the person at full price.
+    #
+    # A code exhausted between this check and the charge still falls through to
+    # core's generic error. That race is rare and not worth guarding.
+    def check_promotion_code_redeemable
+      return unless @coupon && @price
+
+      message = promotion_code_error(@coupon)
+      return unless message
+
+      flash[:error] = message
+      json_redirect_to plan_path(@price)
+    end
   end
+
+  AlaveteliPro::SubscriptionCollection.prepend(PromotionCodeSubscriptions)
 end

--- a/lib/models/alaveteli_pro/discount_code_resolution.rb
+++ b/lib/models/alaveteli_pro/discount_code_resolution.rb
@@ -34,7 +34,7 @@ module AlaveteliPro
 
       if !discount.valid || discount.exhausted?
         _('Coupon code has expired.')
-      elsif below_minimum_amount?(discount, price)
+      elsif minimum_amount_unmet?(discount, price)
         _('This coupon code cannot be used with this plan.')
       elsif discount.first_time_transaction? && returning_customer?
         _('This coupon code is only available to new subscribers.')
@@ -44,18 +44,25 @@ module AlaveteliPro
     # A promotion code can require a minimum purchase. Verified against Stripe
     # test mode: it compares the minimum with the price *before* tax and
     # *before* the discount, and rejects the subscription outright if the price
-    # falls short. A minimum in another currency can't be met at all.
-    def below_minimum_amount?(discount, price)
+    # falls short.
+    #
+    # A minimum priced in another currency counts as unmet. Stripe can carry
+    # per-currency minimums in restrictions.currency_options, which we don't
+    # read - refusing is the conservative reading, and the site only sells in
+    # one currency.
+    def minimum_amount_unmet?(discount, price)
       minimum = discount.minimum_amount
       return false if minimum.blank?
-
-      currency = discount.minimum_amount_currency
-      if currency.present? &&
-         currency.downcase != AlaveteliConfiguration.iso_currency_code.downcase
-        return true
-      end
+      return true if mismatched_minimum_currency?(discount)
 
       price.unit_amount < minimum
+    end
+
+    def mismatched_minimum_currency?(discount)
+      currency = discount.minimum_amount_currency
+      return false if currency.blank?
+
+      currency.downcase != AlaveteliConfiguration.iso_currency_code.downcase
     end
 
     # first_time_transaction is the one restriction we cannot read off the
@@ -64,13 +71,17 @@ module AlaveteliPro
     # SubscriptionsController#create builds it later - so they pass. Only
     # called for codes that actually carry the restriction.
     #
+    # Void invoices don't count, matching Stripe: a customer with "no prior
+    # payments or non-void invoices" is still a first-time transaction. Counting
+    # them would refuse a discount Stripe would have honoured.
+    #
     # On a Stripe error, let them through: Stripe still enforces the
     # restriction when the subscription is created.
     def returning_customer?
       pro_account = current_user.pro_account
       return false unless pro_account
 
-      pro_account.invoices.any?
+      pro_account.invoices.any? { |invoice| invoice.status != 'void' }
     rescue Stripe::StripeError
       false
     end

--- a/lib/models/alaveteli_pro/discount_code_resolution.rb
+++ b/lib/models/alaveteli_pro/discount_code_resolution.rb
@@ -29,16 +29,33 @@ module AlaveteliPro
     #
     # Returns nil when the code is redeemable, or when it isn't a promotion
     # code at all.
-    def promotion_code_error(discount)
+    def promotion_code_error(discount, price)
       return unless discount.is_a?(AlaveteliPro::PromotionCode)
 
       if !discount.valid || discount.exhausted?
         _('Coupon code has expired.')
-      elsif discount.minimum_amount?
-        _('Coupon code is invalid.')
+      elsif below_minimum_amount?(discount, price)
+        _('This coupon code cannot be used with this plan.')
       elsif discount.first_time_transaction? && returning_customer?
         _('This coupon code is only available to new subscribers.')
       end
+    end
+
+    # A promotion code can require a minimum purchase. Verified against Stripe
+    # test mode: it compares the minimum with the price *before* tax and
+    # *before* the discount, and rejects the subscription outright if the price
+    # falls short. A minimum in another currency can't be met at all.
+    def below_minimum_amount?(discount, price)
+      minimum = discount.minimum_amount
+      return false if minimum.blank?
+
+      currency = discount.minimum_amount_currency
+      if currency.present? &&
+         currency.downcase != AlaveteliConfiguration.iso_currency_code.downcase
+        return true
+      end
+
+      price.unit_amount < minimum
     end
 
     # first_time_transaction is the one restriction we cannot read off the

--- a/lib/models/alaveteli_pro/discount_code_resolution.rb
+++ b/lib/models/alaveteli_pro/discount_code_resolution.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module AlaveteliPro
+  # Shared by the theme's patches to AlaveteliPro::PlansController and
+  # AlaveteliPro::SubscriptionsController, so the coupon preview and the
+  # checkout resolve a typed code - and judge whether it can be redeemed - in
+  # exactly the same way. If the two diverge we advertise a discount that
+  # checkout then refuses.
+  module DiscountCodeResolution
+    # Everything here is private: these are mixed into controllers, where a
+    # public instance method would become an action.
+
+    private
+
+    # Coupon first, matching core's AlaveteliPro::SubscriptionsController
+    # #load_coupon, then promotion code. Coupon ids are namespaced (a typed
+    # FOO looks up RTK-FOO) while promotion codes are matched verbatim, so a
+    # coupon RTK-FOO wins over a promotion code FOO. Documented in the README.
+    def resolve_discount_code(code)
+      AlaveteliPro::Coupon.retrieve(code) ||
+        AlaveteliPro::PromotionCode.retrieve(code)
+    end
+
+    # Reasons a promotion code cannot be redeemed, so we can refuse before any
+    # charge is attempted. Stripe would refuse most of these itself, but core's
+    # SubscriptionsController#create only maps "No such coupon" and "Coupon
+    # expired" to a useful message - anything else shows a generic payment
+    # failure and emails an exception notification.
+    #
+    # Returns nil when the code is redeemable, or when it isn't a promotion
+    # code at all.
+    def promotion_code_error(discount)
+      return unless discount.is_a?(AlaveteliPro::PromotionCode)
+
+      if !discount.valid || discount.exhausted?
+        _('Coupon code has expired.')
+      elsif discount.minimum_amount?
+        _('Coupon code is invalid.')
+      elsif discount.first_time_transaction? && returning_customer?
+        _('This coupon code is only available to new subscribers.')
+      end
+    end
+
+    # first_time_transaction is the one restriction we cannot read off the
+    # promotion code, because it depends on the person's payment history. A
+    # first-time subscriber has no Stripe customer yet - core's
+    # SubscriptionsController#create builds it later - so they pass. Only
+    # called for codes that actually carry the restriction.
+    #
+    # On a Stripe error, let them through: Stripe still enforces the
+    # restriction when the subscription is created.
+    def returning_customer?
+      pro_account = current_user.pro_account
+      return false unless pro_account
+
+      pro_account.invoices.any?
+    rescue Stripe::StripeError
+      false
+    end
+  end
+end

--- a/lib/models/alaveteli_pro/discount_code_resolution.rb
+++ b/lib/models/alaveteli_pro/discount_code_resolution.rb
@@ -16,6 +16,18 @@ module AlaveteliPro
     # #load_coupon, then promotion code. Coupon ids are namespaced (a typed
     # FOO looks up RTK-FOO) while promotion codes are matched verbatim, so a
     # coupon RTK-FOO wins over a promotion code FOO. Documented in the README.
+    #
+    # Returns an AlaveteliPro::Coupon or an AlaveteliPro::PromotionCode. The
+    # two are interchangeable for everything the signup flow does with a
+    # discount - id, valid, percent_off, amount_off, currency, metadata, terms,
+    # to_param - so callers don't branch on the type, except
+    # promotion_code_error below, which checks restrictions only a promotion
+    # code has.
+    #
+    # Supporting both costs a second Stripe round trip whenever the typed
+    # string turns out to be a promotion code: the coupon lookup has to fail
+    # first. That's inherent to searching two namespaces, and it's why the
+    # preview endpoint is rate limited.
     def resolve_discount_code(code)
       AlaveteliPro::Coupon.retrieve(code) ||
         AlaveteliPro::PromotionCode.retrieve(code)
@@ -75,8 +87,12 @@ module AlaveteliPro
     # payments or non-void invoices" is still a first-time transaction. Counting
     # them would refuse a discount Stripe would have honoured.
     #
-    # On a Stripe error, let them through: Stripe still enforces the
-    # restriction when the subscription is created.
+    # On a Stripe error, let them through. This check is advisory - it exists
+    # to turn Stripe's rejection into a clear message instead of a generic
+    # payment failure and an exception email - and Stripe remains the
+    # enforcement point at create. So failing open costs a worse error message,
+    # not a bypass, whereas failing closed would refuse legitimate subscribers
+    # during a Stripe blip.
     def returning_customer?
       pro_account = current_user.pro_account
       return false unless pro_account

--- a/lib/models/alaveteli_pro/promotion_code.rb
+++ b/lib/models/alaveteli_pro/promotion_code.rb
@@ -38,8 +38,12 @@ module AlaveteliPro
       promotion_code = Stripe::PromotionCode.list(
         code: code, active: true, limit: 1
       ).data.first
+      return unless promotion_code
 
-      new(promotion_code) if promotion_code
+      # Resolve the coupon here rather than lazily, so a coupon we can't fetch
+      # leaves us with nil - an invalid code - instead of raising later from
+      # inside a before_action, where it would be a 500 rather than a message.
+      new(promotion_code).tap(&:coupon)
     rescue Stripe::InvalidRequestError
       nil
     end
@@ -68,6 +72,14 @@ module AlaveteliPro
     # and StripeObject raises NoMethodError for an absent attribute.
     def name
       coupon.name if coupon.respond_to?(:name)
+    end
+
+    # Mirrors AlaveteliPro::Coupon#terms, which is part of the interface this
+    # class stands in for and is rendered by core's subscriptions view. Reads
+    # the merged metadata rather than the coupon's, so a code can describe
+    # itself differently from the coupon behind it.
+    def terms
+      metadata[:humanized_terms].presence || name
     end
 
     def exhausted?

--- a/lib/models/alaveteli_pro/promotion_code.rb
+++ b/lib/models/alaveteli_pro/promotion_code.rb
@@ -44,6 +44,13 @@ module AlaveteliPro
       # leaves us with nil - an invalid code - instead of raising later from
       # inside a before_action, where it would be a 500 rather than a message.
       new(promotion_code).tap(&:coupon)
+
+    # Deliberately narrow, matching AlaveteliPro::Coupon.retrieve. Only
+    # InvalidRequestError means "no such code"; a connection or rate limit
+    # error means we don't know. Swallowing those would return nil, and core's
+    # create only attaches a discount when one is present - so a Stripe blip
+    # would quietly charge somebody full price instead of applying the code
+    # they typed. Raising is the safer failure here.
     rescue Stripe::InvalidRequestError
       nil
     end
@@ -64,8 +71,15 @@ module AlaveteliPro
     # `humanized_terms` live on the coupon. Merge the two so one coupon can
     # back several codes that describe themselves differently, with the code
     # winning.
+    #
+    # Returned as a StripeObject, not a Hash, so it behaves exactly like
+    # AlaveteliPro::Coupon#metadata: callers reading `metadata.humanized_terms`
+    # (as core's Coupon#terms does) work against either kind of discount, and
+    # an absent key raises NoMethodError on both rather than only on one.
     def metadata
-      coupon.metadata.to_h.merge(__getobj__.metadata.to_h)
+      Stripe::StripeObject.construct_from(
+        coupon.metadata.to_h.merge(__getobj__.metadata.to_h)
+      )
     end
 
     # Read defensively: Stripe omits the attribute rather than returning null,

--- a/lib/models/alaveteli_pro/promotion_code.rb
+++ b/lib/models/alaveteli_pro/promotion_code.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module AlaveteliPro
+  # A wrapper for a Stripe::PromotionCode that can stand in for an
+  # AlaveteliPro::Coupon anywhere the Pro signup flow expects one.
+  #
+  # A promotion code is a customer-facing string pointing at a coupon, and it
+  # carries the restrictions a coupon cannot express: a redemption cap per
+  # code, first-time subscribers only, an expiry independent of the coupon's.
+  # Stripe only enforces those if the subscription is created with
+  # `promotion_code:`, which is why #id keeps returning the promotion code's
+  # own id rather than the coupon's - see PromotionCodeSubscriptions, which
+  # moves that id to the right Stripe parameter.
+  #
+  # Unlike coupon ids, promotion codes are not namespaced: the code is looked
+  # up exactly as typed.
+  class PromotionCode < SimpleDelegator
+    # Marks an id as a promotion code's rather than a coupon's. It is a String
+    # everywhere it matters - Stripe serialises it, specs compare it - but it
+    # lets PromotionCodeSubscriptions route the id to the right Stripe
+    # parameter without guessing from the id's format.
+    class Id < String; end
+
+    # The discount itself lives on the coupon behind the code. A promotion code
+    # has no percent_off or amount_off of its own, so everything the price
+    # arithmetic and the preview need has to come from the coupon.
+    delegate :amount_off, :percent_off, :currency, :duration,
+             :duration_in_months, to: :coupon
+
+    # Filtering on active: true means an expired or exhausted code does not
+    # resolve at all, and so reads as invalid rather than expired. That is the
+    # right trade: Stripe only guarantees a code is unique amongst *active*
+    # promotion codes, so dropping the filter could match a retired code that
+    # shares its string with a live one.
+    def self.retrieve(code)
+      return if code.blank?
+
+      promotion_code = Stripe::PromotionCode.list(
+        code: code, active: true, limit: 1
+      ).data.first
+
+      new(promotion_code) if promotion_code
+    rescue Stripe::InvalidRequestError
+      nil
+    end
+
+    def id
+      Id.new(__getobj__.id)
+    end
+
+    def coupon
+      @coupon ||= AlaveteliPro::Coupon.new(stripe_coupon)
+    end
+
+    def valid
+      active && coupon.valid
+    end
+
+    # Restrictions live on the promotion code; the `interval` restriction and
+    # `humanized_terms` live on the coupon. Merge the two so one coupon can
+    # back several codes that describe themselves differently, with the code
+    # winning.
+    def metadata
+      coupon.metadata.to_h.merge(__getobj__.metadata.to_h)
+    end
+
+    # Read defensively: Stripe omits the attribute rather than returning null,
+    # and StripeObject raises NoMethodError for an absent attribute.
+    def name
+      coupon.name if coupon.respond_to?(:name)
+    end
+
+    def exhausted?
+      max_redemptions.present? && times_redeemed >= max_redemptions
+    end
+
+    # Stripe refuses a minimum_amount promotion code on a subscription
+    # outright, so there is nothing useful we can do with one here.
+    def minimum_amount?
+      restrictions.to_h[:minimum_amount].present?
+    end
+
+    def first_time_transaction?
+      !!restrictions.to_h[:first_time_transaction]
+    end
+
+    def to_param
+      code
+    end
+
+    private
+
+    # Stripe returns the coupon expanded, but a bare id would put a String
+    # behind the delegator and every discount attribute above would raise.
+    def stripe_coupon
+      stripe_coupon = __getobj__.coupon
+      return stripe_coupon unless stripe_coupon.is_a?(String)
+
+      Stripe::Coupon.retrieve(stripe_coupon)
+    end
+  end
+end

--- a/lib/models/alaveteli_pro/promotion_code.rb
+++ b/lib/models/alaveteli_pro/promotion_code.rb
@@ -74,10 +74,12 @@ module AlaveteliPro
       max_redemptions.present? && times_redeemed >= max_redemptions
     end
 
-    # Stripe refuses a minimum_amount promotion code on a subscription
-    # outright, so there is nothing useful we can do with one here.
-    def minimum_amount?
-      restrictions.to_h[:minimum_amount].present?
+    def minimum_amount
+      restrictions.to_h[:minimum_amount]
+    end
+
+    def minimum_amount_currency
+      restrictions.to_h[:minimum_amount_currency]
     end
 
     def first_time_transaction?

--- a/lib/promotion_code_subscriptions.rb
+++ b/lib/promotion_code_subscriptions.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Sends a promotion code to Stripe as a promotion code.
+#
+# AlaveteliPro::SubscriptionsController#create writes the discount id under
+# `coupon:` whatever it is, and we can't change core. A promotion code id has
+# to reach Stripe as `promotion_code:` instead, so that Stripe applies the
+# code, enforces its restrictions and counts the redemption - applying the
+# underlying coupon directly would leave times_redeemed at zero and
+# max_redemptions never counting down.
+#
+# The id gets there via #load_coupon in lib/controller_patches.rb, and carries
+# AlaveteliPro::PromotionCode::Id so we don't have to guess its kind from the
+# string.
+module PromotionCodeSubscriptions
+  def create(attributes = {})
+    id = attributes[:coupon]
+    return super unless id.is_a?(AlaveteliPro::PromotionCode::Id)
+
+    super(attributes.except(:coupon).merge(promotion_code: id.to_s))
+  end
+end

--- a/spec/coupon_preview_rate_limit_spec.rb
+++ b/spec/coupon_preview_rate_limit_spec.rb
@@ -83,6 +83,25 @@ RSpec.describe AlaveteliPro::PlansController, type: :controller do
       end
     end
 
+    # A typed code is looked up as a coupon and then as a promotion code, so
+    # the endpoint is an existence oracle over both namespaces. Promotion codes
+    # are not namespaced, which makes them the easier of the two to guess. The
+    # limiter has to short circuit before either lookup, otherwise a throttled
+    # user still learns what exists and still amplifies against Stripe.
+    context 'when the user is over the limit' do
+      before do
+        allow(limiter).to receive(:limit?).and_return(true)
+        allow(Stripe::Coupon).to receive(:retrieve).and_call_original
+        allow(Stripe::PromotionCode).to receive(:list).and_call_original
+        get :coupon_preview, params: { price_id: 'pro', coupon_code: 'SUMMER25' }
+      end
+
+      it 'does not look the code up in either namespace' do
+        expect(Stripe::Coupon).not_to have_received(:retrieve)
+        expect(Stripe::PromotionCode).not_to have_received(:list)
+      end
+    end
+
     # The field is cleared and retyped in ordinary use, and a blank code is
     # answered from the price alone without touching Stripe, so it must not
     # consume the allowance.

--- a/spec/coupon_preview_spec.rb
+++ b/spec/coupon_preview_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe AlaveteliPro::PlansController, type: :controller do # rubocop:dis
       end
     end
 
-    context 'with a signed-in user' do
+    context 'with a signed-in user' do # rubocop:disable Metrics/BlockLength
       before { sign_in user }
 
       context 'with a blank coupon code' do
@@ -223,6 +223,46 @@ RSpec.describe AlaveteliPro::PlansController, type: :controller do # rubocop:dis
           expect(json['status']).to eq('invalid')
           expect(json['message'])
             .to eq('This coupon code cannot be used with this plan.')
+        end
+      end
+
+      # A promotion code resolves through the same path as a coupon, so the
+      # preview and checkout can't disagree - see
+      # AlaveteliPro::DiscountCodeResolution and spec/promotion_code_spec.rb.
+      context 'with a promotion code' do
+        before do
+          stripe_helper.create_coupon(
+            id: 'HALF', percent_off: 50, amount_off: nil, currency: nil
+          )
+          Stripe::PromotionCode.create(coupon: 'HALF', code: 'SUMMER25')
+          get :coupon_preview,
+              params: { price_id: 'pro', coupon_code: 'SUMMER25' }
+        end
+
+        it "previews the underlying coupon's discount" do
+          expect(json['status']).to eq('valid')
+          expect(json['amount']).to eq(money(2475)) # 4500 - 50% + 10% tax
+        end
+      end
+
+      context 'with a promotion code that is no longer active' do
+        before do
+          stripe_helper.create_coupon(
+            id: 'HALF', percent_off: 50, amount_off: nil, currency: nil
+          )
+          Stripe::PromotionCode.create(
+            coupon: 'HALF', code: 'SUMMER25', active: false
+          )
+          get :coupon_preview,
+              params: { price_id: 'pro', coupon_code: 'SUMMER25' }
+        end
+
+        # Stripe deactivates a promotion code when it expires or is exhausted,
+        # and the lookup only asks for active codes, so a dead code doesn't
+        # resolve at all and reads as invalid rather than expired.
+        it 'reports the code as invalid' do
+          expect(json['status']).to eq('invalid')
+          expect(json['message']).to eq('Coupon code is invalid.')
         end
       end
 

--- a/spec/coupon_preview_spec.rb
+++ b/spec/coupon_preview_spec.rb
@@ -266,6 +266,57 @@ RSpec.describe AlaveteliPro::PlansController, type: :controller do # rubocop:dis
         end
       end
 
+      # The preview applies the same restriction checks as checkout, including
+      # first_time_transaction, which is the one that has to read the person's
+      # payment history. current_user is a private alias of authenticated_user
+      # on ApplicationController, so it resolves here as it does anywhere else -
+      # it is not stubbed below, precisely so this exercises the real thing.
+      context 'with a promotion code for new subscribers only' do
+        before do
+          stripe_helper.create_coupon(
+            id: 'HALF', percent_off: 50, amount_off: nil, currency: nil
+          )
+          Stripe::PromotionCode.create(
+            coupon: 'HALF', code: 'SUMMER25',
+            restrictions: {
+              first_time_transaction: true,
+              minimum_amount: nil,
+              minimum_amount_currency: nil
+            }
+          )
+        end
+
+        context 'and the person has already paid an invoice' do
+          before do
+            customer = Stripe::Customer.create(email: user.email)
+            user.create_pro_account(stripe_customer_id: customer.id)
+            allow(Stripe::Invoice).to receive(:list)
+              .and_return([double(:invoice, status: 'paid')])
+
+            get :coupon_preview,
+                params: { price_id: 'pro', coupon_code: 'SUMMER25' }
+          end
+
+          it 'says so rather than previewing a discount they cannot have' do
+            expect(json['status']).to eq('invalid')
+            expect(json['message'])
+              .to eq('This coupon code is only available to new subscribers.')
+          end
+        end
+
+        context 'and the person is new' do
+          before do
+            get :coupon_preview,
+                params: { price_id: 'pro', coupon_code: 'SUMMER25' }
+          end
+
+          it 'previews the discount' do
+            expect(json['status']).to eq('valid')
+            expect(json['amount']).to eq(money(2475))
+          end
+        end
+      end
+
       context 'with an unknown price_id' do
         before do
           get :coupon_preview, params: { price_id: 'nope', coupon_code: 'HALF' }

--- a/spec/promotion_code_spec.rb
+++ b/spec/promotion_code_spec.rb
@@ -160,6 +160,27 @@ RSpec.describe AlaveteliPro::SubscriptionsController, # rubocop:disable Metrics/
 
       expect(AlaveteliPro::PromotionCode.retrieve('SUMMER25')).to be_nil
     end
+
+    # The rescue in retrieve is deliberately narrow. Swallowing a connection
+    # error would return nil, and core only attaches a discount when one is
+    # present, so a Stripe blip would quietly charge full price instead of
+    # applying the code. Better to fail loudly and take no money.
+    it 'does not treat a Stripe outage as an unknown code' do
+      allow(Stripe::PromotionCode).to receive(:list).and_raise(
+        Stripe::APIConnectionError.new('could not connect')
+      )
+
+      expect { AlaveteliPro::PromotionCode.retrieve('SUMMER25') }
+        .to raise_error(Stripe::APIConnectionError)
+    end
+
+    # Interchangeable with a coupon: metadata is a StripeObject on both, so a
+    # caller reading metadata.humanized_terms works either way.
+    it 'exposes metadata the same way a coupon does' do
+      expect(subject.metadata).to be_a(Stripe::StripeObject)
+      expect(AlaveteliPro::Coupon.retrieve('HALFOFF').metadata)
+        .to be_a(Stripe::StripeObject)
+    end
   end
 
   describe 'metadata' do
@@ -170,8 +191,12 @@ RSpec.describe AlaveteliPro::SubscriptionsController, # rubocop:disable Metrics/
       )
       create_promotion_code(coupon: 'MONTHLYONLY')
 
-      expect(AlaveteliPro::PromotionCode.retrieve('SUMMER25').metadata)
-        .to include(interval: 'month')
+      metadata = AlaveteliPro::PromotionCode.retrieve('SUMMER25').metadata
+
+      # Both access styles, because check_coupon_matches_price reads
+      # metadata.to_h[:interval] and core's Coupon#terms reads the accessor.
+      expect(metadata.to_h).to include(interval: 'month')
+      expect(metadata.interval).to eq('month')
     end
 
     it 'lets the promotion code override the coupon' do
@@ -183,7 +208,7 @@ RSpec.describe AlaveteliPro::SubscriptionsController, # rubocop:disable Metrics/
         coupon: 'TERMED', metadata: { humanized_terms: '50% off' }
       )
 
-      expect(AlaveteliPro::PromotionCode.retrieve('SUMMER25').metadata)
+      expect(AlaveteliPro::PromotionCode.retrieve('SUMMER25').metadata.to_h)
         .to include(humanized_terms: '50% off')
     end
 
@@ -368,6 +393,26 @@ RSpec.describe AlaveteliPro::SubscriptionsController, # rubocop:disable Metrics/
         before { stub_invoices('void', 'void') }
 
         it 'subscribes the user' do
+          subscribe('SUMMER25')
+
+          expect(assigns(:subscription)).not_to be_nil
+        end
+      end
+
+      # The check is advisory - Stripe enforces the restriction at create - so
+      # failing open costs a worse error message, not a bypass. Failing closed
+      # would refuse legitimate subscribers during a Stripe blip.
+      context 'and the invoice lookup fails' do
+        before do
+          pro_account = FactoryBot.create(:pro_account, user: user)
+          allow(pro_account).to receive(:invoices).and_raise(
+            Stripe::APIConnectionError.new('could not connect')
+          )
+          allow(user).to receive(:pro_account).and_return(pro_account)
+          allow(controller).to receive(:current_user).and_return(user)
+        end
+
+        it 'lets the person through rather than refusing them' do
           subscribe('SUMMER25')
 
           expect(assigns(:subscription)).not_to be_nil

--- a/spec/promotion_code_spec.rb
+++ b/spec/promotion_code_spec.rb
@@ -143,6 +143,23 @@ RSpec.describe AlaveteliPro::SubscriptionsController, # rubocop:disable Metrics/
     it 'exposes the typed code as the param' do
       expect(subject.to_param).to eq('SUMMER25')
     end
+
+    # AlaveteliPro::Coupon#terms is part of the interface this class stands in
+    # for, and core's subscriptions view renders it.
+    it 'describes itself the way a coupon does' do
+      expect(subject).to respond_to(:terms)
+      expect(subject.terms).to eq(subject.name)
+    end
+
+    # A coupon that can't be fetched must leave us with an invalid code, not an
+    # exception raised later from inside a before_action.
+    it 'resolves to nil when the coupon behind it cannot be fetched' do
+      allow(Stripe::Coupon).to receive(:retrieve).and_raise(
+        Stripe::InvalidRequestError.new('No such coupon', 'coupon')
+      )
+
+      expect(AlaveteliPro::PromotionCode.retrieve('SUMMER25')).to be_nil
+    end
   end
 
   describe 'metadata' do
@@ -168,6 +185,17 @@ RSpec.describe AlaveteliPro::SubscriptionsController, # rubocop:disable Metrics/
 
       expect(AlaveteliPro::PromotionCode.retrieve('SUMMER25').metadata)
         .to include(humanized_terms: '50% off')
+    end
+
+    it 'describes itself with the humanized terms' do
+      stripe_helper.create_coupon(
+        id: 'TERMED', percent_off: 50, amount_off: nil, currency: nil,
+        metadata: { humanized_terms: 'half price' }
+      )
+      create_promotion_code(coupon: 'TERMED')
+
+      expect(AlaveteliPro::PromotionCode.retrieve('SUMMER25').terms)
+        .to eq('half price')
     end
   end
 
@@ -307,7 +335,15 @@ RSpec.describe AlaveteliPro::SubscriptionsController, # rubocop:disable Metrics/
       end
     end
 
-    context 'when the code is for new subscribers and the user has invoices' do
+    context 'when the code is for new subscribers' do
+      def stub_invoices(*statuses)
+        pro_account = FactoryBot.create(:pro_account, user: user)
+        invoices = statuses.map { |status| double(:invoice, status: status) }
+        allow(pro_account).to receive(:invoices).and_return(invoices)
+        allow(user).to receive(:pro_account).and_return(pro_account)
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
       before do
         create_promotion_code(
           restrictions: {
@@ -316,15 +352,27 @@ RSpec.describe AlaveteliPro::SubscriptionsController, # rubocop:disable Metrics/
             minimum_amount_currency: nil
           }
         )
-
-        pro_account = FactoryBot.create(:pro_account, user: user)
-        allow(pro_account).to receive(:invoices).and_return([double(:invoice)])
-        allow(user).to receive(:pro_account).and_return(pro_account)
-        allow(controller).to receive(:current_user).and_return(user)
       end
 
-      include_examples 'refused before any charge',
-                       'This coupon code is only available to new subscribers.'
+      context 'and the user has paid an invoice' do
+        before { stub_invoices('paid') }
+
+        include_examples 'refused before any charge',
+                         'This coupon code is only available to new subscribers.'
+      end
+
+      # Stripe treats a customer with no payments and no *non-void* invoices as
+      # a first-time transaction, so counting void invoices here would refuse a
+      # discount Stripe would have honoured.
+      context 'and the user only has void invoices' do
+        before { stub_invoices('void', 'void') }
+
+        it 'subscribes the user' do
+          subscribe('SUMMER25')
+
+          expect(assigns(:subscription)).not_to be_nil
+        end
+      end
     end
 
     context 'when the code is for new subscribers and the user is new' do

--- a/spec/promotion_code_spec.rb
+++ b/spec/promotion_code_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe AlaveteliPro::SubscriptionsController, # rubocop:disable Metrics/
     allow(AlaveteliConfiguration).to receive(:stripe_prices)
       .and_return('pro' => 'pro')
     allow(AlaveteliConfiguration).to receive(:stripe_tax_rate).and_return('0.0')
+    allow(AlaveteliConfiguration).to receive(:iso_currency_code)
+      .and_return('AUD')
 
     sign_in user
   end
@@ -254,8 +256,10 @@ RSpec.describe AlaveteliPro::SubscriptionsController, # rubocop:disable Metrics/
       include_examples 'refused before any charge', 'Coupon code has expired.'
     end
 
-    context 'when the code carries a minimum amount' do
-      # Stripe refuses these on subscriptions outright.
+    # Stripe compares a minimum against the price before tax and before the
+    # discount, and refuses the subscription if it falls short. The price here
+    # is 1000.
+    context 'when the price falls short of the minimum amount' do
       before do
         create_promotion_code(
           restrictions: {
@@ -266,7 +270,41 @@ RSpec.describe AlaveteliPro::SubscriptionsController, # rubocop:disable Metrics/
         )
       end
 
-      include_examples 'refused before any charge', 'Coupon code is invalid.'
+      include_examples 'refused before any charge',
+                       'This coupon code cannot be used with this plan.'
+    end
+
+    context 'when the minimum amount is in another currency' do
+      before do
+        create_promotion_code(
+          restrictions: {
+            first_time_transaction: false,
+            minimum_amount: 500,
+            minimum_amount_currency: 'usd'
+          }
+        )
+      end
+
+      include_examples 'refused before any charge',
+                       'This coupon code cannot be used with this plan.'
+    end
+
+    context 'when the price meets the minimum amount' do
+      before do
+        create_promotion_code(
+          restrictions: {
+            first_time_transaction: false,
+            minimum_amount: 500,
+            minimum_amount_currency: 'aud'
+          }
+        )
+      end
+
+      it 'subscribes the user' do
+        subscribe('SUMMER25')
+
+        expect(assigns(:subscription)).not_to be_nil
+      end
     end
 
     context 'when the code is for new subscribers and the user has invoices' do

--- a/spec/promotion_code_spec.rb
+++ b/spec/promotion_code_spec.rb
@@ -1,0 +1,310 @@
+# frozen_string_literal: true
+
+# Exercises the theme's support for Stripe promotion codes at Pro checkout,
+# added in lib/models/alaveteli_pro/promotion_code.rb,
+# lib/models/alaveteli_pro/discount_code_resolution.rb,
+# lib/promotion_code_subscriptions.rb and wired up in
+# lib/controller_patches.rb.
+#
+# Core resolves the typed code as a coupon id only, and writes whatever it
+# finds under `coupon:`. The theme falls back to a promotion code lookup, and
+# moves that id to Stripe's `promotion_code:` parameter so that Stripe applies
+# the code, enforces its restrictions and counts the redemption.
+#
+# StripeMock caveats this file works around:
+#
+# - its promotion code list handler ignores the `code:` filter and returns
+#   everything, so each example must have exactly one promotion code (it does
+#   honour `active:`)
+# - creating a subscription with `promotion_code:` is validated but no discount
+#   is attached, so the seam is asserted against the params Stripe receives
+#
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(
+  File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper')
+)
+require 'stripe_mock'
+
+RSpec.describe AlaveteliPro::SubscriptionsController, # rubocop:disable Metrics/BlockLength
+               type: :controller, feature: :pro_pricing do
+  before { StripeMock.start }
+  after { StripeMock.stop }
+
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  let(:product) { stripe_helper.create_product }
+  let(:token) { stripe_helper.generate_card_token }
+  let(:user) { FactoryBot.create(:user) }
+
+  let!(:price) do
+    stripe_helper.create_price(
+      id: 'pro', product: product.id, unit_amount: 1000
+    )
+  end
+
+  let!(:coupon) do
+    stripe_helper.create_coupon(
+      id: 'HALFOFF', percent_off: 50, amount_off: nil, currency: nil
+    )
+  end
+
+  def create_promotion_code(attributes = {})
+    Stripe::PromotionCode.create(
+      { coupon: 'HALFOFF', code: 'SUMMER25' }.merge(attributes)
+    )
+  end
+
+  def subscribe(coupon_code)
+    post :create, params: {
+      'stripe_token' => token,
+      'price_id' => 'pro',
+      'coupon_code' => coupon_code
+    }
+  end
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:stripe_prices)
+      .and_return('pro' => 'pro')
+    allow(AlaveteliConfiguration).to receive(:stripe_tax_rate).and_return('0.0')
+
+    sign_in user
+  end
+
+  describe 'POST #create with a promotion code' do
+    let!(:promotion_code) { create_promotion_code }
+
+    # The seam: core writes the id under `coupon:`, and
+    # PromotionCodeSubscriptions has to move it. If this fails, people are
+    # charged with the bare coupon applied and the promotion code's
+    # times_redeemed never moves.
+    it 'sends the promotion code to Stripe as a promotion code' do
+      allow(Stripe::Subscription).to receive(:create).and_call_original
+
+      subscribe('SUMMER25')
+
+      expect(Stripe::Subscription).to have_received(:create).with(
+        hash_including(promotion_code: promotion_code.id)
+      )
+      expect(Stripe::Subscription).not_to have_received(:create).with(
+        hash_including(:coupon)
+      )
+    end
+
+    it 'subscribes the user' do
+      subscribe('SUMMER25')
+
+      expect(response).to redirect_to(
+        authorise_subscription_path(assigns(:subscription).id)
+      )
+    end
+  end
+
+  describe 'resolution order' do
+    it 'resolves a promotion code when no coupon matches' do
+      create_promotion_code
+
+      subscribe('SUMMER25')
+
+      expect(assigns(:coupon)).to be_a(AlaveteliPro::PromotionCode)
+    end
+
+    it 'prefers a coupon of the same name over a promotion code' do
+      create_promotion_code(code: 'HALFOFF')
+
+      subscribe('HALFOFF')
+
+      expect(assigns(:coupon)).to be_a(AlaveteliPro::Coupon)
+      expect(assigns(:coupon)).not_to be_a(AlaveteliPro::PromotionCode)
+    end
+
+    it 'ignores an unknown code, as core does for an unknown coupon' do
+      subscribe('NOSUCHCODE')
+
+      expect(assigns(:coupon)).to be_nil
+    end
+  end
+
+  describe 'discount attributes read through to the coupon' do
+    let!(:promotion_code) { create_promotion_code }
+
+    subject { AlaveteliPro::PromotionCode.retrieve('SUMMER25') }
+
+    it 'keeps the promotion code id, so Stripe redeems the code' do
+      expect(subject.id).to eq(promotion_code.id)
+    end
+
+    it 'takes the discount from the underlying coupon' do
+      expect(subject.percent_off).to eq(50)
+      expect(subject.amount_off).to be_nil
+    end
+
+    it 'exposes the typed code as the param' do
+      expect(subject.to_param).to eq('SUMMER25')
+    end
+  end
+
+  describe 'metadata' do
+    it 'reads the interval restriction from the coupon' do
+      stripe_helper.create_coupon(
+        id: 'MONTHLYONLY', percent_off: 50, amount_off: nil, currency: nil,
+        metadata: { interval: 'month' }
+      )
+      create_promotion_code(coupon: 'MONTHLYONLY')
+
+      expect(AlaveteliPro::PromotionCode.retrieve('SUMMER25').metadata)
+        .to include(interval: 'month')
+    end
+
+    it 'lets the promotion code override the coupon' do
+      stripe_helper.create_coupon(
+        id: 'TERMED', percent_off: 50, amount_off: nil, currency: nil,
+        metadata: { humanized_terms: 'half price' }
+      )
+      create_promotion_code(
+        coupon: 'TERMED', metadata: { humanized_terms: '50% off' }
+      )
+
+      expect(AlaveteliPro::PromotionCode.retrieve('SUMMER25').metadata)
+        .to include(humanized_terms: '50% off')
+    end
+  end
+
+  describe 'the interval restriction still applies through a promotion code' do
+    let!(:annual_price) do
+      stripe_helper.create_price(
+        id: 'annual_price', product: product.id, unit_amount: 10_000,
+        recurring: { interval: 'year', interval_count: 1 }
+      )
+    end
+
+    before do
+      allow(AlaveteliConfiguration).to receive(:stripe_prices)
+        .and_return('pro' => 'pro', 'annual_price' => 'annual')
+
+      stripe_helper.create_coupon(
+        id: 'MONTHLYONLY', percent_off: 50, amount_off: nil, currency: nil,
+        metadata: { interval: 'month' }
+      )
+      create_promotion_code(coupon: 'MONTHLYONLY')
+
+      post :create, params: {
+        'stripe_token' => token,
+        'price_id' => 'annual',
+        'coupon_code' => 'SUMMER25'
+      }
+    end
+
+    it 'does not create a subscription' do
+      expect(assigns(:subscription)).to be_nil
+    end
+
+    it 'redirects back to the plan with an error' do
+      expect(flash[:error])
+        .to eq('This coupon code cannot be used with this plan.')
+      expect(response).to redirect_to(plan_path('annual'))
+    end
+  end
+
+  describe 'refusing a promotion code that cannot be redeemed' do
+    shared_examples 'refused before any charge' do |message|
+      it 'does not create a subscription' do
+        subscribe('SUMMER25')
+
+        expect(assigns(:subscription)).to be_nil
+      end
+
+      it 'redirects back to the plan with an error' do
+        subscribe('SUMMER25')
+
+        expect(flash[:error]).to eq(message)
+        expect(response).to redirect_to(plan_path('pro'))
+      end
+    end
+
+    # Stripe deactivates a promotion code when it expires or is exhausted, and
+    # the lookup only asks for active codes, so a dead code doesn't resolve.
+    # Core then charges the list price, exactly as it does for an unknown
+    # coupon - the preview tells people before they get that far.
+    context 'when the code is no longer active' do
+      before { create_promotion_code(active: false) }
+
+      it 'is ignored rather than applied' do
+        subscribe('SUMMER25')
+
+        expect(assigns(:coupon)).to be_nil
+        expect(assigns(:subscription)).not_to be_nil
+      end
+    end
+
+    context 'when the underlying coupon is no longer valid' do
+      before do
+        stripe_helper.create_coupon(
+          id: 'DEAD', percent_off: 50, amount_off: nil, currency: nil,
+          valid: false
+        )
+        create_promotion_code(coupon: 'DEAD')
+      end
+
+      include_examples 'refused before any charge', 'Coupon code has expired.'
+    end
+
+    context 'when the code has reached its redemption limit' do
+      before { create_promotion_code(max_redemptions: 2, times_redeemed: 2) }
+
+      include_examples 'refused before any charge', 'Coupon code has expired.'
+    end
+
+    context 'when the code carries a minimum amount' do
+      # Stripe refuses these on subscriptions outright.
+      before do
+        create_promotion_code(
+          restrictions: {
+            first_time_transaction: false,
+            minimum_amount: 5000,
+            minimum_amount_currency: 'aud'
+          }
+        )
+      end
+
+      include_examples 'refused before any charge', 'Coupon code is invalid.'
+    end
+
+    context 'when the code is for new subscribers and the user has invoices' do
+      before do
+        create_promotion_code(
+          restrictions: {
+            first_time_transaction: true,
+            minimum_amount: nil,
+            minimum_amount_currency: nil
+          }
+        )
+
+        pro_account = FactoryBot.create(:pro_account, user: user)
+        allow(pro_account).to receive(:invoices).and_return([double(:invoice)])
+        allow(user).to receive(:pro_account).and_return(pro_account)
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      include_examples 'refused before any charge',
+                       'This coupon code is only available to new subscribers.'
+    end
+
+    context 'when the code is for new subscribers and the user is new' do
+      before do
+        create_promotion_code(
+          restrictions: {
+            first_time_transaction: true,
+            minimum_amount: nil,
+            minimum_amount_currency: nil
+          }
+        )
+      end
+
+      it 'subscribes the user' do
+        subscribe('SUMMER25')
+
+        expect(assigns(:subscription)).not_to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

The "Do you have a coupon code?" field on the Pro plan page now accepts a Stripe **promotion code** as well as a coupon id, and sends it to Stripe *as* a promotion code so Stripe enforces its restrictions and counts the redemption.

Theme-only. No changes to Alaveteli core or upstream.

- `AlaveteliPro::PromotionCode` wraps a `Stripe::PromotionCode` and stands in for an `AlaveteliPro::Coupon`. It keeps its own id, so Stripe redeems the *code*, but takes `percent_off`, `amount_off`, `currency`, `metadata`, `terms` and friends from the coupon behind it. Promotion code metadata overrides the coupon's, so one coupon can back several codes that describe themselves differently.
- `AlaveteliPro::DiscountCodeResolution` is mixed into both `PlansController` and `SubscriptionsController`, so the live price preview and the checkout resolve a typed code - and judge whether it can be redeemed - identically. If the two diverged we would advertise a discount that checkout then refused.
- `PromotionCodeSubscriptions` moves the id from `coupon:` to `promotion_code:` in `AlaveteliPro::SubscriptionCollection#create`. Core's `create` action writes it under `coupon:` whatever it is, and we can't change core. The id carries a marker type rather than being sniffed for a `promo_` prefix.
- Restrictions Stripe would reject (inactive, exhausted, minimum not met, first time subscribers only) are refused in a `before_action`, before any charge. Core runs its subscription-creating block unconditionally and only checks `flash[:error]` afterwards, so a late error would still charge the person at full price.

Two deliberate differences from coupons, both documented in the README:

- **Promotion codes are not namespaced.** Coupon ids are prefixed with `STRIPE_NAMESPACE`; a promotion code is matched exactly as typed.
- **A coupon wins a collision.** A typed code is looked up as a coupon first, then as a promotion code.

## Motivation and Context

Until now the field only ever resolved a Stripe Coupon id. Coupons cannot express a redemption cap for a single code, first-time subscribers only, or a per-customer restriction, and most coupon fields are immutable once created - changing `max_redemptions`, `redeem_by` or `percent_off` means deleting and recreating the coupon. Promotion codes can do all of that, and many codes can share one coupon, so a campaign can be tracked and retired without touching the discount itself.

The important part is that the code reaches Stripe as a promotion code. Resolving it down to its underlying coupon and applying that instead looks like the smaller change, but the promotion code is then never redeemed: `times_redeemed` stays at zero and `max_redemptions` never counts down, so any cap would be measuring a number that never moves.

No existing issue - happy to raise one if it would help tracking.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

**Automated:** 77 theme specs pass (was 66 before this branch), RuboCop clean. New specs cover the seam (that `Stripe::Subscription.create` receives `promotion_code:` and not `coupon:`), resolution order, the attribute split between code and coupon, the `interval` restriction still applying through a promotion code, and each refusal branch. The specs added for review findings were each confirmed to fail when the fix is reverted, so they guard rather than decorate.

**Against real Stripe, test mode:** a script exercised the actual classes against the live test-mode API, since `stripe-ruby-mock` differs from Stripe in ways that matter here. It confirmed that `Subscription.create(promotion_code:)` is accepted under the API version Alaveteli pins (`2020-03-02`, which predates promotion codes - this was the assumption the whole design rested on), that the discount attaches, that `times_redeemed` increments, that `PromotionCode.list(code:, active: true)` matches case-insensitively with the coupon already expanded, and that core's post-purchase `Subscription::Discount` display is correct. It also established that `restrictions.minimum_amount` applies on subscription *create* and is compared against the price before tax and before the discount. All throwaway Stripe objects were deleted afterwards.

**Not done:** no browser run through `/pro/plans/pro`. The Docker app container's `bundle install` currently fails on a `ruby-msg` gemspec incompatibility with current RubyGems, which is unrelated to this change. So the preview rendering in a real browser and completing signup through the real form are unverified by me. The JSON contract and `coupon_preview.js` are unchanged, so the risk is low, but worth a manual check on staging before this comes out of draft.

## Screenshots (if appropriate):

None - there is no visual change. The field, its label and the price preview are unchanged; a promotion code simply now resolves where it previously did not.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

New README section covering how to create a promotion code, the lack of namespacing, resolution order, and which restriction is enforced by Stripe, by the theme, or not at all.

One thing I left out deliberately: the new user-facing string ("This coupon code is only available to new subscribers.") is **not** added to `locale-theme/en/app.po`. That file overrides core English rather than extracting strings, it sits first in the FastGettext chain, and an entry with an empty `msgstr` risks returning blank instead of falling back to the msgid. The three strings from the earlier coupon work aren't there either. Happy to add it if you'd rather have it recorded for translators.

## AI assistance

Assisted-by: Claude Code:claude-opus-5

Used throughout: writing the implementation, specs and documentation, and running the verification described above. I have reviewed all of it and can support the change. The design was also put through an adversarial review, which turned up two real defects that are fixed in this branch - void invoices being counted against Stripe's first-time-subscriber rule, and an unrescued Stripe call that would have been a 500 rather than an error message - plus one earlier mistake of mine, where I had wrongly assumed Stripe refuses `minimum_amount` codes on subscriptions.
