### PR TITLE
Fix the whatismyip diagnostic reporting the forwarded IP, and bound its Cloudflare fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,9 +369,13 @@ It should report the same value as https://whatismyip.akamai.com/
 Off by default; set `PROVIDE_WHATISMYIP: true` in `general.yml` to turn it on.
 
 ```bash
-curl https://staging.righttoknow.org.au/whatismyip
+curl https://www-staging.righttoknow.org.au/whatismyip
 curl https://www.righttoknow.org.au/whatismyip
 ```
+
+`www-staging.righttoknow.org.au` is a CNAME for `staging.righttoknow.org.au`, the name
+the staging host is configured under in the infrastructure repo; either reaches the same
+server, and the `www-staging` form is used here to match the staging URL above.
 
 ## Authorities
 

--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -26,6 +26,12 @@ Rails.configuration.to_prepare do
 
     class RangesUnavailable < StandardError; end
 
+    # Short enough that a Cloudflare outage frees the Rails worker promptly.
+    # Net::HTTP otherwise defaults to about a minute for each of connect and
+    # read, and failures here are deliberately not cached, so repeated public
+    # requests during an outage would tie up more workers each time.
+    FETCH_TIMEOUT = 5
+
     def index
       render plain: "#{peer_address}#{status_suffix}"
     end
@@ -67,7 +73,7 @@ Rails.configuration.to_prepare do
     # Each list checked independently - a truncated v6 list shouldn't pass
     # just because v4 came back full-sized.
     def fetch_ranges(url)
-      response = Net::HTTP.get_response(URI(url))
+      response = get(URI(url))
       raise RangesUnavailable unless response.is_a?(Net::HTTPSuccess)
 
       ranges = response.body.lines.map(&:strip).reject(&:empty?)
@@ -77,6 +83,15 @@ Rails.configuration.to_prepare do
     rescue Timeout::Error, SocketError, SystemCallError, OpenSSL::SSL::SSLError, EOFError, Net::ProtocolError,
            Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError
       raise RangesUnavailable
+    end
+
+    def get(uri)
+      Net::HTTP.start(uri.host, uri.port,
+                      use_ssl: uri.scheme == 'https',
+                      open_timeout: FETCH_TIMEOUT,
+                      read_timeout: FETCH_TIMEOUT) do |http|
+        http.request(Net::HTTP::Get.new(uri))
+      end
     end
   end
 end

--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -27,17 +27,26 @@ Rails.configuration.to_prepare do
     class RangesUnavailable < StandardError; end
 
     def index
-      render plain: "#{request.remote_ip}#{status_suffix}"
+      render plain: "#{peer_address}#{status_suffix}"
     end
 
     private
+
+    # Deliberately request.remote_addr rather than request.remote_ip.
+    # ActionDispatch derives remote_ip from X-Forwarded-For, so it reports the
+    # real visitor IP even when nginx has failed to rewrite REMOTE_ADDR - which
+    # is the misconfiguration this action exists to catch, and would make the
+    # check below wrongly pass.
+    def peer_address
+      request.remote_addr
+    end
 
     def check_enabled
       head :not_found unless AlaveteliConfiguration.get('PROVIDE_WHATISMYIP', false)
     end
 
     def status_suffix
-      ip = IPAddr.new(request.remote_ip)
+      ip = IPAddr.new(peer_address)
       cloudflare_ranges.any? { |range| range.include?(ip) } ? ' FAIL' : ''
     rescue RangesUnavailable, IPAddr::Error
       ' UNABLE TO CHECK'

--- a/spec/whatismyip_spec.rb
+++ b/spec/whatismyip_spec.rb
@@ -2,12 +2,14 @@
 
 # Exercises lib/whatismyip_controller.rb, routed in lib/config/custom-routes.rb.
 #
-# Net::HTTP is stubbed rather than exercised for real so the spec doesn't
-# depend on cloudflare.com being reachable. Rails.cache is real (:null_store
-# in test, per config/environments/test.rb) so the fetch/validate block in
-# cloudflare_ranges actually runs on every request - important since the bug
-# this spec guards against (a bad fetch getting cached and poisoning every
-# check for 24 hours) is specifically about what happens inside that block.
+# Cloudflare's range lists are stubbed with WebMock rather than fetched for
+# real, so the spec doesn't depend on cloudflare.com being reachable. The
+# stubbing is at the HTTP layer, so the controller's own Net::HTTP call runs as
+# written. Rails.cache is real (:null_store in test, per
+# config/environments/test.rb) so the fetch/validate block in cloudflare_ranges
+# actually runs on every request - important since one of the bugs this spec
+# guards against (a bad fetch getting cached and poisoning every check for 24
+# hours) is specifically about what happens inside that block.
 #
 # If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
 ALAVETELI_TEST_THEME = 'righttoknow'
@@ -15,48 +17,49 @@ require File.expand_path(
   File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper')
 )
 
