### PR TITLE
Match the dev container database and mail service to Right to Know

### DIFF
--- a/.devcontainer/Dockerfile-postgres
+++ b/.devcontainer/Dockerfile-postgres
@@ -1,8 +1,16 @@
-# Replicates alaveteli's docker/Dockerfile-postgres so the database matches
-# what Alaveteli's own Docker environment provides (en_GB.UTF-8 locale and a
-# UTF-8 template database).
+# Based on alaveteli's docker/Dockerfile-postgres, with two deliberate
+# differences so development matches Right to Know rather than mySociety:
+#
+# - PostgreSQL 15, not 13.5. Production and staging share the RDS instance
+#   defined in the infrastructure repo (terraform/database.tf), which runs the
+#   15 series with auto_minor_version_upgrade on. Tracking the 15 family here
+#   rather than pinning a patch keeps it aligned as AWS moves the minor
+#   version, the same reasoning that file applies to its MySQL instance.
+# - en_AU.UTF-8, not en_GB.UTF-8. This is an Australian site. The two collate
+#   English text identically in glibc, so this is for consistency rather than
+#   to change any sort order.
 
-FROM postgres:13.5
-RUN localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
-ENV LANG=en_GB.utf8
+FROM postgres:15
+RUN localedef -i en_AU -c -f UTF-8 -A /usr/share/locale/locale.alias en_AU.UTF-8
+ENV LANG=en_AU.utf8
 ADD ./createdb.sh /docker-entrypoint-initdb.d/

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,8 +1,10 @@
 # Development stack for the Right to Know theme.
 #
-# Mirrors the services in openaustralia/alaveteli's docker-compose.yml, but is
-# self-contained: Alaveteli itself is cloned into the `alaveteli` volume by
+# Covers the same services as openaustralia/alaveteli's docker-compose.yml, but
+# is self-contained: Alaveteli itself is cloned into the `alaveteli` volume by
 # .devcontainer/setup.sh, so the only checkout you need is this repository.
+# Where a name differs from Alaveteli's, the service carries a comment saying
+# why.
 #
 # Used by both the Dev Container (.devcontainer/devcontainer.json) and the
 # plain Docker workflow (Makefile in the repository root).
@@ -23,7 +25,7 @@ services:
       - BUNDLE_PATH=/bundle/vendor
       - DATABASE_URL=postgres://postgres:password@db/
       - REDIS_URL=redis://redis:6379
