### PR TITLE
Add /whatismyip trust-boundary diagnostic endpoint (attempt 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ One-time bootstrap per server:
 `GET /whatismyip` reports the IP Rails sees for the request, to aid in checking cloudflare proxying
 with a one-line curl rather than a real sign-in or a log dig. It returns the IP, or the IP plus
 ` FAIL` if that IP falls within Cloudflare's own published ranges - a sign the trust boundary isn't rewriting
-it to the real visitor IP.
+it to the real visitor IP. If Cloudflare's published ranges can't be fetched or look truncated, it
+returns the IP plus ` UNABLE TO CHECK` rather than guessing.
 
 It should report the same value as https://whatismyip.akamai.com/
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,22 @@ One-time bootstrap per server:
 
 `deploy:check_shared` runs at the start of every deploy and fails fast if any required file is missing.
 
+### whatismyip trust-boundary check
+
+`GET /whatismyip` reports the IP Rails sees for the request, to aid in checking cloudflare proxying
+with a one-line curl rather than a real sign-in or a log dig. It returns the IP, or the IP plus
+` FAIL` if that IP falls within Cloudflare's own published ranges - a sign the trust boundary isn't rewriting
+it to the real visitor IP.
+
+It should report the same value as https://whatismyip.akamai.com/
+
+Off by default; set `PROVIDE_WHATISMYIP: true` in `general.yml` to turn it on.
+
+```bash
+curl https://staging.righttoknow.org.au/whatismyip
+curl https://www.righttoknow.org.au/whatismyip
+```
+
 ## Authorities
 
 ### Adding new authorities

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -40,6 +40,9 @@ end
 # Error monitoring and APM (no-op unless the sentry gems and DSN are present)
 require File.expand_path('sentry_config.rb', __dir__)
 
+# A new controller (not a patch to an existing one) - see its own file for why
+require File.expand_path('whatismyip_controller.rb', __dir__)
+
 # Note you should rename the file at "config/custom-routes.rb" to
 # something unique (e.g. yourtheme-custom-routes.rb":
 $alaveteli_route_extensions << 'custom-routes.rb'

--- a/lib/config/custom-routes.rb
+++ b/lib/config/custom-routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
   # get '/help/help_out' => 'help#help_out'
   get '/help/house_rules' => 'help#house_rules'
 
+  # See lib/whatismyip_controller.rb. Controller 404s unless PROVIDE_WHATISMYIP is on.
+  get '/whatismyip' => 'whatismyip#index'
+
   # We used to have a dedicated people page which was made in this theme.
   # Now that same information has been merged into the statistics page
   # in the main project there is no need for our version. Just to be

--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -20,10 +20,14 @@ Rails.configuration.to_prepare do
       'https://www.cloudflare.com/ips-v6'
     ].freeze
 
+    # Real lists are ~15 (v4) and ~7 (v6) entries; anything under this is
+    # Cloudflare erroring or truncating rather than a genuine empty list.
+    MIN_EXPECTED_RANGES = 4
+
+    class RangesUnavailable < StandardError; end
+
     def index
-      ip = request.remote_ip
-      ip += ' FAIL' if cloudflare_ip?(ip)
-      render plain: ip
+      render plain: "#{request.remote_ip}#{status_suffix}"
     end
 
     private
@@ -32,21 +36,35 @@ Rails.configuration.to_prepare do
       head :not_found unless AlaveteliConfiguration.get('PROVIDE_WHATISMYIP', false)
     end
 
-    def cloudflare_ip?(ip)
-      cloudflare_ranges.any? { |range| range.include?(IPAddr.new(ip)) }
-    rescue IPAddr::Error
-      false
+    def status_suffix
+      ip = IPAddr.new(request.remote_ip)
+      cloudflare_ranges.any? { |range| range.include?(ip) } ? ' FAIL' : ''
+    rescue RangesUnavailable, IPAddr::Error
+      ' UNABLE TO CHECK'
     end
 
-    # Cached a day so this doesn't depend on cloudflare.com being reachable
-    # on every check.
+    # Cached a day so this doesn't depend on cloudflare.com being reachable on
+    # every check. Validated and parsed to IPAddr before caching, not after -
+    # a failed/truncated fetch must raise inside the block so Rails.cache
+    # never stores it, or a bad response would silently poison every check
+    # for the next 24 hours (reported by Sentry as a real incident).
     def cloudflare_ranges
