### PR TITLE
Always run migrations in the dev container setup

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -5,8 +5,9 @@
 # Idempotent: safe to re-run at any time. On first run it clones the
 # openaustralia/alaveteli fork into /alaveteli (a Docker volume), wires this
 # theme in with Alaveteli's switch-theme script, then migrates and seeds the
-# databases and builds the search index. Subsequent runs only update gems and
-# re-link the theme.
+# databases and builds the search index. Subsequent runs update gems, re-link
+# the theme and run any pending migrations, but leave the sample data alone
+# unless --reset-data is passed.
 #
 # Runs as the Dev Container onCreateCommand, and via `make setup` for the
 # plain Docker workflow. Mirrors the steps in alaveteli's docker/bootstrap and
@@ -61,8 +62,8 @@ ln -sfn "$THEME_DIR" lib/themes/righttoknow
 bin/rails assets:clean >/dev/null
 success_msg 'done'
 
-# If the database has never been seeded, load schema and data (matching
-# alaveteli's docker/setup). Pass --reset-data to force a reload.
+# Sample data is loaded once, on a database that has never been seeded. Pass
+# --reset-data to force a reload.
 set +e
 bin/rails runner 'User.find(1)' >/dev/null 2>&1
 RESET_DATA_FLAG=$?
@@ -74,16 +75,20 @@ for arg in "$@"; do
   esac
 done
 
-if [ $RESET_DATA_FLAG -eq 0 ]; then
-  success_msg 'Database already set up; skipping migrations and sample data'
-  success_msg 'Setup finished'
-  exit 0
-fi
-
+# Migrations run every time, not just on first setup: /alaveteli is a
+# persistent volume, so a re-run after the checkout moves to a revision with
+# new migrations is exactly when the schemas would otherwise go stale. Both
+# db:migrate and db:seed are idempotent.
 notice_msg 'Migrating development and test databases...'
 bin/rails db:migrate db:seed >/dev/null
 bin/rails db:migrate RAILS_ENV=test >/dev/null
 success_msg 'done'
+
+if [ $RESET_DATA_FLAG -eq 0 ]; then
+  success_msg 'Sample data already loaded; skipping'
+  success_msg 'Setup finished'
+  exit 0
+fi
 
 notice_msg 'Loading sample data...'
 bundle exec script/load-sample-data >/dev/null


### PR DESCRIPTION
## Description

`.devcontainer/setup.sh` says at the top that it is safe to re-run at any time, but the `User.find(1)` probe returned early and skipped migrations along with the sample data. `/alaveteli` is a persistent Docker volume, so the case where a re-run matters most - the checkout has moved to a revision carrying new migrations - was the one case that left both the development and test schemas stale.

Migrations now run every time, and only the sample data is gated on the probe. `db:migrate` is a no-op when nothing is pending, and alaveteli's `db/seeds.rb` states in its own header that seeds must be idempotent, creating roles and request summary categories only when they are missing. The header comment is updated to match.

## Motivation and Context

[Copilot review comment on #1084](https://github.com/openaustralia/righttoknow/pull/1084#discussion_r3920607218). @Br3nda flagged it as our own addition rather than something from core, and left the call to me; on reading it the point holds, because it defeats the idempotence the script advertises.

Follows on from the dev container work in #1044 and #1085.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [ ] Ran `/code-review` (or equivalent)
- [ ] GitHub Actions tests

Tested by running the script with its external commands stubbed and every `rails` invocation logged, against a database that already has user 1:

| | old script | this branch |
|---|---|---|
| seeded database | `assets:clean`, the probe, nothing else | `db:migrate db:seed`, `db:migrate RAILS_ENV=test`, then "Sample data already loaded; skipping" |
| `--reset-data` | migrates and reloads sample data | unchanged |
| fresh database | full bootstrap | unchanged |

That first row is the bug: no migrations at all.

`shellcheck` and `sh -n` are both clean. There are no specs covering `.devcontainer/`, and the container bootstrap was not re-run end to end - the change is entirely to the control flow above, which is what the stubbed run exercises. Worth a real `make setup` re-run by whoever next has the stack up.

## Screenshots (if appropriate):

None.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

The only documentation is the script's own header comment, updated in the same commit.

---

AI disclosure: the change, commit message and this description were written by Claude Code (claude-opus-5), working from the Copilot review comment on #1084. The commit carries an `Assisted-by` trailer.
