### PR TITLE
Fix theme Gemfile injection during deploys

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -58,15 +58,15 @@ namespace :themes do
   desc 'Upload Gemfile.theme and inject into alaveteli Gemfile before bundle install'
   task :pre_bundle_setup do
     on roles(:app) do
-      theme_dir = release_path.join('lib', 'themes', 'righttoknow')
-      execute :mkdir, '-p', theme_dir
-      # Upload Gemfile.theme (theme runtime gems only) rather than the theme
-      # repo's main Gemfile, which carries dev/deployment tooling we don't
-      # want leaking into alaveteli's server bundle. The uploaded file is
-      # renamed to "Gemfile" in the release so eval_gemfile finds it.
-      upload! 'Gemfile.theme', "#{theme_dir}/Gemfile"
-      execute :bash, '-c',
-              "echo \"\\neval_gemfile '#{theme_dir}/Gemfile'\" >> #{release_path.join('Gemfile')}"
+      # Upload Gemfile.theme (theme runtime gems only) to the release root,
+      # not into lib/themes/righttoknow, because themes:install re-clones the
+      # theme there later in the deploy, clobbering anything we put in it.
+      theme_gemfile = release_path.join('Gemfile.theme')
+      upload! 'Gemfile.theme', theme_gemfile
+      # A single echo command; `bash -c "echo ..."` here would hand bash only
+      # the word "echo" as its script and silently append nothing.
+      execute :echo, "\"eval_gemfile '#{theme_gemfile}'\"", '>>',
+              release_path.join('Gemfile')
     end
   end
 end


### PR DESCRIPTION
## Description

Fixes `themes:pre_bundle_setup` in `config/deploy.rb` so the theme's runtime gems actually make it into the server bundle.

Two changes:
- The `eval_gemfile` line is now appended with a plain `echo` command. The previous `execute :bash, '-c', "echo ... >> Gemfile"` was flattened by SSHKit into `bash -c echo "..." >> Gemfile`, which hands bash only the word `echo` as its script and appends a bare newline, so the line was never added on any deploy.
- `Gemfile.theme` is now uploaded to the release root as `Gemfile.theme` instead of `lib/themes/righttoknow/Gemfile`, because `themes:install` re-clones the theme into that directory later in the deploy and was replacing the uploaded runtime Gemfile with the theme repo's dev/deployment tooling Gemfile.

## Motivation and Context

Server-side Sentry monitoring (#1004, added in #1058) has been reporting no data from staging or production. The sentry gems were never installed in the server bundle because of the quoting bug above, so `lib/sentry_config.rb`'s `defined?(Sentry)` guard made the integration a silent no-op. Full diagnosis in #1061, which this resolves.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Verified the generated command locally: `sh -c '/usr/bin/env echo "eval_gemfile ..." >> file'` appends the correct line. Inspected the deployed releases on both servers to confirm the failure fingerprint (trailing blank line on the release Gemfile, no sentry entries in `Gemfile.lock`, theme dev Gemfile sitting where the runtime one was uploaded). Rubocop passes. The real test is the next `cap staging deploy`: the release Gemfile should end with the `eval_gemfile` line and `grep sentry Gemfile.lock` should find the gems, then staging events should appear in the right-to-know Sentry project.

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

AI disclosure: diagnosed and written with OpenCode using model anthropic.claude-fable-5 (Assisted-by trailer on the commit); reviewed by @benrfairless.