### PR TITLE
Add a pass to destroy never-confirmed empty accounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,20 @@ only). Run via `rails runner` from the **host app**, not this repo — see
   a coupon `interval` metadata key, enforced identically in the checkout path
   and the live price-preview endpoint (both in `controller_patches.rb`). See
   "Pro subscriptions" in `README.md`.
+- **Account lifecycle**: an **unused account** is the host's `User.unused`
+  scope (no content, no admin/pro role, no retained `user_sign_ins` row); it
+  says nothing about whether the address was confirmed or the account banned. A
+  **dormant account** is an unused account created more than two years ago that
+  has not signed in within two years — exactly the cohort the host's
+  `users:destroy_unused` cron would destroy, mirrored here by
+  `DormantAccounts.scope` so the deletion pass and the notice can't disagree
+  about who is at risk. A **never-confirmed account** has
+  `email_confirmed = false` and can never be emailed, because
+  `User#should_be_emailed?` requires confirmation. A **bounce** is the host's
+  `email_bounced_at`, which only `script/handle-mail-replies` ever sets. Use
+  those four terms rather than drifting to "inactive", "stale" or "abandoned".
+  See `docs/DECISIONS.md` (2026-09-03) and "Account housekeeping" in
+  `README.md`.
 
 ## Working with AI tools
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,36 @@ bundle exec cap staging xapian:destroy_and_rebuild_index
 bundle exec cap production xapian:destroy_and_rebuild_index
 ```
 
+### Account housekeeping
+
+One-off jobs that act on people's accounts. Each is **dry unless you pass `DRYRUN=0`**, and each
+prints account ids and dates rather than email addresses, so the output is safe to paste into an
+issue as a record of what ran.
+
+Destroy never-confirmed accounts that have no content and are over two years old
+([#1096](https://github.com/openaustralia/righttoknow/issues/1096)):
+
+```bash
+# List what would go, and check the count against production before acting
+bundle exec cap production accounts:destroy_never_confirmed
+
+# Start small, check Sentry, then run the rest
+bundle exec cap production accounts:destroy_never_confirmed DRYRUN=0 LIMIT=10
+bundle exec cap production accounts:destroy_never_confirmed DRYRUN=0
+```
+
+These accounts never confirmed their email address, so they cannot be warned first and are handled
+separately from the dormant-account notice. What "never-confirmed" and "dormant" mean, and why the
+order matters, is in `AGENTS.md` under "Key domain knowledge" and in `docs/DECISIONS.md`
+(2026-09-03).
+
+The same job can be run from a shell on the server, with the same environment variables:
+
+```bash
+cd /srv/www/production/current
+lib/themes/righttoknow/script/destroy-never-confirmed-accounts
+```
+
 ### First-time server setup
 
 After the [infrastructure repo](https://github.com/openaustralia/infrastructure) has provisioned the host, the shared path needs the config files in place before the first deploy. The deploy itself auto-creates any missing shared directories (cache, logs, storage, xapian indexes, vendored bundle, etc.) on each run via `deploy:check_shared`.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -113,6 +113,40 @@ namespace :xapian do
   end
 end
 
+# One-off account housekeeping jobs (#1095, #1096). Both are dry unless
+# DRYRUN=0, and both print user ids rather than email addresses. See "Account
+# housekeeping" in README.md.
+namespace :accounts do
+  # Runs `bundle exec rails runner` directly rather than the theme's script/
+  # wrappers: capistrano-rbenv maps the `bundle` command to `rbenv exec
+  # bundle`, and a bash wrapper calling bare `bundle` would not find Ruby.
+  #
+  # `capture` rather than `execute` because Airbrussh does not show command
+  # output by default, and the per-account ids these jobs print are the audit
+  # trail. `capture` also raises on a non-zero exit, so a failed run is loud.
+  #
+  # :bundle has to stay the first argument - SSHKit only applies `within` and
+  # `with` when the first argument has no whitespace in it.
+  def run_account_job(expression)
+    env = { rails_env: fetch(:rails_env), dryrun: ENV.fetch('DRYRUN', '1') }
+    env[:limit] = ENV['LIMIT'] if ENV['LIMIT']
+
+    on roles(:app) do
+      within current_path do
+        with env do
+          puts capture(:bundle, "exec rails runner '#{expression}' 2>&1")
+        end
+      end
+    end
+  end
+
+  desc 'Destroy never-confirmed accounts with no content, over two years old ' \
+       '(#1096). DRYRUN=0 to destroy, LIMIT=n to cap the batch'
+  task :destroy_never_confirmed do
+    run_account_job('DormantAccounts.destroy_never_confirmed')
+  end
+end
+
 namespace :deploy do
   # The shared files on this server are laid out by basename
   # (shared/database.yml rather than shared/config/database.yml), which does

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,6 +5,41 @@ wouldn't surface them. A decision local to one file/view/patch belongs as a comm
 
 Append new entries at the top and date them. Don't edit past entries except to mark them superseded (and say by what).
 