+RSpec.shared_context 'stubbed Cloudflare ranges' do
+  def ipv4_url = 'https://www.cloudflare.com/ips-v4'
+  def ipv6_url = 'https://www.cloudflare.com/ips-v6'
+
+  def full_ipv4 = %w[173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22]
+  def full_ipv6 = %w[2400:cb00::/32 2606:4700::/32 2803:f800::/32 2405:b500::/32]
+
+  def stub_ranges(url, cidrs)
+    stub_request(:get, url).to_return(status: 200, body: cidrs.join("\n"))
+  end
+
+  def stub_healthy_cloudflare
+    stub_ranges(ipv4_url, full_ipv4)
+    stub_ranges(ipv6_url, full_ipv6)
+  end
+end
+
 RSpec.describe WhatismyipController, type: :controller do
-  def stub_cloudflare(ipv4:, ipv6:)
-    responses = {
-      'https://www.cloudflare.com/ips-v4' => ipv4,
-      'https://www.cloudflare.com/ips-v6' => ipv6
-    }
-    allow(Net::HTTP).to receive(:get_response) do |uri|
-      responses.fetch(uri.to_s)
-    end
-  end
+  include_context 'stubbed Cloudflare ranges'
 
-  def success(*cidrs)
-    double('response', is_a?: true, body: cidrs.join("\n"))
-  end
-
-  def failure
-    double('response', is_a?: false)
+  # A default stub is needed alongside the PROVIDE_WHATISMYIP one: rendering
+  # goes through ApplicationController#set_gettext_locale, which reads other
+  # settings, and a bare `with` stub would make those raise.
+  def stub_whatismyip_setting(enabled)
+    allow(AlaveteliConfiguration).to receive(:get).and_call_original
+    allow(AlaveteliConfiguration).to receive(:get)
+      .with('PROVIDE_WHATISMYIP', false).and_return(enabled)
   end
 
   describe 'GET #index' do
     context 'when PROVIDE_WHATISMYIP is off' do
       it 'is not found' do
-        allow(AlaveteliConfiguration).to receive(:get)
-          .with('PROVIDE_WHATISMYIP', false).and_return(false)
+        stub_whatismyip_setting(false)
         get :index
         expect(response).to have_http_status(:not_found)
       end
     end
 
     context 'when PROVIDE_WHATISMYIP is on' do
-      before do
-        allow(AlaveteliConfiguration).to receive(:get)
-          .with('PROVIDE_WHATISMYIP', false).and_return(true)
-      end
+      before { stub_whatismyip_setting(true) }
 
       context 'with a healthy Cloudflare response' do
-        before do
-          stub_cloudflare(
-            ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
-            ipv6: success('2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32')
-          )
-        end
+        before { stub_healthy_cloudflare }
 
         it 'returns the IP alone when outside Cloudflare\'s ranges' do
           request.remote_addr = '1.2.3.4'
@@ -73,7 +76,8 @@ RSpec.describe WhatismyipController, type: :controller do
 
       context 'when Cloudflare returns an error status' do
         before do
-          stub_cloudflare(ipv4: failure, ipv6: success('2400:cb00::/32'))
+          stub_request(:get, ipv4_url).to_return(status: 500)
+          stub_ranges(ipv6_url, full_ipv6)
           request.remote_addr = '1.2.3.4'
         end
 
@@ -85,10 +89,7 @@ RSpec.describe WhatismyipController, type: :controller do
         it 'recovers once Cloudflare responds normally again' do
           get :index
 
-          stub_cloudflare(
-            ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
-            ipv6: success('2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32')
-          )
+          stub_healthy_cloudflare
           get :index
 
           expect(response.body).to eq('1.2.3.4')
@@ -99,10 +100,8 @@ RSpec.describe WhatismyipController, type: :controller do
         before do
           # A full-sized v4 list must not offset a truncated v6 one - each is
           # checked independently.
-          stub_cloudflare(
-            ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
-            ipv6: success('2400:cb00::/32')
-          )
+          stub_ranges(ipv4_url, full_ipv4)
+          stub_ranges(ipv6_url, %w[2400:cb00::/32])
           request.remote_addr = '1.2.3.4'
         end
 
@@ -112,5 +111,29 @@ RSpec.describe WhatismyipController, type: :controller do
         end
       end
     end
+  end
+end
+
+# The point of this action is to report what nginx actually handed Rails, so it
+# has to be exercised through the middleware stack: ActionDispatch::RemoteIp,
+# which is what would mask a Cloudflare peer address behind a forwarded visitor
+# IP, only runs on a real request.
+RSpec.describe 'GET /whatismyip', type: :request do
+  include_context 'stubbed Cloudflare ranges'
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:get).and_call_original
+    allow(AlaveteliConfiguration).to receive(:get)
+      .with('PROVIDE_WHATISMYIP', false).and_return(true)
+    stub_healthy_cloudflare
+  end
+
+  it 'reports the peer address, not the forwarded visitor IP' do
+    get '/whatismyip', headers: {
+      'REMOTE_ADDR' => '173.245.48.1',
+      'X-Forwarded-For' => '1.2.3.4'
+    }
+
+    expect(response.body).to eq('173.245.48.1 FAIL')
   end
 end

