### PR TITLE
Pin sentry gems to the 6.x line

### DIFF
--- a/Gemfile.theme
+++ b/Gemfile.theme
@@ -12,6 +12,11 @@ source 'https://rubygems.org'
 # Error monitoring and APM (https://github.com/openaustralia/righttoknow/issues/1004).
 # Initialised in lib/sentry_config.rb; does nothing unless SENTRY_DSN is set
 # in the host's config/general.yml.
-gem 'sentry-rails'
-gem 'sentry-ruby'
-gem 'sentry-sidekiq'
+#
+# Pinned to the 6.x line: 7.0.0 removed `enable_logs` (used in
+# lib/sentry_config.rb) and changed the PII/metrics defaults. Nothing here
+# is covered by the host's Gemfile.lock, so without a constraint every
+# deploy re-resolves and can pull an untested major.
+gem 'sentry-rails', '~> 6.7'
+gem 'sentry-ruby', '~> 6.7'
+gem 'sentry-sidekiq', '~> 6.7'


### PR DESCRIPTION
## Description

Pins the three sentry gems in `Gemfile.theme` to `~> 6.7`, and adds a comment explaining why the constraint has to be there.

## Motivation and Context

sentry-ruby [7.0.0](https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md) was released on 2026-09-01 and removed `enable_logs`, which `lib/sentry_config.rb:27` sets. The gems were unpinned and are not covered by the host Alaveteli `Gemfile.lock`, because `themes:pre_bundle_setup` merges `Gemfile.theme` in at deploy time via `eval_gemfile`. Bundler therefore re-resolves them fresh on every deploy, and the `cap production deploy` on 2026-09-03 picked up the new major and aborted at `deploy:assets:precompile`:

```
NoMethodError: undefined method 'enable_logs=' for an instance of Sentry::Configuration
Did you mean?  enabled_patches=
/srv/www/production/releases/20260903070404/lib/themes/righttoknow/lib/sentry_config.rb:27
```

The failure was before `deploy:symlink:release`, so `current` never moved and there was no outage.

`~> 6.7` is the line staging has been running since the Sentry integration went in, so this pins to what was actually tested rather than adopting an untested major mid-deploy. Deleting the `enable_logs` line and floating to 7.x would have been the smaller diff, but 7.0.0 also deprecates `send_default_pii` in favour of a granular `data_collection` config, turns metrics on by default, and flips the OTLP defaults. None of that has been reviewed for this site, and the `data_collection` change in particular deserves a deliberate look at what we send given the correspondence Right to Know handles. Doing that properly is tracked separately in #1090.

**Note on sequencing:** production is already running this pin. `themes:pre_bundle_setup` uploads `Gemfile.theme` from the local working copy rather than from `origin/production`, so the re-run of `cap production deploy` succeeded with the change uncommitted. This PR brings the branches in line with what is deployed, so it wants merging to `staging` and then through to `production` reasonably promptly.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system

Verified on production rather than staging, by the successful `cap production deploy` after the change: the deploy got past `deploy:assets:precompile` (the step that was failing) and completed. The `Gemfile.theme` content that deploy uploaded is identical to what is committed here.

- [ ] Ran automated tests on my own system

Not applicable. The theme's specs run against the host Alaveteli checkout and none of them exercise gem resolution; there is no test that could catch this class of failure, since it only appears when bundler resolves against live rubygems at deploy time.

- [ ] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below

Not run. The change is a three-line version constraint plus a comment.

- [x] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)

All seven checks pass on this PR: rubocop, CodeQL plus its three Analyze jobs (actions, javascript-typescript, ruby), and both Socket Security checks. Rubocop also passes locally (42 files, no offences), though `Gemfile.theme` is excluded from it anyway.

## Screenshots (if appropriate):

N/A

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Follow-up: #1090 (upgrade to sentry 7.x deliberately and lift this pin).

AI disclosure: drafted with assistance from Claude Code, model `claude-opus-5`. Each commit carries an `Assisted-by: Claude Code:claude-opus-5` trailer. Reviewed by me before submitting.
