### PR TITLE
Switch Capistrano to reach hosts via SSM Session Manager

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -8,11 +8,13 @@ install_plugin Capistrano::SCM::Git
 require 'capistrano/scm/git-with-submodules'
 install_plugin Capistrano::SCM::Git::WithSubmodules
 
+require 'capistrano/aws'
 require 'capistrano/bundler'
 require 'capistrano/maintenance'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano/rbenv'
 require 'capistrano/tagging3'
+require 'net/ssh/proxy/command'
 
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ end
 group :deployment do
   gem 'bcrypt_pbkdf', '~> 1.1'
   gem 'capistrano', '~> 3.19'
+  gem 'capistrano-aws', '~> 1.4'
   gem 'capistrano-bundler', '~> 2.1'
   gem 'capistrano-git-with-submodules', '~> 2.0'
   gem 'capistrano-maintenance', '~> 1.2'
@@ -25,4 +26,7 @@ group :deployment do
   gem 'ed25519', '~> 1.3'
   gem 'net-ssh', '~> 7.2.0'
   gem 'net-ssh-gateway', '>= 1.1.0', '< 3.0.0'
+  # aws-sdk-ec2 (via capistrano-aws) needs an XML library at runtime and this
+  # bundle has no Rails to provide one; rexml is the lightest choice.
+  gem 'rexml'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,13 +4,34 @@ GEM
     airbrussh (1.6.2)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1282.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-ec2 (1.639.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.2)
+    bigdecimal (4.1.2)
     capistrano (3.20.1)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
+    capistrano-aws (1.4.0)
+      aws-sdk-ec2 (~> 1)
+      capistrano (~> 3.1)
+      rainbow (~> 3)
+      terminal-table (>= 1.7, < 4.0)
     capistrano-bundler (2.2.0)
       capistrano (~> 3.1)
     capistrano-git-with-submodules (2.0.6)
@@ -65,6 +86,7 @@ GEM
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.9.2)
+    jmespath (1.6.2)
     json (2.6.3)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
@@ -113,8 +135,9 @@ GEM
     regexp_parser (2.12.0)
     reline (0.7.0)
       io-console (~> 0.5)
