### PR TITLE
Keep the personal information gate answered after a failed submission

### DIFF
--- a/lib/views/request/new.html.erb
+++ b/lib/views/request/new.html.erb
@@ -262,8 +262,13 @@
       <% if !@batch && @info_request.public_body.info_requests_hidden_count >= 2 %>
         <%# Answer "No" for people who have already been through the form once,
             so they don't lose their place. Replaces a jQuery equivalent that
-            checked for .errorExplanation and a filled-in subject. %>
-        <% personal_switch_answered = @existing_request.present? || @info_request.title.present? %>
+            checked for .errorExplanation and a filled-in subject; the errors
+            below are what foi_error_messages_for renders as .errorExplanation,
+            so a submission that failed validation still counts as answered
+            even when the title came back blank. %>
+        <% personal_switch_answered = @existing_request.present? ||
+                                      @info_request.title.present? ||
+                                      [@info_request, @outgoing_message].compact.any? { |record| record.errors.any? } %>
         <fieldset id="request_personal_switch" class="request_personal_switch">
           <legend>Are you asking for <strong>personal information</strong> that should be confidential?</legend>
           <p>This includes <em>police incident reports</em>, <em>court records</em>, <em>medical records</em>, <em>paperwork for insurance or court</em>, etc.</p>

--- a/spec/personal_message_switch_spec.rb
+++ b/spec/personal_message_switch_spec.rb
@@ -74,6 +74,29 @@ RSpec.describe RequestController, type: :controller do
       end
     end
 
+    context 'when a submission comes back with a validation error' do
+      # The regression this guards: the blank title means neither
+      # @existing_request nor @info_request.title says the form has been
+      # through once, but foi_error_messages_for has rendered
+      # .errorExplanation, which is what the old JavaScript keyed off.
+      before do
+        get :new, params: {
+          submitted_new_request: 1,
+          info_request: { title: '', public_body_id: public_body.id },
+          outgoing_message: { body: 'Please send me the minutes.' }
+        }
+      end
+
+      it 'shows the validation error' do
+        expect(response.body).to have_css('.errorExplanation', visible: :all)
+      end
+
+      it 'answers "No" so the person keeps their place' do
+        expect(response.body)
+          .to have_css('#request_personal_switch_no[checked]', visible: :all)
+      end
+    end
+
     context 'when coming back to a request that has a subject already' do
       before do
         get :new, params: {


### PR DESCRIPTION
## Description

The new request form asks whether you are requesting personal information and hides the rest of the form until you answer. #1070 moved that gate from JavaScript to CSS, and in doing so replaced the old check for `.errorExplanation` or a filled-in subject with:

```erb
<% personal_switch_answered = @existing_request.present? || @info_request.title.present? %>
```

Those are not equivalent. A submission that fails validation with a blank title has neither `@existing_request` nor a title, so the rerender hid the form again and asked the personal information question a second time, losing the place of someone who had just filled the rest of it in. A blank title is itself one of the validation errors, so this is not a corner case.

This counts model errors as well. `foi_error_messages_for :info_request, :outgoing_message` is what renders `.errorExplanation` for validation failures, so the condition now looks at the same two records that helper does. `@outgoing_message` is checked separately because the controller deletes `:outgoing_messages` from the request's own errors before rerendering, leaving a blank message body visible only on the outgoing message.

## Motivation and Context

[Copilot review comment on #1084](https://github.com/openaustralia/righttoknow/pull/1084#discussion_r3920607270). Follows on from #1070, which resolved #1065.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Ran `/code-review` (or equivalent)
- [ ] GitHub Actions tests

Run against a host Alaveteli checkout at 0.46.7.0 on Ruby 3.4.10.

`spec/personal_message_switch_spec.rb` gains an example that submits with a blank title and a filled-in body. It fails on the previous condition and passes on this one, so the regression is actually covered rather than just described.

`bundle exec rspec lib/themes/righttoknow/spec/personal_message_switch_spec.rb` - 8 examples, 0 failures. `bundle exec rubocop` - 42 files, no offenses.

Full theme suite on this branch is 95 examples, 6 failures, all of them the whatismyip examples that already fail on `staging` against core 0.46.7.0 and are unrelated to this change. #1086 fixes those; once it merges this branch is fully green.

## Screenshots (if appropriate):

None attached. To see it by hand: start a request to an authority with two or more hidden requests, submit with the summary left blank, and the personal information question should stay answered rather than hiding the form you just filled in.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

AI disclosure: the code change, spec, commit message and this description were written by Claude Code (claude-opus-5), working from the Copilot review comment on #1084. The commit carries an `Assisted-by` trailer.
