### PR TITLE
Configure per-repo agent skill settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,3 +273,30 @@ only). Run via `rails runner` from the **host app**, not this repo — see
 - Keep all copy, help text, and authority notes non-partisan — Right To Know
   reports FOI activity and authority information neutrally, never implying
   endorsement or criticism of any agency, party, or position.
+
+## Agent skills
+
+Per-repo configuration for the mattpocock engineering skills (`/triage`,
+`/to-tickets`, `/to-spec`, `/wayfinder`, `/domain-modeling` and friends). The
+files under `docs/agents/` are what those skills read; edit them directly rather
+than re-running the setup skill.
+
+### Issue tracker
+
+Issues live as GitHub issues in this repo, driven with the `gh` CLI. Note that
+the Alaveteli fork this theme is loaded into has GitHub Issues disabled, so work
+on the host app is tracked here too. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage roles map to `needs-triage`, `needs-info`,
+`ready-for-agent`, `ready-for-human` and `wontfix`. See
+`docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context. This repo already keeps the two records the skills look for
+under different names, so they are pointed at those rather than at a new
+`CONTEXT.md` and `docs/adr/`: "Key domain knowledge" above plus `README.md` for
+vocabulary, and `docs/DECISIONS.md` for cross-cutting decisions. See
+`docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,56 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when
+exploring the codebase.
+
+This repo is **single-context**, and it already keeps the two records the skills
+look for, under its own names. Use these rather than creating a `CONTEXT.md` or a
+`docs/adr/` directory alongside them - a second, parallel record is worse than
+one that is actually maintained.
+
+## Before exploring, read these
+
+- **`AGENTS.md`**, "Key domain knowledge" - the glossary role. Jurisdictions,
+  authorities and Pro coupons, with the reasoning behind each.
+- **`README.md`** - the reference tables the glossary points at: Jurisdictions,
+  Categories, Authorities, Pro subscriptions, and "Adding more jurisdictions".
+- **`docs/DECISIONS.md`** - the decision-record role, in place of `docs/adr/`.
+  Cross-cutting engineering decisions that aren't tied to one file or area. Read
+  the entries touching the area you're about to work in. It currently holds only
+  its own conventions and no entries yet, so expect nothing there until decisions
+  start being recorded.
+
+Also read `AGENTS.md`, "Architecture" before changing how the theme loads,
+patches, or overrides the host app.
+
+## Recording new decisions
+
+Where a skill would write an ADR under `docs/adr/`, add an entry to
+`docs/DECISIONS.md` instead, following the conventions stated at the top of that
+file: append new entries at the top, date them, and don't edit past entries
+except to mark them superseded and say by what. A decision local to one
+file/view/patch belongs as a comment there instead, explaining why.
+
+Numbered ADR filenames don't exist here, so refer to a decision by its date and
+heading rather than an `ADR-0007` style identifier.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal,
+a hypothesis, a test name), use the term as defined in "Key domain knowledge" and
+`README.md`. Don't drift to synonyms those explicitly avoid. This repo overlays a
+much larger host app, so host Alaveteli vocabulary matters too: an
+`InfoRequest`, an `IncomingMessage`, an authority **tag** driving jurisdiction
+rules. Prefer the host's name for a host concept over inventing a theme-local
+one.
+
+If the concept you need isn't documented yet, that's a signal - either you're
+inventing language the project doesn't use (reconsider) or there's a real gap
+(note it for `/domain-modeling`).
+
+## Flag decision conflicts
+
+If your output contradicts an entry in `docs/DECISIONS.md`, surface it explicitly
+rather than silently overriding:
+
+> _Contradicts the <date> decision on <heading>, but worth reopening because..._

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,102 @@
+# Issue tracker: GitHub
+
+Issues and specs live as GitHub issues in this repo, `openaustralia/righttoknow`.
+Use the `gh` CLI, which infers the repo from `git remote -v` when run inside this
+clone.
+
+The Alaveteli fork this theme is loaded into
+([openaustralia/alaveteli](https://github.com/openaustralia/alaveteli)) has
+GitHub Issues **disabled**, so issues about the host app are tracked here as
+well. Branch names in that repo carry the issue number with an `rtk` prefix, e.g.
+`feature/rtk1045-ruby-3.4.10` is issue #1045 here; branches in this repo use the
+bare number, e.g. `feature/1045-ruby-3.4.10`.
+
+## Drafting, not creating
+
+OAF agent convention, and it governs everything below: GitHub issues have no
+draft state, so don't create one directly. Draft the title and body for the human
+to file themselves, unless they have explicitly asked you to create it this
+time. The same care applies to comments and label changes on other people's
+issues. Reading and listing need no such ceremony.
+
+## Conventions
+
+- **Create an issue** (only when the human has asked you to file it):
+  `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line
+  bodies, and fill in the org-level issue form from `openaustralia/.github` under
+  `.github/ISSUE_TEMPLATE/` rather than writing a freeform body.
+- **Read an issue**: `gh issue view <number> --comments`
+- **List issues**:
+  `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+  with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` /
+  `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external
+PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using
+the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for
+  the diff.
+- **List external PRs for triage**:
+  `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments`
+  then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`,
+  or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label` /
+  `--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be
+either - resolve with `gh pr view 42` and fall back to `gh issue view 42`. A
+number in a *host app* branch or commit message is an issue here, not a PR.
+
+Note that PRs against the host Alaveteli fork live in that repo, so reviewing
+theme and host changes for one piece of work can mean two PRs in two repos
+against one issue here.
+
+## When a skill says "publish to the issue tracker"
+
+Draft a GitHub issue and hand the title and body to the human to file - see
+"Drafting, not creating" above.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as
+tickets. Creating any of these goes through "Drafting, not creating" first.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes /
+  Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on
+  the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a
+  task list in the map body and put `Part of #<map>` at the top of the child
+  body. Labels: `wayfinder:<type>`
+  (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is
+  assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** - the canonical,
+  UI-visible representation. Add an edge with
+  `gh api --method POST repos/openaustralia/righttoknow/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`,
+  where `<blocker-db-id>` is the blocker's numeric **database id**
+  (`gh api repos/openaustralia/righttoknow/issues/<n> --jq .id`, _not_ the
+  `#number` or `node_id`). GitHub reports
+  `issue_dependencies_summary.blocked_by` (open blockers only - the live gate).
+  Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>`
+  line at the top of the child body. A ticket is unblocked when every blocker is
+  closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`,
+  scoped to the map's sub-issues / task list), drop any with an open blocker
+  (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the
+  `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` - the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then
+  `gh issue close <n>`, then append a context pointer to the map's
+  Decisions-so-far. Where the answer is a cross-cutting decision rather than a
+  one-off, add it to `docs/DECISIONS.md` too and link that from the map.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,34 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those
+roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the
+corresponding label string from this table.
+
+## Relationship to the labels already here
+
+`needs-info` and `ready-for-human` are renames of this tracker's earlier
+`needs-reproduction` and `ready` labels, so issues already carrying those keep
+their history under the new names. Two labels were deliberately left alone
+because they mean something narrower:
+
+- `needs-repro-env` - needs the production mail/server pipeline to reproduce, so
+  it is not doable on a dev instance. That is a different blocker from waiting on
+  the reporter, so it is not folded into `needs-info`.
+- `stale` - old item likely referring to behaviour that no longer exists, pending
+  review or close. Not the same as `needs-triage`, which is a live item awaiting
+  evaluation.
+
+`next` and `in progress` remain the board-position labels and sit alongside
+these roles rather than mapping onto them.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Description

Adds the per-repo configuration that the installed engineering skills (`/triage`, `/to-tickets`, `/to-spec`, `/wayfinder`, `/domain-modeling` and friends) read, plus an `## Agent skills` section in `AGENTS.md` pointing at it. Generated by `/setup-matt-pocock-skills` and then edited to match how this repo actually works.

- **`docs/agents/issue-tracker.md`** - GitHub issues in this repo. Records that the host Alaveteli fork has GitHub Issues disabled, so host app work is tracked here too, along with the `rtk`-prefixed branch numbering that follows from it. Keeps this repo's existing rule that an agent drafts an issue for a human to file rather than filing it. PRs-as-a-request-surface flag is set to `no`.
- **`docs/agents/triage-labels.md`** - maps the five canonical triage roles onto this tracker's labels. `needs-info` and `ready-for-human` are renames of the existing `needs-reproduction` and `ready` labels, so the issues carrying them keep their history; `needs-triage`, `ready-for-agent` and `wontfix` are new. `needs-repro-env`, `stale`, `next` and `in progress` were deliberately left alone as narrower or board-position labels.
- **`docs/agents/domain.md`** - points the skills at "Key domain knowledge" in `AGENTS.md`, the reference tables in `README.md`, and `docs/DECISIONS.md`, rather than seeding a parallel `CONTEXT.md` and `docs/adr/`.

The label renames and creations have **already been applied** to this repo, since the skills read live label state. That part is not revertable by reverting this PR.

## Motivation and Context
I am using [mattpocock-skills](https://github.com/mattpocock/skills) as part of our development workflow.

Without these files the skills fall back to their own defaults: they assume a `CONTEXT.md` and a `docs/adr/` directory, and they will create issues directly rather than drafting them. Both are wrong for this repo. Writing the config down once means the behaviour is consistent across sessions and editable in place, instead of being re-derived (differently) each time.

Choosing `docs/DECISIONS.md` over `docs/adr/` is the substantive decision here: a second decision record that nobody maintains is worse than the one that already exists and that `AGENTS.md` already tells agents to check.

No linked issue.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system

Label state verified against GitHub after the renames: `needs-info` carries 1 issue and `ready-for-human` 6 issues plus 5 PRs, matching the counts on `needs-reproduction` and `ready` beforehand, so no issue lost its label in the rename.

- [ ] Ran automated tests on my own system

Documentation and config only, no code paths touched, so there is nothing for RSpec to exercise.

- [ ] Confirmed it passed the GitHub actions tests

CI here is Rubocop only and this change adds no Ruby. To be confirmed before taking the PR out of draft.

## Screenshots (if appropriate):

n/a

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## AI assistance

Drafted with AI assistance and reviewed before submitting. The `Assisted-by: Claude Code:claude-opus-5` trailer is on the commit.