--- a/spec/whatismyip_spec.rb
+++ b/spec/whatismyip_spec.rb
@@ -96,6 +96,19 @@ RSpec.describe WhatismyipController, type: :controller do
         end
       end
 
+      context 'when Cloudflare does not respond in time' do
+        before do
+          stub_request(:get, ipv4_url).to_timeout
+          stub_ranges(ipv6_url, full_ipv6)
+          request.remote_addr = '1.2.3.4'
+        end
+
+        it 'reports UNABLE TO CHECK rather than hanging' do
+          get :index
+          expect(response.body).to eq('1.2.3.4 UNABLE TO CHECK')
+        end
+      end
+
       context 'when one list is suspiciously truncated' do
         before do
           # A full-sized v4 list must not offset a truncated v6 one - each is


### PR DESCRIPTION
## Description

Two fixes to the `/whatismyip` trust-boundary diagnostic, plus the README hostname it is documented with. All three were raised by Copilot review on #1084. Related to (new) issue:
* https://github.com/openaustralia/infrastructure/issues/733

- **It reported the wrong IP.** The action existed to show what nginx actually handed Rails, but read `request.remote_ip`, which ActionDispatch derives from `X-Forwarded-For`. When the Cloudflare real-IP rewrite is missing, Cloudflare's own `X-Forwarded-For` still carries the visitor IP, so the action reported that and the Cloudflare-range check passed. The one misconfiguration it was written to catch was the one case it could not see. Now reads `request.remote_addr` for both the value shown and the value checked.
- **The Cloudflare fetch was unbounded.** `Net::HTTP.get_response` carries defaults of roughly a minute each for connect and read. While `PROVIDE_WHATISMYIP` is on, a Cloudflare outage could hold a Rails worker that long per request, and failures here are deliberately not cached, so each repeat request would tie up another worker. Now fetched through `Net::HTTP.start` with a five second open and read timeout, which surfaces as the existing ` UNABLE TO CHECK` path.
- **The README used two staging hostnames.** The verification snippet said `staging.righttoknow.org.au` while the version check earlier in the file says `www-staging.righttoknow.org.au`, reading as two environments. They are the same server (`www-staging` is a CNAME for `staging`, per `terraform/righttoknow/dns.tf`). Both now use `www-staging`, with a line saying why they are interchangeable.

The spec is also switched from replacing `Net::HTTP.get_response` to stubbing Cloudflare with WebMock, so the controller's own HTTP call runs as written and real `Net::HTTPResponse` objects come back.

## Motivation and Context

Copilot review comments on #1084: [remote_ip](https://github.com/openaustralia/righttoknow/pull/1084#discussion_r3920607288), [timeouts](https://github.com/openaustralia/righttoknow/pull/1084#discussion_r3920607306), [staging hostname](https://github.com/openaustralia/righttoknow/pull/1084#discussion_r3920607325).

@Br3nda asked on both `lib/whatismyip_controller.rb` comments whether this is part of core, and whether we should therefore merge as is. It is not: `lib/whatismyip_controller.rb` is ours, added in this theme and routed from `lib/config/custom-routes.rb`, so there is no upstream to defer to.

One thing worth knowing separately: neither staging DNS record is Cloudflare-proxied (`proxied = false` in `terraform/righttoknow/dns.tf`), so a check against staging cannot return ` FAIL` for a Cloudflare range whatever the nginx config does. That is not changed here, just noted.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Ran `/code-review` (or equivalent)
- [ ] GitHub Actions tests

Run against a host Alaveteli checkout at 0.46.7.0 on Ruby 3.4.10.

**The peer address fix is proven by its own spec.** It is only reproducible through the middleware stack, since `ActionDispatch::RemoteIp` does not run in a controller spec and `remote_ip` there falls back to `remote_addr`, so the new example is a request spec. Reverting the controller to `remote_ip` fails it with `1.2.3.4` where the Cloudflare peer address should be; with the fix it passes.

`bundle exec rspec lib/themes/righttoknow/spec/whatismyip_spec.rb` - 8 examples, 0 failures. Full theme suite on this branch: 95 examples, 0 failures. `bundle exec rubocop` - 42 files, no offenses.

**Note for whoever reviews the other three branches:** six of the seven whatismyip examples currently fail on `staging` against core 0.46.7.0, before any change here. The spec stubbed `AlaveteliConfiguration.get` with a bare `with('PROVIDE_WHATISMYIP', false)` and no default, and rendering goes through `ApplicationController#set_gettext_locale`, which reads other settings and so raises. This branch adds the default stub and fixes that. Until it merges, the other branches show those six failures too.

## Screenshots (if appropriate):

None. The output is a plain-text IP.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

AI disclosure: the code changes, specs, commit messages and this description were written by Claude Code (claude-opus-5), working from the Copilot review comments on #1084. Each commit carries an `Assisted-by` trailer.