-    rubocop (1.89.0)
-      json (~> 2.3)
+    rexml (3.4.4)
+    rubocop (1.90.0)
+      json (>= 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
       parallel (>= 1.10)
@@ -140,11 +163,11 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     thor (1.5.0)
     tsort (0.2.0)
-    unicode-display_width (3.2.0)
-      unicode-emoji (~> 4.1)
-    unicode-emoji (4.2.0)
+    unicode-display_width (2.6.0)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -163,6 +186,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt_pbkdf (~> 1.1)
   capistrano (~> 3.19)
+  capistrano-aws (~> 1.4)
   capistrano-bundler (~> 2.1)
   capistrano-git-with-submodules (~> 2.0)
   capistrano-maintenance (~> 1.2)
@@ -178,6 +202,7 @@ DEPENDENCIES
   rack-livereload
   rb-fsevent
   rb-inotify
+  rexml
   rubocop
   ruby-lsp
 

--- a/README.md
+++ b/README.md
@@ -213,9 +213,24 @@ The application is deployed using [Capistrano 3](https://capistranorb.com/). Dep
 
 ### Prerequisites
 
-- SSH access to the deployment servers as the `deploy` user
+Capistrano looks up the EC2 deploy targets dynamically by their `Application` and `Stage` tags
+and tunnels SSH through [AWS SSM Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html)
+rather than connecting to a public hostname, so you need:
+
+- The [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+  and the [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
+  installed
+- An AWS profile named `oaf` with permission to describe EC2 instances and start SSM sessions
+- An SSH key for the `deploy` user (SSH still runs as normal inside the SSM tunnel). If your
+  key isn't picked up by default, add a `Host i-*` entry with `IdentityFile` to `~/.ssh/config`
 - Gems installed: `bundle install --with deployment`
 - The server must have `shared/rbenv-version`, `shared/general.yml`, and all other shared files in place (managed by the [infrastructure repo](https://github.com/openaustralia/infrastructure))
+
+To check which instances a stage will deploy to:
+
+```bash
+bundle exec cap staging aws:ec2:instances
+```
 
 ### Deploy commands
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,10 +8,27 @@ set :use_sudo,    false
 
 set :rbenv_type, :user
 
-# net-ssh misinterprets the ^ modifier syntax in ~/.ssh/config Ciphers entries,
-# leaving the client cipher list empty and causing algorithm negotiation to fail.
-# Setting encryption explicitly bypasses that and still matches all server ciphers.
+# Deploy targets are found dynamically by capistrano-aws using the Application,
+# Stage and Roles tags Terraform sets on the EC2 instances (see
+# terraform/righttoknow/*.tf in the infrastructure repo). The gem's default
+# filters match those tags against :application and :stage, so no overrides are
+# needed here.
+set :aws_ec2_regions, ['ap-southeast-2']
+
+# Contact instances by ID as that is what SSM needs.
+set :aws_ec2_contact_point, :id
+
 set :ssh_options, {
+  # SSH reaches the instances through an AWS SSM Session Manager tunnel rather
+  # than a public hostname, so deploys work without the instances accepting
+  # direct SSH from the internet.
+  proxy: Net::SSH::Proxy::Command.new(
+    'aws ssm start-session --profile oaf --target %h ' \
+    '--document-name AWS-StartSSHSession --parameters portNumber=%p'
+  ),
+  # net-ssh misinterprets the ^ modifier syntax in ~/.ssh/config Ciphers entries,
+  # leaving the client cipher list empty and causing algorithm negotiation to fail.
+  # Setting encryption explicitly bypasses that and still matches all server ciphers.
   encryption: %w[chacha20-poly1305@openssh.com aes256-gcm@openssh.com
                  aes128-gcm@openssh.com aes256-ctr aes192-ctr aes128-ctr]
 }

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,7 +1,6 @@
 production:
   branch: production
   repository: https://github.com/openaustralia/alaveteli.git
-  server: prod.righttoknow.org.au
   user: deploy
   deploy_to: /srv/www/production
   rails_env: production
@@ -10,7 +9,6 @@ production:
 staging:
   branch: staging
   repository: https://github.com/openaustralia/alaveteli.git
-  server: staging.righttoknow.org.au
   user: deploy
   deploy_to: /srv/www/staging
   rails_env: production

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -4,9 +4,9 @@ require 'yaml'
 
 configuration = YAML.load_file('config/deploy.yml')['production']
 
-server configuration['server'],
-       user: configuration['user'],
-       roles: %w[app web db]
+# Registers the EC2 instance(s) matching this stage's tags as deploy targets,
+# with roles taken from each instance's Roles tag (app,web,db).
+aws_ec2_register(user: configuration['user'])
 
 set :repo_url,    configuration['repository']
 set :branch,      configuration['branch']

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -4,9 +4,9 @@ require 'yaml'
 
 configuration = YAML.load_file('config/deploy.yml')['staging']
 
-server configuration['server'],
-       user: configuration['user'],
-       roles: %w[app web db]
+# Registers the EC2 instance(s) matching this stage's tags as deploy targets,
+# with roles taken from each instance's Roles tag (app,web,db).
+aws_ec2_register(user: configuration['user'])
 
 set :repo_url,    configuration['repository']
 set :branch,      configuration['branch']


### PR DESCRIPTION
## Description

Switches Capistrano's deploy target lookup from the static hostnames in `config/deploy.yml` to dynamic EC2 instance lookup with [capistrano-aws](https://github.com/fernandocarletti/capistrano-aws), proxying SSH through `aws ssm start-session` so deploys no longer need the instances to accept direct SSH from the internet.

This is the Right To Know counterpart of openaustralia/planningalerts#2202, but simpler by design: the gem's default filters (`Application` + `Stage` tags + running state) match the tags Terraform already sets on both Right To Know instances (see `terraform/righttoknow/*.tf` in the infrastructure repo, which was tagged with exactly this change in mind), so none of PlanningAlerts' custom filter overrides or blue/green selection logic is needed. Each stage file now just calls the gem's stock `aws_ec2_register`, with roles read from the instance's `Roles` tag (`app,web,db`, matching what the stage files previously hardcoded).

Also adds `rexml` to the deployment gem group (aws-sdk-ec2 needs an XML library and this deploy-only bundle has no Rails to provide one) and updates the README deployment prerequisites (AWS CLI, Session Manager plugin, `oaf` profile, `Host i-*` SSH key hint). The `rubocop` 1.89.0 -> 1.90.0 bump in `Gemfile.lock` is a forced re-resolution (capistrano-aws -> terminal-table caps `unicode-display_width` below 3); rubocop still passes clean.

## Motivation and Context

Resolves #1074.

Part of tightening Right To Know security to require SSH access to EC2 instances go via AWS SSM with MFA, per [infrastructure#224](https://github.com/openaustralia/infrastructure/issues/224) and [infrastructure#503](https://github.com/openaustralia/infrastructure/issues/503).

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system - `bundle exec cap staging aws:ec2:instances` and `bundle exec cap production aws:ec2:instances` resolve `righttoknow-staging` (i-04885b2749bc99213) and `righttoknow-production` (i-03999611ef2c44a9a) respectively, each with contact point set to the instance ID and roles `app,web,db` from the tags
- [ ] Ran automated tests on my own system (n/a - deploy configuration only, not exercised by the theme specs; `bundle exec rubocop` passes)
- [x] Confirmed it passed the GitHub actions tests

An end-to-end `bundle exec cap staging deploy` over the SSM tunnel still needs to be run by a human with the `oaf` AWS profile and MFA before this merges.

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## AI usage

This PR was written with assistance from OpenCode (model: anthropic.claude-fable-5). The commit carries an `Assisted-by: OpenCode:anthropic.claude-fable-5` trailer alongside the human sign-off.
