### PR TITLE
Send Right To Know errors and traces to Sentry

### DIFF
--- a/Gemfile.theme
+++ b/Gemfile.theme
@@ -8,3 +8,10 @@
 # production-runtime gems belong here.
 
 source 'https://rubygems.org'
+
+# Error monitoring and APM (https://github.com/openaustralia/righttoknow/issues/1004).
+# Initialised in lib/sentry_config.rb; does nothing unless SENTRY_DSN is set
+# in the host's config/general.yml.
+gem 'sentry-rails'
+gem 'sentry-ruby'
+gem 'sentry-sidekiq'

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -37,6 +37,9 @@ end
   require File.expand_path "../#{patch}", __FILE__
 end
 
+# Error monitoring and APM (no-op unless the sentry gems and DSN are present)
+require File.expand_path('sentry_config.rb', __dir__)
+
 # Note you should rename the file at "config/custom-routes.rb" to
 # something unique (e.g. yourtheme-custom-routes.rb":
 $alaveteli_route_extensions << 'custom-routes.rb'

--- a/lib/sentry_config.rb
+++ b/lib/sentry_config.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Sentry error monitoring and APM for Right To Know
+# (https://github.com/openaustralia/righttoknow/issues/1004).
+#
+# The sentry gems are only present in the server bundle, where Gemfile.theme
+# is merged into the host Alaveteli Gemfile at deploy time, so do nothing
+# when they aren't loaded (local development and CI).
+if defined?(Sentry)
+  Sentry.init do |config|
+    # With no DSN configured the SDK stays disabled.
+    config.dsn = AlaveteliConfiguration.get('SENTRY_DSN', nil)
+
+    # Both servers run RAILS_ENV=production, so STAGING_SITE is what
+    # distinguishes them. Read it with `get` and a default: it is not one of
+    # AlaveteliConfiguration's DEFAULTS keys, so the `staging_site` reader
+    # method does not exist and would raise NoMethodError here.
+    config.environment =
+      if Rails.env.production?
+        AlaveteliConfiguration.get('STAGING_SITE', 0).to_i == 1 ? 'staging' : 'production'
+      else
+        Rails.env.to_s
+      end
+
+    config.breadcrumbs_logger = %i[active_support_logger http_logger]
+    config.send_default_pii = true
+    config.enable_logs = true
+
+    # Fraction of requests traced for APM. Tune in general.yml without a
+    # code change if quota becomes a problem.
+    config.traces_sample_rate =
+      AlaveteliConfiguration.get('SENTRY_TRACES_SAMPLE_RATE', 0.1).to_f
+  end
+end

--- a/lib/views/general/_before_head_end.html.erb
+++ b/lib/views/general/_before_head_end.html.erb
@@ -7,3 +7,16 @@
 <script defer data-domain="righttoknow.org.au" src="https://plausible.io/js/script.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
 <% end %>
+<%# Sentry browser error monitoring (issue #1004). The loader URL is set in
+    general.yml on the servers, so this renders nothing in development. %>
+<% sentry_js_loader_url = AlaveteliConfiguration.get('SENTRY_JS_LOADER_URL', '') %>
+<% unless sentry_js_loader_url.empty? %>
+<script>
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      environment: <%= (defined?(Sentry) && Sentry.initialized? ? Sentry.configuration.environment : Rails.env).to_json.html_safe %>
+    });
+  };
+</script>
+<script src="<%= sentry_js_loader_url %>" crossorigin="anonymous"></script>
+<% end %>


### PR DESCRIPTION
## Description

Adds Sentry error monitoring and APM to Right To Know, bootstrapped entirely from this theme repo with no changes to upstream Alaveteli:

- `Gemfile.theme` gains `sentry-ruby`, `sentry-rails` and `sentry-sidekiq`, so the gems reach the server bundle via `themes:pre_bundle_setup` and stay out of local development and CI.
- New `lib/sentry_config.rb`, required from `lib/alavetelitheme.rb` at boot. It is a no-op unless the gems are loaded and `SENTRY_DSN` is set in `general.yml`, so local checkouts and the specs are unaffected. The Sentry environment is derived from `STAGING_SITE` (both servers run `RAILS_ENV=production`), read via `AlaveteliConfiguration.get` with a default because `STAGING_SITE` is not one of the host's `DEFAULTS` keys and the `staging_site` reader method does not exist.
- Browser-side error monitoring via Sentry's loader script in `lib/views/general/_before_head_end.html.erb`, reporting to a separate `right-to-know-js` Sentry project so browser noise (extensions, bots) stays out of the server issue list. Gated on a `SENTRY_JS_LOADER_URL` key, so nothing is served in development. Note the `js-de.sentry-cdn.com` host: the org is in Sentry's EU region and the default `js.sentry-cdn.com` serves a no-op stub for it.
- `send_default_pii` is on, so events carry the request IP and headers. Deliberate call for debugging value; flagging it here in case it sits poorly with an FOI site's privacy expectations.
- Tracing (APM) samples 10% of requests by default; the rate and the loader URL come from `general.yml`, so both can be changed with a provision run rather than a deploy.

The companion provisioning change (renders `SENTRY_DSN` and friends into `general.yml`, wraps the cron jobs in Sentry check-in monitors) is openaustralia/infrastructure#661.

## Motivation and Context

We constantly hit monthly limits with Honeybadger and it no longer offers an OSS plan. Sentry has given OAF a sponsored Business plan, and this takes advantage of it, adding APM in the process. Resolves #1004.

Notably, Right To Know has no Honeybadger project at all, so this is a fresh install rather than a migration; error visibility today is exception email only.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Verified end to end in the local Docker environment with the theme's `Gemfile.theme` merged into the host Gemfile exactly the way `themes:pre_bundle_setup` does at deploy, and a real DSN in `general.yml`:

- A deliberate `raise` in a theme partial, triggered through a real HTTP request, arrived in Sentry with fully readable frames down to the theme file and line, correct culprit (`GeneralController#frontpage`), release picked up from git, and an attached trace ([RIGHT-TO-KNOW-2](https://oaf-org-au.sentry.io/issues/RIGHT-TO-KNOW-2), resolved with a note).
- A real unhandled JS error thrown in a browser on the rendered page arrived in the `right-to-know-js` project via the loader ([RIGHT-TO-KNOW-JS-1](https://oaf-org-au.sentry.io/issues/RIGHT-TO-KNOW-JS-1), resolved with a note).
- Confirmed `Sentry.init` sees the intended config inside the running app (`initialized=true`, environment/traces/logs as expected), and that the environment derivation returns `staging`/`production`/`development` correctly for each branch.
- Confirmed the file is inert when the gems are absent (plain `ruby -e "require ..."` is a no-op), so dev and CI are unaffected.
- RuboCop clean on the changed files.

The spec suite was not run: this change adds no behaviour the existing specs cover, and the SDK is disabled under test (no DSN).

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

AI disclosure: this change was developed with opencode using the model amazon-bedrock/anthropic.claude-fable-5 (see the `Assisted-by` commit trailer). A human reviewed, committed and signed off the work.

Follow-ups deliberately not in this PR: Slack alert rules for `#sentry-alerts` (needs an org auth token with `alerts:write`), and eventually turning down the exception notification email once Sentry has proven itself in production.
