### PR TITLE
Restore gap between page content and footer

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -798,6 +798,13 @@ dt {
 
 @import "responsive/rtk/oaf-footer";
 
+// The vendored standard footer carries no outer margin (and must stay
+// byte-identical to the standard), so restore the 3em gap the previous
+// footer kept between page content and the dark footer surface.
+.oaf-footer {
+  margin-top: 3em;
+}
+
 .request_listing .head, .body_listing .head, .user_listing .head {
   // Provide a tiny bit of extra room at the top of headers in lists so that
   // the top of letters don't get chopped off


### PR DESCRIPTION
## Description

Restores `margin-top: 3em` on `.oaf-footer`, adding it in the theme's `responsive/custom.scss` immediately after the `responsive/rtk/oaf-footer` import rather than in the vendored file itself, which has to stay byte-identical to the OAF standard footer.

## Motivation and Context

Fixes #1063. At the bottom of a request page the "Actions" dropdown and the "Follow" / follower count buttons sat flush against the top edge of the dark footer, so they read as part of the footer rather than the request.

The issue guessed this might be request-page specific, but it isn't. cef57f6 ("Adopt the OAF standard footer") deleted `responsive/rtk/_footer.scss`, which carried `margin-top: 3em` alongside `padding: 2.5em 0` on `.oaf-footer`. The vendored `_oaf-footer.scss` reproduces the padding but has no outer margin, so every page lost the gap between its last content element and the dark surface. Request pages are just where it's most visible, because `.request-footer__action-bar-container` ends in a row of buttons with no bottom spacing of its own (core `_request_layout.scss` relies on core's own light-background footer padding reading as a gap).

Fixing it on the footer rather than on the request page therefore matches the issue's own suggestion and restores the pre-cef57f6 rendering exactly, rather than patching one page and leaving the rest flush.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

Compiled the full stylesheet the theme actually feeds into (`alaveteli/app/assets/stylesheets/responsive/all.scss`, with the theme's asset path prepended ahead of the host's and `vendor/assets/stylesheets` on the load path) using dart-sass 1.103.1. Clean compile, and the new rule lands after the vendored footer styles in the cascade as intended.

Not verified in a browser: the host Alaveteli bundle isn't installed in my checkout, so I couldn't boot the app and look at a real request page. Worth a look on staging before this comes out of draft, at desktop and mobile width. There's no CSS test harness in this repo, so there's no automated regression test for the gap, and RuboCop doesn't apply because no Ruby changed.

## Screenshots (if appropriate):

Before: see the screenshot on #1063.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

AI disclosure: drafted with AI assistance, `OpenCode:claude-opus-5`. Note that the `Assisted-by:` trailer on the commit reads `OpenCode:anthropic.claude-fable-5`, which is wrong. The model actually used is the one named here. Left uncorrected deliberately rather than rewriting a signed-off commit.