-      - SMTP_URL=smtp://smtp:1025
+      - SMTP_URL=smtp://mailhog:1025
       - ALAVETELI_REPO=${ALAVETELI_REPO:-https://github.com/openaustralia/alaveteli.git}
       - ALAVETELI_BRANCH=${ALAVETELI_BRANCH:-staging}
     ports:
@@ -35,7 +37,7 @@ services:
     depends_on:
       - db
       - redis
-      - smtp
+      - mailhog
 
   sidekiq:
     build:
@@ -52,7 +54,7 @@ services:
       - BUNDLE_PATH=/bundle/vendor
       - DATABASE_URL=postgres://postgres:password@db/
       - REDIS_URL=redis://redis:6379
-      - SMTP_URL=smtp://smtp:1025
+      - SMTP_URL=smtp://mailhog:1025
     volumes:
       - ..:/alaveteli-themes/righttoknow:cached
       - alaveteli:/alaveteli
@@ -60,7 +62,7 @@ services:
     depends_on:
       - db
       - redis
-      - smtp
+      - mailhog
 
   db:
     build:
@@ -77,7 +79,10 @@ services:
     volumes:
       - redis:/data
 
-  smtp:
+  # Named for what it is, rather than "smtp": nothing here can send mail
+  # anywhere. MailHog accepts everything Alaveteli sends and holds it for
+  # you to read at http://localhost:1080 instead of delivering it.
+  mailhog:
     image: mailhog/mailhog
     ports:
       - '${MAILHOG_PORT:-1080}:8025'


### PR DESCRIPTION
## Description

Addresses three of Brenda's review comments on #1084, which is a `staging` to `production` release merge and so is not the place to make changes. All three are on the Dev Container files added by #1044, so this targets `staging`.

- [Postgres version](https://github.com/openaustralia/righttoknow/pull/1084#discussion_r3908070339) - "our postgres is up at version 15 on prod." Correct. `.devcontainer/Dockerfile-postgres` was on `postgres:13.5`, two major versions behind. Bumped to `postgres:15`.
- [Locale](https://github.com/openaustralia/righttoknow/pull/1084#discussion_r3908063532) - "shouldn't this be australian english?" Changed `en_GB.UTF-8` to `en_AU.UTF-8`.
- [Mail service name](https://github.com/openaustralia/righttoknow/pull/1084#discussion_r3908053806) - nitpick that `smtp` reads as though real mail delivery is configured. Renamed the compose service to `mailhog`.

Three files, one of them only comments. No application, theme or deploy code is touched: this is all development-environment tooling.

### Where I did something other than what was suggested

The mail service is named `mailhog`, not `mailtrap`. Mailtrap is a separate commercial product we do not use, so borrowing its name swaps one piece of confusion for another. `mailhog` is what is actually running, and it makes the same point Brenda was making - it is a catcher, not a relay. Happy to change it if you would rather have `mailcatcher` or something else.

## Motivation and Context

`.devcontainer/Dockerfile-postgres` and `docker-compose.yml` were written by copying Alaveteli's `docker/` equivalents so the two environments would match. That was the right starting point, but it also imported mySociety's choices wholesale - a UK locale, and a Postgres version pinned at whatever Alaveteli was using - without checking them against our own production.

**Postgres.** Right to Know production and staging both use the shared RDS instance defined in the `infrastructure` repo at `terraform/database.tf`, which is `engine_version = "15.17"` with `auto_minor_version_upgrade = true`. So Brenda is right, and the dev container was standing in for a database two major versions older than the real one. I have tracked the `15` family rather than pinning `15.17`, because that instance moves its own minor version - the same reasoning the file just below applies to its MySQL instance ("Track the 8.4 family rather than a pinned patch... a pinned value drifts").

**Locale.** `LANG` on the Postgres container becomes the cluster's default `LC_COLLATE`/`LC_CTYPE`. In glibc, `en_AU.UTF-8` and `en_GB.UTF-8` collate English text identically, so nothing about sort order changes here - this is a consistency fix on an Australian site, not a behavioural one.

**Mail.** `USE_MAILCATCHER_IN_DEVELOPMENT` defaults to `true` in the host app (`lib/configuration.rb`), so mail capture is genuinely wired up - Brenda's comment is about the name misleading a reader of the config, not about a broken setup. `SMTP_URL` keeps its `smtp://` scheme because that is the protocol the host app's `config/environments/development.rb` parses for a host and port; only the hostname changes.

### Note for anyone who has already run `make setup`

A PostgreSQL 13 data directory will not start under 15, so an existing environment needs its volume rebuilt:

```
make reset
```

That is a destructive reset of local dev data only. I have deliberately not put this in the `README.md`, since it is a one-off migration note that would go stale there.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Built and ran the changed Postgres image locally:

- `postgres:15` resolves to `15.19 (Debian 15.19-1.pgdg13+2)`, the same major series as production's 15.17.
- The cluster initialises with `en_AU.utf8` for both `datcollate` and `datctype`, encoding `UTF8`, and `localedef -i en_AU` builds cleanly on the image.
- `createdb.sh` still works on 15: `template_utf8` is created as a template with `datallowconn = false`, alongside `alaveteli_development` and `alaveteli_test`. That was the main risk in a major version bump and it is fine.

Checked the compose changes:

- `docker compose config` validates, and both `app` and `sidekiq` resolve the renamed `mailhog` dependency.
- Started the service and confirmed from another container on the compose network that `mailhog` resolves and accepts a connection on port 1025, which is what `SMTP_URL=smtp://mailhog:1025` needs.
- Grepped the repository: nothing outside `docker-compose.yml` referred to the old `smtp` service name. The `README.md` and `devcontainer.json` references are to MailHog and port 1080, which are unchanged.

`bundle exec rubocop`: 42 files inspected, no offences. That is the only check CI runs here, and none of these files are Ruby, so it is not meaningful coverage of the change - the local Docker run above is the real evidence.

What I have **not** done is a full `make setup` from scratch against the new image. That clones Alaveteli, installs gems, migrates, seeds and builds a Xapian index.

## Screenshots (if appropriate):

None. No user-visible change.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

Ticked as breaking only in the narrow sense described above: existing local dev environments need `make reset`. Nothing deployed is affected.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

The comment headers in both files are updated to record why they now differ from Alaveteli's, so the next person to compare them does not "fix" the divergence back.

---

AI disclosure: the changes and this description were written by Claude Code (claude-opus-5), working from Brenda's review comments, the `infrastructure` repo's Terraform, the host Alaveteli checkout and local Docker runs. Reviewed by me before pushing.
