### PR TITLE
Restore login gate on Pro plan page

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -39,7 +39,18 @@ Rails.configuration.to_prepare do # rubocop:disable Metrics/BlockLength
     # raise: false so that an upstream rename of the html_response callback
     # degrades this action rather than failing to boot the whole application.
     skip_before_action :html_response, only: [:coupon_preview], raise: false
-    before_action :authenticate, only: [:coupon_preview]
+
+    # Registered under a theme-specific name, NOT `before_action :authenticate`:
+    # re-registering a host callback by name replaces the host's registration
+    # (ActiveSupport::Callbacks de-duplicates on the filter symbol), which
+    # silently removed the login gate from #show and 500ed every logged-out
+    # visitor there (issue #1055). Same hazard applies to any future theme
+    # before_action that reuses a host callback name.
+    before_action :authenticate_coupon_preview, only: [:coupon_preview]
+
+    def authenticate_coupon_preview
+      authenticate
+    end
 
     def coupon_preview
       price = AlaveteliPro::Price.retrieve(params[:price_id])

--- a/spec/plans_show_authentication_spec.rb
+++ b/spec/plans_show_authentication_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Guards the login gate on AlaveteliPro::PlansController#show against theme
+# patches clobbering the host's callbacks. Re-registering a host callback by
+# name in lib/controller_patches.rb (e.g. `before_action :authenticate`)
+# replaces the host's registration instead of adding to it, which removed
+# authentication from #show entirely and 500ed every logged-out visitor in
+# check_has_current_subscription (issue #1055).
+#
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(
+  File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper')
+)
+require 'stripe_mock'
+
+RSpec.describe AlaveteliPro::PlansController, type: :controller do
+  before { StripeMock.start }
+  after { StripeMock.stop }
+
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  let(:product) { stripe_helper.create_product }
+
+  let!(:pro_price) do
+    stripe_helper.create_price(
+      id: 'pro', product: product.id, unit_amount: 4500
+    )
+  end
+
+  describe 'GET #show' do
+    context 'without a signed-in user' do
+      before { get :show, params: { id: 'pro' } }
+
+      it 'redirects to the login form with a post redirect back to the plan' do
+        expect(response).to redirect_to(signin_path(token: PostRedirect.last.token))
+        expect(PostRedirect.last.uri).to eq(plan_path('pro'))
+      end
+    end
+
+    context 'with a signed-in user without a subscription' do
+      before do
+        sign_in FactoryBot.create(:user)
+        get :show, params: { id: 'pro' }
+      end
+
+      it 'renders the plan page' do
+        expect(response).to be_successful
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Registers the theme's coupon-preview authentication callback under its own name (`authenticate_coupon_preview`, delegating to the host's `authenticate`) instead of re-registering the host's `authenticate` callback. `ActiveSupport::Callbacks` de-duplicates on the filter symbol, so the old registration replaced the host's `before_action :authenticate, only: [:show]` rather than adding to it, removing the login gate from `plans#show`. `check_has_current_subscription` then ran with `@user` nil and 500ed every logged-out visitor to a plan page.

Also adds a regression spec: a logged-out `GET plans#show` redirects to sign-in with a `PostRedirect` back to the plan page, and a logged-in user without a subscription still sees the page. Nothing previously covered `plans#show`.

## Motivation and Context

Logged-out visitors are the primary audience for the plan page (the Pro signup entry point), and every one of them got a 500 on staging and, in all likelihood, production. Resolves #1055.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system (new spec reproduced the exact production `NoMethodError` before the fix; full theme suite now passes, 81 examples, 0 failures; rubocop clean)
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

AI disclosure: assisted by OpenCode:anthropic.claude-fable-5 (root-cause analysis was already in the issue; the tool wrote the fix, spec, and this PR).
