### PR TITLE
Pin EC2 discovery and the SSM tunnel to the same AWS profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,10 @@ rather than connecting to a public hostname, so you need:
 - The [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
   and the [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
   installed
-- An AWS profile named `oaf` with permission to describe EC2 instances and start SSM sessions
+- An AWS profile named `oaf` with permission to describe EC2 instances and start SSM sessions.
+  `config/deploy.rb` sets `AWS_PROFILE` to `oaf` unless you have already set it, so instance
+  lookup and the SSM tunnel always use the same account; set `AWS_PROFILE` yourself if your
+  profile is named something else
 - An SSH key for the `deploy` user (SSH still runs as normal inside the SSM tunnel). If your
   key isn't picked up by default, add a `Host i-*` entry with `IdentityFile` to `~/.ssh/config`
 - Gems installed: `bundle install --with deployment`

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,6 +8,15 @@ set :use_sudo,    false
 
 set :rbenv_type, :user
 
+# capistrano-aws builds its Aws::EC2::Resource with a region and nothing else,
+# so instance lookup would otherwise use whatever the SDK resolves as the
+# default profile - a different account, or none, depending on the machine.
+# Name the profile here instead, so lookup and the SSM tunnel below are always
+# the same account. Set AWS_PROFILE yourself to override, and static
+# credentials in the environment still win over a profile in both the SDK and
+# the CLI.
+ENV['AWS_PROFILE'] ||= 'oaf'
+
 # Deploy targets are found dynamically by capistrano-aws using the Application,
 # Stage and Roles tags Terraform sets on the EC2 instances (see
 # terraform/righttoknow/*.tf in the infrastructure repo). The gem's default
@@ -22,8 +31,10 @@ set :ssh_options, {
   # SSH reaches the instances through an AWS SSM Session Manager tunnel rather
   # than a public hostname, so deploys work without the instances accepting
   # direct SSH from the internet.
+  # No --profile here: the CLI inherits AWS_PROFILE from the environment set
+  # above, so the tunnel cannot end up on a different account from the lookup.
   proxy: Net::SSH::Proxy::Command.new(
-    'aws ssm start-session --profile oaf --target %h ' \
+    'aws ssm start-session --target %h ' \
     '--document-name AWS-StartSSHSession --parameters portNumber=%p'
   ),
   # net-ssh misinterprets the ^ modifier syntax in ~/.ssh/config Ciphers entries,


### PR DESCRIPTION
## Description

`README.md` says a deploy needs an AWS profile named `oaf`, but only the SSM tunnel actually used it. capistrano-aws builds its `Aws::EC2::Resource` with a region and nothing else:

```ruby
@ec2[region] = ::Aws::EC2::Resource.new(region: region)
```

so instance discovery fell through to whatever the SDK resolved as the default profile. On a machine whose default profile is another account, `aws_ec2_register` would find no instances, or the wrong ones, before the tunnel was ever opened. Since #1075 removed the `server:` fallback from `config/deploy.yml`, there is nothing to catch that.

`config/deploy.rb` now sets `AWS_PROFILE` unless it is already set, and `--profile oaf` is dropped from the SSM command so the CLI inherits the same value. The two cannot diverge. Static credentials in the environment still take precedence over a named profile in both the SDK and the CLI, so this does not override anyone supplying credentials that way. The README prerequisite says so.

## Motivation and Context

[Copilot review comment on #1084](https://github.com/openaustralia/righttoknow/pull/1084#discussion_r3920607248), which @Br3nda agreed looked like a good addition. Follows on from #1075, which resolved #1074.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [ ] Ran `/code-review` (or equivalent)
- [ ] GitHub Actions tests

`bundle exec cap staging aws:ec2:instances`, read-only, against live AWS:

- with no `AWS_PROFILE` set, it lists `i-04885b2749bc99213` (`righttoknow-staging`, roles `app,web,db`), so discovery works with the default this adds
- with `AWS_PROFILE` pointed at a profile that does not exist, it fails with missing credentials, so an explicit setting is honoured rather than replaced

Note that on my own machine the `default` and `oaf` profiles happen to resolve to the same account, so I could not reproduce the wrong-account failure locally - the fix is from reading the gem source above rather than from a reproduction.

`bundle exec rubocop` - 42 files, no offenses. No specs cover `config/deploy.rb`. The SSM tunnel itself is not exercised by `aws:ec2:instances`, so the first real deploy after this merges is still the proof that the tunnel works with the profile inherited rather than passed.

## Screenshots (if appropriate):

None.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

AI disclosure: the change, commit message and this description were written by Claude Code (claude-opus-5), working from the Copilot review comment on #1084. The commit carries an `Assisted-by` trailer.