-      cidrs = Rails.cache.fetch('whatismyip_cloudflare_ranges', expires_in: 1.day) do
-        CLOUDFLARE_RANGE_URLS.flat_map do |url|
-          Net::HTTP.get(URI(url)).lines.map(&:strip).reject(&:empty?)
-        end
+      Rails.cache.fetch('whatismyip_cloudflare_ranges', expires_in: 1.day) do
+        CLOUDFLARE_RANGE_URLS.flat_map { |url| fetch_ranges(url) }
+                             .map { |cidr| IPAddr.new(cidr) }
       end
-      cidrs.map { |cidr| IPAddr.new(cidr) }
+    end
+
+    # Each list checked independently - a truncated v6 list shouldn't pass
+    # just because v4 came back full-sized.
+    def fetch_ranges(url)
+      response = Net::HTTP.get_response(URI(url))
+      raise RangesUnavailable unless response.is_a?(Net::HTTPSuccess)
+
+      ranges = response.body.lines.map(&:strip).reject(&:empty?)
+      raise RangesUnavailable if ranges.size < MIN_EXPECTED_RANGES
+
+      ranges
     end
   end
 end

--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -11,6 +11,8 @@ Rails.configuration.to_prepare do
   class WhatismyipController < ApplicationController
     # rubocop:enable Lint/ConstantDefinitionInBlock
     skip_before_action :html_response