+## 2026-09-03: dormant accounts are handled in three ordered steps, and the blackhole address is the bounce address
+
+The host's `users:destroy_unused` cron has been shipped disabled since #1031, because its first run
+would destroy 2,732 of the site's 10,149 accounts and its "dormant for two years" guard reads
+`last_sign_in_at`, a column added in 0.46 with no backfill. Four accounts have it set, so for anyone
+who last signed in before the upgrade the guard sees a null and calls that "never signed in". Three
+issues sequence getting to a point where the cron can be enabled honestly, and the order is the
+decision worth recording:
+
+- **Never-confirmed accounts go first, with no notice (#1096).** 969 of the 2,732 never confirmed
+  their email address. `User#should_be_emailed?` requires `email_confirmed`, so there is no way to
+  warn them and no reason to think a warning would arrive. Waiting gains nothing, so this pass is
+  deliberately separate and unblocked: `DormantAccounts.destroy_never_confirmed`, a hard `destroy`
+  like the host task, two years to stay consistent with it, `DRYRUN` on unless told otherwise. It
+  logs account ids and creation dates, never addresses or names — the point is to hold less personal
+  data, not to copy it into a terminal.
+- **Bounce recording before any bulk send (#1094).** No account on the site has ever had a bounce
+  recorded. Every mail the app sends sets `Return-Path` to the blackhole address
+  (`ApplicationMailer#mail_user`), so **the blackhole, not `CONTACT_EMAIL`, is where bounces
+  arrive** — which is the opposite of what upstream's install guide assumes, and the reason
+  `script/handle-mail-replies` has never seen a single message here. It is also currently a Google
+  Group that archives them. Fixing it is Workspace routing plus a Postfix pipe in the
+  `infrastructure` repo, with no application code. Right to Know's sending reputation is what gets
+  FOI requests delivered to authorities, so this lands before anything is mailed in bulk.
+- **Notice to the accounts that can actually receive one (#1095).** `DormantAccountMailer` honours
+  `should_be_emailed?`, so banned, opted-out and bounced accounts get no notice and are left to the
+  cron, as upstream did on WhatDoTheyKnow. Recipients are tagged `dormant_account_notice:<date>`
+  so a re-run can't mail them twice; user tags are used because `UserInfoRequestSentAlert` requires
+  an `info_request_id` and these accounts have no requests by definition. Sends are capped per run
+  and triggered by hand so the bounce rate can be watched between tranches rather than discovered
+  afterwards. The email states a removal date computed as the run date plus 60 days, so **the cron
+  must not be enabled before the latest date any tranche was told**.
+
+The notice mailer's code may land before bounce recording works; its first live send may not.
+
 ## 2026-08-24: the personal information gate fails open, and Sentry RIGHT-TO-KNOW-JS-5 is our canary
 
 The new request form asks whether you're requesting personal information that should be confidential, and hides the

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -41,6 +41,9 @@ require File.expand_path('sentry_config.rb', __dir__)
 # A new controller (not a patch to an existing one) - see its own file for why
 require File.expand_path('whatismyip_controller.rb', __dir__)
 
+# Account housekeeping (#1095, #1096) - see "Account housekeeping" in README.md
+require File.expand_path('dormant_accounts.rb', __dir__)
+
 # Note you should rename the file at "config/custom-routes.rb" to
 # something unique (e.g. yourtheme-custom-routes.rb":
 $alaveteli_route_extensions << 'custom-routes.rb'

--- a/lib/dormant_accounts.rb
+++ b/lib/dormant_accounts.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+##
+# Housekeeping for accounts that have never been used, and the shared
+# definition of the cohort the host's `users:destroy_unused` cron would
+# destroy (openaustralia/righttoknow#1031, #1095, #1096).
+#
+# See "Account housekeeping" in README.md for how to run this, and
+# docs/DECISIONS.md (2026-09-03) for why never-confirmed accounts are
+# handled separately and without notice.
+#
+module DormantAccounts
+  # Exactly the cohort of the host's `users:destroy_unused`
+  # (alaveteli/lib/tasks/users.rake). Kept in one place so this pass and the
+  # dormant-account notice (DormantAccountMailer) can never disagree about who
+  # is at risk of deletion.
+  #
+  # `last_sign_in_at` is nil for every account that predates the 0.46 upgrade,
+  # which is why the host cron is still disabled - see #1031.
+  def self.scope
+    time_range = ...2.years.ago
+    User.unused.where(created_at: time_range, last_sign_in_at: [nil, time_range])
+  end
+
+  # Accounts in that cohort that never confirmed their email address. They
+  # cannot be sent the notice at all (`User#should_be_emailed?` requires
+  # `email_confirmed`), so there is nothing to wait for before deleting them.
+  def self.never_confirmed
+    scope.where(email_confirmed: false)
+  end
+
+  # Destroy the never-confirmed cohort. Dry unless DRYRUN=0, so a bare run is
+  # always safe; LIMIT caps the batch, which is how to start a live run small.
+  #
+  # Prints one line per account as `id<TAB>created_at`, deliberately without
+  # the email address or name - the point of the exercise is to hold less
+  # personal data, not to copy it into a terminal and an issue comment.
+  def self.destroy_never_confirmed(dryrun: ENV['DRYRUN'] != '0',
+                                   limit: ENV['LIMIT'].presence&.to_i,
+                                   out: $stderr)
+    users = never_confirmed.order(:id)
+    users = users.limit(limit) if limit
+
+    users.pluck(:id, :created_at).each do |id, created_at|
+      out.puts "#{id}\t#{created_at.iso8601}"
+    end
+
+    if dryrun
+      out.puts "DRY RUN: would destroy #{users.count} never-confirmed accounts"
+      return
+    end
+
+    out.puts "Destroyed #{destroy_users(users)} never-confirmed accounts"
+  end
+
+  # Same shape as the host task: clear the inbound TrackThing references that
+  # have a foreign key but no association to cascade them, preload everything
+  # so the cascade isn't an N+1, and silence the logger so a large run doesn't
+  # write a line of SQL per row.
+  #
+  # `destroy!` rather than `destroy` so that a destroy blocked by a callback or
+  # a foreign key fails the run instead of being counted as a success.
+  def self.destroy_users(users)
+    TrackThing.where(tracked_user_id: users.select(:id))
+              .update_all(tracked_user_id: nil)
+
+    destroyed = 0
+    ActiveRecord::Base.logger.silence do
+      users.preload(User.reflect_on_all_associations.map(&:name))
+           .in_batches.each_record do |user|
+        user.destroy!
+        destroyed += 1
+      end
+    end
+    destroyed
+  end
+  private_class_method :destroy_users
+end

--- a/script/destroy-never-confirmed-accounts
+++ b/script/destroy-never-confirmed-accounts
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Destroy never-confirmed, content-free accounts older than two years
+# (openaustralia/righttoknow#1096).
+#
+# Dry unless DRYRUN=0. LIMIT=n caps the batch. Prints one id and created_at per
+# account, then a count.
+#
+# Run from a shell on the server; from your own machine use
+# `bundle exec cap production accounts:destroy_never_confirmed` instead. See
+# "Account housekeeping" in README.md.
+set -euo pipefail
+
+# This theme is checked out at alaveteli/lib/themes/righttoknow, so the host
+# app root is four levels up from script/.
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
+bundle exec rails runner 'DormantAccounts.destroy_never_confirmed'

--- a/spec/dormant_accounts_spec.rb
+++ b/spec/dormant_accounts_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper'))
+
+RSpec.describe DormantAccounts do
+  # The host loads spec/fixtures/users.yml globally, and those fixtures include
+  # accounts that legitimately fall in this cohort (`unconfirmed_user` was
+  # created in 2007). So these examples assert on the records they create
+  # rather than on absolute counts.
+  let(:out) { StringIO.new }
+
+  let!(:dormant_unconfirmed) do
+    FactoryBot.create(:user, :unconfirmed, created_at: 3.years.ago)
+  end
+
+  before do
+    # `User.unused` creates the CONTACT_EMAIL account if it is missing, so
+    # reference it up front and keep that side effect out of the examples.
+    User.internal_admin_user
+  end
+
+  describe '.scope' do
+    subject { described_class.scope }
+
+    it 'includes a content-free confirmed account over two years old' do
+      user = FactoryBot.create(:user, created_at: 3.years.ago)
+      is_expected.to include(user)
+    end
+
+    it 'includes a content-free never-confirmed account over two years old' do
+      is_expected.to include(dormant_unconfirmed)
+    end
+
+    it 'excludes an account created within the last two years' do
+      user = FactoryBot.create(:user, :unconfirmed, created_at: 1.year.ago)
+      is_expected.not_to include(user)
+    end
+
+    it 'excludes an account that signed in within the last two years' do
+      user = FactoryBot.create(:user, :unconfirmed, created_at: 3.years.ago,
+                                                    last_sign_in_at: 1.year.ago)
+      is_expected.not_to include(user)
+    end
+
+    it 'excludes an account with a retained sign-in record' do
+      # Inserted rather than built through the factory: this environment sets
+      # USER_SIGN_IN_ACTIVITY_RETENTION_DAYS to 0, so User::SignIn's
+      # before_create aborts and the factory can never save a row. The scope
+      # reads the table, so a directly inserted row is the real thing.
+      now = Time.zone.now
+      User::SignIn.insert_all(
+        [{ user_id: dormant_unconfirmed.id, created_at: now, updated_at: now }]
+      )
+
+      is_expected.not_to include(dormant_unconfirmed)
+    end
+
+    # One example only, to prove the scope delegates to User.unused. The host's
+    # spec/models/user/unused_spec.rb covers the rest of its conditions.
+    it 'excludes an account that has made a request' do
+      dormant_unconfirmed.update_columns(info_requests_count: 1)
+      is_expected.not_to include(dormant_unconfirmed)
+    end
+
+    it 'excludes the internal admin account' do
+      is_expected.not_to include(User.internal_admin_user)
+    end
+  end
+
+  describe '.never_confirmed' do
+    subject { described_class.never_confirmed }
+
+    it 'includes a never-confirmed account in the cohort' do
+      is_expected.to include(dormant_unconfirmed)
+    end
+
+    it 'excludes a confirmed account in the cohort' do
+      confirmed = FactoryBot.create(:user, created_at: 3.years.ago)
+      is_expected.not_to include(confirmed)
+    end
+  end
+
+  describe '.destroy_never_confirmed' do
+    context 'by default' do
+      it 'destroys nothing' do
+        described_class.destroy_never_confirmed(out: out)
+        expect(User.exists?(dormant_unconfirmed.id)).to eq(true)
+      end
+
+      it 'lists the account it would destroy' do
+        described_class.destroy_never_confirmed(out: out)
+        expect(out.string).to include(
+          "#{dormant_unconfirmed.id}\t#{dormant_unconfirmed.created_at.iso8601}"
+        )
+        expect(out.string).to match(/DRY RUN: would destroy \d+ never-confirmed/)
+      end
+
+      it 'does not list a confirmed account in the cohort' do
+        confirmed = FactoryBot.create(:user, created_at: 3.years.ago)
+        described_class.destroy_never_confirmed(out: out)
+        expect(out.string).not_to match(/^#{confirmed.id}\t/)
+      end
+
+      it 'does not print personal details' do
+        described_class.destroy_never_confirmed(out: out)
+        expect(out.string).not_to include(dormant_unconfirmed.email)
+        expect(out.string).not_to include(dormant_unconfirmed.name)
+      end
+    end
+
+    context 'when DRYRUN is off' do
+      it 'destroys the never-confirmed account' do
+        described_class.destroy_never_confirmed(dryrun: false, out: out)
+        expect(User.exists?(dormant_unconfirmed.id)).to eq(false)
+      end
+
+      it 'reports how many it destroyed' do
+        described_class.destroy_never_confirmed(dryrun: false, out: out)
+        expect(out.string).to match(/Destroyed \d+ never-confirmed accounts/)
+      end
+
+      it 'keeps a confirmed account in the cohort' do
+        confirmed = FactoryBot.create(:user, created_at: 3.years.ago)
+        described_class.destroy_never_confirmed(dryrun: false, out: out)
+        expect(User.exists?(confirmed.id)).to eq(true)
+      end
+
+      it 'keeps a never-confirmed account created within two years' do
+        recent = FactoryBot.create(:user, :unconfirmed, created_at: 1.year.ago)
+        described_class.destroy_never_confirmed(dryrun: false, out: out)
+        expect(User.exists?(recent.id)).to eq(true)
+      end
+
+      it 'keeps a never-confirmed account that has content' do
+        dormant_unconfirmed.update_columns(comments_count: 1)
+        described_class.destroy_never_confirmed(dryrun: false, out: out)
+        expect(User.exists?(dormant_unconfirmed.id)).to eq(true)
+      end
+
+      it 'clears inbound TrackThing references before destroying' do
+        # Built directly rather than with the :user_track factory, whose own
+        # after(:create) hook raises NameError in the host app.
+        track = TrackThing.create!(
+          track_type: 'user_updates',
+          track_query: 'requested_by:example',
+          track_medium: 'email_daily',
+          tracking_user: FactoryBot.create(:user, created_at: 1.day.ago),
+          tracked_user: dormant_unconfirmed
+        )
+
+        described_class.destroy_never_confirmed(dryrun: false, out: out)
+
+        expect(track.reload.tracked_user_id).to be_nil
+        expect(User.exists?(dormant_unconfirmed.id)).to eq(false)
+      end
+    end
+
+    context 'with a limit' do
+      before do
+        Array.new(2) do
+          FactoryBot.create(:user, :unconfirmed, created_at: 3.years.ago)
+        end
+      end
+
+      it 'destroys exactly the limit, not the whole cohort' do
+        expect { described_class.destroy_never_confirmed(dryrun: false, limit: 2, out: out) }
+          .to change { described_class.never_confirmed.count }.by(-2)
+      end
+
+      it 'lists only the accounts within the limit' do
+        described_class.destroy_never_confirmed(limit: 2, out: out)
+        expect(out.string.lines.grep(/\t/).size).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Adds a one-off pass that destroys never-confirmed accounts with no content that are more than two years old, plus the shared definition of the cohort the host's `users:destroy_unused` cron would destroy.

- `DormantAccounts.scope` is that cohort, in one place, so this pass and the dormant-account notice in #1095 cannot disagree about who is at risk of deletion.
- `DormantAccounts.destroy_never_confirmed` narrows it to accounts that never confirmed their address. It follows the host task's shape (clear inbound `TrackThing` references, preload associations, destroy in batches with the logger silenced), but is dry unless `DRYRUN=0` and takes a `LIMIT` so a live run can start at ten accounts.
- Output is account ids and creation dates only, never addresses or names. Deleting these accounts is a data-minimisation exercise, so the audit trail holds no personal data.
- `accounts:destroy_never_confirmed` runs it through Capistrano rather than an interactive SSH session, so every run uses the same reviewed entry point and the printed ids are the record of what ran.
- The account vocabulary goes in `AGENTS.md`, and the three-step ordering across #1094, #1095 and #1096 goes in `docs/DECISIONS.md`.

Not scheduled as a cron. Once the host cron is enabled it covers this cohort anyway.

## Motivation and Context

The `users:destroy_unused` cron is shipped disabled (#1031) because its first run would destroy 2,732 of the site's 10,149 accounts, and its two-year dormancy guard reads `last_sign_in_at`, a column added in 0.46 with no backfill that is set for only 4 accounts.

969 of those 2,732 never confirmed their email address. `User#should_be_emailed?` requires `email_confirmed`, so by design they cannot be included in the notification proposed in #1095, and there is no reason to think a warning would arrive if we tried. That makes handling them separately the only coherent option rather than an optimisation, and it takes the remaining decision on #1095 down from 2,732 accounts to roughly 1,763.

Resolves #1096. Sequenced ahead of #1094 and #1095, which it does not depend on.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below
- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)

21 new examples in `spec/dormant_accounts_spec.rb`, run from the host checkout:

```
bundle exec rspec lib/themes/righttoknow/spec/dormant_accounts_spec.rb
21 examples, 0 failures
```

The whole theme suite is `114 examples, 6 failures`, and those six are the pre-existing `whatismyip_spec.rb` failures. Confirmed by stashing this branch's changes and re-running that file on the base commit, where the same six fail.

`bundle exec rubocop` is clean across the repository with no new `.rubocop_todo.yml` entries.

Two things checked against reality rather than assumed while writing this:

- **`in_batches` honours an existing `limit`.** This matters, because if it did not, `LIMIT=10` would silently destroy the whole cohort. Verified in a console against the test database.
- **The host loads `spec/fixtures/users.yml` globally**, and those fixtures include accounts that legitimately fall in this cohort (`unconfirmed_user`, created 2007). The specs therefore assert on the records they create rather than on absolute counts. `User.unused` also creates the `CONTACT_EMAIL` account when it is missing, which the specs account for.

Not yet run against production. The dry run and the count check against the 969 figure happen once this is deployed, per the sequence in `docs/DECISIONS.md`.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## AI assistance

Written with Claude Code (claude-opus-5). I have reviewed the change and am responsible for it.