+    # Added protect_from_forgery since CodeQL complains and just in case we ever action a POST
+    protect_from_forgery with: :exception
     before_action :check_enabled
 
     CLOUDFLARE_RANGE_URLS = [

--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'ipaddr'
+require 'net/http'
+
+Rails.configuration.to_prepare do
+  # Diagnostic for the nginx/Cloudflare real-IP trust boundary (see
+  # ,plan-staging-rtk.md) - off by default since an open whatismyip would let
+  # anyone check whether a forged CF-Connecting-IP is being trusted.
+  # rubocop:disable Lint/ConstantDefinitionInBlock
+  class WhatismyipController < ApplicationController
+    # rubocop:enable Lint/ConstantDefinitionInBlock
+    skip_before_action :html_response
+    before_action :check_enabled
+
+    CLOUDFLARE_RANGE_URLS = [
+      'https://www.cloudflare.com/ips-v4',
+      'https://www.cloudflare.com/ips-v6'
+    ].freeze
+
+    def index
+      ip = request.remote_ip
+      ip += ' FAIL' if cloudflare_ip?(ip)
+      render plain: ip
+    end
+
+    private
+
+    def check_enabled
+      head :not_found unless AlaveteliConfiguration.get('PROVIDE_WHATISMYIP', false)
+    end
+
+    def cloudflare_ip?(ip)
+      cloudflare_ranges.any? { |range| range.include?(IPAddr.new(ip)) }
+    rescue IPAddr::Error
+      false
+    end
+
+    # Cached a day so this doesn't depend on cloudflare.com being reachable
+    # on every check.
+    def cloudflare_ranges
+      cidrs = Rails.cache.fetch('whatismyip_cloudflare_ranges', expires_in: 1.day) do
+        CLOUDFLARE_RANGE_URLS.flat_map do |url|
+          Net::HTTP.get(URI(url)).lines.map(&:strip).reject(&:empty?)
+        end
+      end
+      cidrs.map { |cidr| IPAddr.new(cidr) }
+    end
+  end
+end

--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -9,8 +9,11 @@ Rails.configuration.to_prepare do
   # anyone check whether a forged CF-Connecting-IP is being trusted.
   # rubocop:disable Lint/ConstantDefinitionInBlock
   class WhatismyipController < ApplicationController
+    # raise: false so that an upstream rename of the html_response callback
+    # degrades this action rather than failing to boot the whole application.
     # rubocop:enable Lint/ConstantDefinitionInBlock
-    skip_before_action :html_response
+    skip_before_action :html_response, raise: false
+
     # Added protect_from_forgery since CodeQL complains and just in case we ever action a POST
     protect_from_forgery with: :exception
     before_action :check_enabled

--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -65,7 +65,8 @@ Rails.configuration.to_prepare do
       raise RangesUnavailable if ranges.size < MIN_EXPECTED_RANGES
 
       ranges
-    rescue Timeout::Error, SocketError, SystemCallError, OpenSSL::SSL::SSLError, EOFError, Net::ProtocolError
+    rescue Timeout::Error, SocketError, SystemCallError, OpenSSL::SSL::SSLError, EOFError, Net::ProtocolError,
+           Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError
       raise RangesUnavailable
     end
   end

--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -15,10 +15,7 @@ Rails.configuration.to_prepare do
     protect_from_forgery with: :exception
     before_action :check_enabled
 
-    CLOUDFLARE_RANGE_URLS = [
-      'https://www.cloudflare.com/ips-v4',
-      'https://www.cloudflare.com/ips-v6'
-    ].freeze
+    CLOUDFLARE_RANGE_URLS = %w[https://www.cloudflare.com/ips-v4 https://www.cloudflare.com/ips-v6].freeze
 
     # Real lists are ~15 (v4) and ~7 (v6) entries; anything under this is
     # Cloudflare erroring or truncating rather than a genuine empty list.
@@ -65,6 +62,8 @@ Rails.configuration.to_prepare do
       raise RangesUnavailable if ranges.size < MIN_EXPECTED_RANGES
 
       ranges
+    rescue Timeout::Error, SocketError, SystemCallError, OpenSSL::SSL::SSLError, EOFError, Net::ProtocolError
+      raise RangesUnavailable
     end
   end
 end

--- a/spec/whatismyip_spec.rb
+++ b/spec/whatismyip_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe WhatismyipController, type: :controller do
         before do
           stub_cloudflare(
             ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
-            ipv6: success('2400:cb00::/32', '2606:4700::/32')
+            ipv6: success('2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32')
           )
         end
 
@@ -87,7 +87,7 @@ RSpec.describe WhatismyipController, type: :controller do
 
           stub_cloudflare(
             ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
-            ipv6: success('2400:cb00::/32', '2606:4700::/32')
+            ipv6: success('2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32')
           )
           get :index
 

--- a/spec/whatismyip_spec.rb
+++ b/spec/whatismyip_spec.rb
@@ -2,9 +2,12 @@
 
 # Exercises lib/whatismyip_controller.rb, routed in lib/config/custom-routes.rb.
 #
-# Rails.cache is stubbed rather than exercised for real so the spec doesn't
-# depend on cloudflare.com being reachable; the stubbed list is a real
-# Cloudflare-published range so the pass/fail examples mean something.
+# Net::HTTP is stubbed rather than exercised for real so the spec doesn't
+# depend on cloudflare.com being reachable. Rails.cache is real (:null_store
+# in test, per config/environments/test.rb) so the fetch/validate block in
+# cloudflare_ranges actually runs on every request - important since the bug
+# this spec guards against (a bad fetch getting cached and poisoning every
+# check for 24 hours) is specifically about what happens inside that block.
 #
 # If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
 ALAVETELI_TEST_THEME = 'righttoknow'
@@ -13,19 +16,30 @@ require File.expand_path(
 )
 
 RSpec.describe WhatismyipController, type: :controller do
-  before do
-    allow(Rails.cache).to receive(:fetch).and_return(['173.245.48.0/20'])
+  def stub_cloudflare(ipv4:, ipv6:)
+    responses = {
+      'https://www.cloudflare.com/ips-v4' => ipv4,
+      'https://www.cloudflare.com/ips-v6' => ipv6
+    }
+    allow(Net::HTTP).to receive(:get_response) do |uri|
+      responses.fetch(uri.to_s)
+    end
+  end
+
+  def success(*cidrs)
+    double('response', is_a?: true, body: cidrs.join("\n"))
+  end
+
+  def failure
+    double('response', is_a?: false)
   end
 
   describe 'GET #index' do
     context 'when PROVIDE_WHATISMYIP is off' do
-      before do
+      it 'is not found' do
         allow(AlaveteliConfiguration).to receive(:get)
           .with('PROVIDE_WHATISMYIP', false).and_return(false)
         get :index
-      end
-
-      it 'is not found' do
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -36,16 +50,66 @@ RSpec.describe WhatismyipController, type: :controller do
           .with('PROVIDE_WHATISMYIP', false).and_return(true)
       end
 
-      it 'returns the IP alone when outside Cloudflare\'s ranges' do
-        request.remote_addr = '1.2.3.4'
-        get :index
-        expect(response.body).to eq('1.2.3.4')
+      context 'with a healthy Cloudflare response' do
+        before do
+          stub_cloudflare(
+            ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
+            ipv6: success('2400:cb00::/32', '2606:4700::/32')
+          )
+        end
+
+        it 'returns the IP alone when outside Cloudflare\'s ranges' do
+          request.remote_addr = '1.2.3.4'
+          get :index
+          expect(response.body).to eq('1.2.3.4')
+        end
+
+        it 'appends FAIL when inside Cloudflare\'s ranges' do
+          request.remote_addr = '173.245.48.1'
+          get :index
+          expect(response.body).to eq('173.245.48.1 FAIL')
+        end
       end
 
-      it 'appends FAIL when inside Cloudflare\'s ranges' do
-        request.remote_addr = '173.245.48.1'
-        get :index
-        expect(response.body).to eq('173.245.48.1 FAIL')
+      context 'when Cloudflare returns an error status' do
+        before do
+          stub_cloudflare(ipv4: failure, ipv6: success('2400:cb00::/32'))
+          request.remote_addr = '1.2.3.4'
+        end
+
+        it 'reports UNABLE TO CHECK rather than caching the failure' do
+          get :index
+          expect(response.body).to eq('1.2.3.4 UNABLE TO CHECK')
+        end
+
+        it 'recovers once Cloudflare responds normally again' do
+          get :index
+
+          stub_cloudflare(
+            ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
+            ipv6: success('2400:cb00::/32', '2606:4700::/32')
+          )
+          get :index
+
+          expect(response.body).to eq('1.2.3.4')
+        end
+      end
+
+      context 'when one list is suspiciously truncated' do
+        before do
+          # A full-sized v4 list must not offset a truncated v6 one - each is
+          # checked independently.
+          stub_cloudflare(
+            ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
+            ipv6: success('2400:cb00::/32')
+          )
+          request.remote_addr = '1.2.3.4'
+        end
+
+        it 'reports UNABLE TO CHECK rather than trusting the truncated list' do
+          get :index
+          expect(response.body).to eq('1.2.3.4 UNABLE TO CHECK')
+        end
       end
     end
   end

--- a/spec/whatismyip_spec.rb
+++ b/spec/whatismyip_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Exercises lib/whatismyip_controller.rb, routed in lib/config/custom-routes.rb.
+#
+# Rails.cache is stubbed rather than exercised for real so the spec doesn't
+# depend on cloudflare.com being reachable; the stubbed list is a real
+# Cloudflare-published range so the pass/fail examples mean something.
+#
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(
+  File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper')
+)
+
+RSpec.describe WhatismyipController, type: :controller do
+  before do
+    allow(Rails.cache).to receive(:fetch).and_return(['173.245.48.0/20'])
+  end
+
+  describe 'GET #index' do
+    context 'when PROVIDE_WHATISMYIP is off' do
+      before do
+        allow(AlaveteliConfiguration).to receive(:get)
+          .with('PROVIDE_WHATISMYIP', false).and_return(false)
+        get :index
+      end
+
+      it 'is not found' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when PROVIDE_WHATISMYIP is on' do
+      before do
+        allow(AlaveteliConfiguration).to receive(:get)
+          .with('PROVIDE_WHATISMYIP', false).and_return(true)
+      end
+
+      it 'returns the IP alone when outside Cloudflare\'s ranges' do
+        request.remote_addr = '1.2.3.4'
+        get :index
+        expect(response.body).to eq('1.2.3.4')
+      end
+
+      it 'appends FAIL when inside Cloudflare\'s ranges' do
+        request.remote_addr = '173.245.48.1'
+        get :index
+        expect(response.body).to eq('173.245.48.1 FAIL')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Adds `GET /whatismyip`, a small standalone controller/route that returns the request's `remote_ip` as plain text, with ` FAIL` appended if that IP falls within Cloudflare's own published ranges.

- Off by default; requires `PROVIDE_WHATISMYIP: true` in `general.yml` to respond (404 otherwise).
- Cloudflare's published IPv4/IPv6 ranges are fetched from `cloudflare.com` and cached for a day via `Rails.cache`.
- Documented in `README.md` under a new "whatismyip trust-boundary check" section.

## Motivation and Context

Part of the app-side work for the righttoknow staging Cloudflare Tunnel dry run (see `,plan-staging-rtk.md`, infrastructure/oaf-internal#266). Confirming that nginx/Cloudflare correctly resolve the real visitor IP currently means a real sign-in or a log dig; this turns that into a one-line curl.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system (`rubocop` clean; new `spec/whatismyip_spec.rb` covers the enabled/disabled flag and the in/out-of-Cloudflare-range cases - not yet run against the host app locally, its bundle is currently broken independent of this change)
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

N/A - JSON/plain-text endpoint, no UI change.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## AI disclosure

Written with assistance from Claude Code (claude-sonnet-5); see `Assisted-by` trailer on the commit. Reviewed before submitting.