### PR TITLE
Notify dormant accounts before they are removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,11 +360,34 @@ separately from the dormant-account notice. What "never-confirmed" and "dormant"
 order matters, is in `AGENTS.md` under "Key domain knowledge" and in `docs/DECISIONS.md`
 (2026-09-03).
 
-The same job can be run from a shell on the server, with the same environment variables:
+Tell the remaining dormant accounts they will be removed unless they sign in
+([#1095](https://github.com/openaustralia/righttoknow/issues/1095)):
+
+```bash
+# List who would be notified, and the removal date the email would quote
+bundle exec cap production accounts:send_dormant_notices
+
+# Send one tranche, then watch the bounce count before sending the next
+bundle exec cap production accounts:send_dormant_notices DRYRUN=0 LIMIT=20
+bundle exec cap production accounts:send_dormant_notices DRYRUN=0
+```
+
+**Do not send these live until bounce recording works
+([#1094](https://github.com/openaustralia/righttoknow/issues/1094)).** Without it nothing suppresses
+repeat sends to addresses that have permanently failed, and there is no way to judge the send. Right
+to Know's sending reputation is what gets FOI requests delivered to authorities.
+
+Each notice quotes a removal date of the run date plus 60 days, and each account notified is tagged
+`dormant_account_notice:<date>` so a later run never mails the same person twice. **The host's
+`users:destroy_unused` cron must not be enabled before the latest date any tranche was told.** The
+run prints that date so it can be recorded on the issue.
+
+Either job can be run from a shell on the server, with the same environment variables:
 
 ```bash
 cd /srv/www/production/current
 lib/themes/righttoknow/script/destroy-never-confirmed-accounts
+lib/themes/righttoknow/script/send-dormant-account-notices
 ```
 
 ### First-time server setup

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -145,6 +145,12 @@ namespace :accounts do
   task :destroy_never_confirmed do
     run_account_job('DormantAccounts.destroy_never_confirmed')
   end
+
+  desc 'Email dormant accounts a removal notice (#1095). DRYRUN=0 to send, ' \
+       'LIMIT=n per tranche (default 200). Needs bounce recording (#1094)'
+  task :send_dormant_notices do
+    run_account_job('DormantAccountMailer.send_notices')
+  end
 end
 
 namespace :deploy do

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -43,6 +43,7 @@ require File.expand_path('whatismyip_controller.rb', __dir__)
 
 # Account housekeeping (#1095, #1096) - see "Account housekeeping" in README.md
 require File.expand_path('dormant_accounts.rb', __dir__)
+require File.expand_path('dormant_account_mailer.rb', __dir__)
 
 # Note you should rename the file at "config/custom-routes.rb" to
 # something unique (e.g. yourtheme-custom-routes.rb":

--- a/lib/dormant_account_mailer.rb
+++ b/lib/dormant_account_mailer.rb
@@ -50,8 +50,7 @@ Rails.configuration.to_prepare do
       mail_user(
         @user,
         subject: lambda {
-          _('Your {{site_name}} account will be removed unless you sign in',
-            site_name: site_name)
+          _('Sign in to keep your {{site_name}} account', site_name: site_name)
         }
       )
     end

--- a/lib/dormant_account_mailer.rb
+++ b/lib/dormant_account_mailer.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 Rails.configuration.to_prepare do
+  # Removed first for the same reason as WhatismyipController: to_prepare runs
+  # again on every code reload against a fresh ApplicationMailer, and this
+  # constant isn't Zeitwerk-managed, so redefining it would raise "superclass
+  # mismatch".
+  Object.send(:remove_const, :DormantAccountMailer) if
+    Object.const_defined?(:DormantAccountMailer, false)
+
   ##
   # Tells the people behind dormant accounts that the account will be removed
   # unless they sign in (openaustralia/righttoknow#1095).

--- a/lib/dormant_account_mailer.rb
+++ b/lib/dormant_account_mailer.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+Rails.configuration.to_prepare do
+  ##
+  # Tells the people behind dormant accounts that the account will be removed
+  # unless they sign in (openaustralia/righttoknow#1095).
+  #
+  # Modelled on the host's SurveyMailer: a class method selects the cohort,
+  # checks a per-account "already sent" guard, delivers, and records the send.
+  # The store is a user tag rather than a UserInfoRequestSentAlert, because
+  # that model requires an info_request_id and these accounts have no requests
+  # by definition.
+  #
+  # Do not run a live send until bounce recording works (#1094). See
+  # "Account housekeeping" in README.md and docs/DECISIONS.md (2026-09-03).
+  # rubocop:disable Lint/ConstantDefinitionInBlock
+  class DormantAccountMailer < ApplicationMailer
+    # rubocop:enable Lint/ConstantDefinitionInBlock
+    # Checked by name, so a re-run never mails the same account twice even
+    # though each tag carries the date it was sent.
+    TAG = 'dormant_account_notice'
+
+    # How long people are given to sign in. The host cron must not be enabled
+    # before the latest date any tranche was told, which is why the date goes
+    # in the email rather than being left vague.
+    NOTICE_PERIOD = 60.days
+
+    # Mail is handed to a local Postfix, so a per-address failure is nearly
+    # impossible: a bad address is accepted and bounced later. Several failures
+    # in a row means the local pipe is broken and would fail for the whole
+    # tranche, so stop rather than burning it.
+    MAX_CONSECUTIVE_FAILURES = 5
+
+    def notice(user, removal_date)
+      @user = user
+      @removal_date = removal_date
+
+      # Only Reply-To. `mail_user` already sets Return-Path to the blackhole
+      # address and adds the auto-generated headers, so setting those here as
+      # SurveyMailer does would put each of them in the message twice.
+      headers('Reply-To' => contact_from_name_and_email)
+
+      mail_user(
+        @user,
+        subject: lambda {
+          _('Your {{site_name}} account will be removed unless you sign in',
+            site_name: site_name)
+        }
+      )
+    end
+
+    # Mail one tranche of the dormant cohort. Dry unless DRYRUN=0, and capped
+    # at LIMIT accounts so the bounce rate can be watched between tranches
+    # rather than discovered after the whole cohort has been mailed.
+    def self.send_notices(dryrun: ENV['DRYRUN'] != '0',
+                          limit: Integer(ENV.fetch('LIMIT', 200)),
+                          out: $stderr)
+      removal_date = Date.current + NOTICE_PERIOD
+      sent = 0
+      failed = 0
+      consecutive_failures = 0
+
+      DormantAccounts.scope.without_tag(TAG).order(:id).find_each do |user|
+        break if sent >= limit
+        # Skips banned, closed, unconfirmed, opted-out and bounced accounts.
+        # They get no notice and are left to the host cron, as upstream did.
+        next unless user.should_be_emailed?
+
+        out.puts user.id
+
+        if dryrun
+          sent += 1
+          next
+        end
+
+        if deliver_and_tag(user, removal_date, out)
+          sent += 1
+          consecutive_failures = 0
+        else
+          failed += 1
+          consecutive_failures += 1
+          if consecutive_failures >= MAX_CONSECUTIVE_FAILURES
+            out.puts "Stopping: #{consecutive_failures} consecutive failures"
+            break
+          end
+        end
+      end
+
+      out.puts summary(dryrun, sent, failed, removal_date)
+    end
+
+    # Tags only after a successful delivery, so an account that failed is
+    # picked up by the next run.
+    #
+    # Rescues StandardError rather than a mail-specific class because
+    # `raise_delivery_errors` is on and a sendmail failure surfaces as
+    # Errno::EPIPE or similar. Logs the class, never the message, since a
+    # delivery error can echo the address back.
+    def self.deliver_and_tag(user, removal_date, out)
+      notice(user, removal_date).deliver_now
+      user.add_tag_if_not_already_present("#{TAG}:#{Date.current.iso8601}")
+      true
+    rescue StandardError => e
+      out.puts "user #{user.id}: delivery failed (#{e.class})"
+      false
+    end
+    private_class_method :deliver_and_tag
+
+    def self.summary(dryrun, sent, failed, removal_date)
+      if dryrun
+        "DRY RUN: would notify #{sent} dormant accounts, " \
+          "quoting a removal date of #{removal_date.iso8601}"
+      else
+        "Notified #{sent} dormant accounts (#{failed} failed). " \
+          "They may be removed on or after #{removal_date.iso8601}"
+      end
+    end
+    private_class_method :summary
+  end
+end

--- a/lib/dormant_account_mailer.rb
+++ b/lib/dormant_account_mailer.rb
@@ -19,7 +19,8 @@ Rails.configuration.to_prepare do
   # by definition.
   #
   # Do not run a live send until bounce recording works (#1094). See
-  # "Account housekeeping" in README.md and docs/DECISIONS.md (2026-09-03).
+  # "Account housekeeping" in README.md and
+  # doc/adr/0003-dormant-account-deletion-is-three-ordered-passes.md.
   # rubocop:disable Lint/ConstantDefinitionInBlock
   class DormantAccountMailer < ApplicationMailer
     # rubocop:enable Lint/ConstantDefinitionInBlock

--- a/lib/views/dormant_account_mailer/notice.text.erb
+++ b/lib/views/dormant_account_mailer/notice.text.erb
@@ -2,27 +2,42 @@
 <%# file and the subject line in lib/dormant_account_mailer.rb, so the copy  %>
 <%# can be revised in one place. Signed off by the CEO before the first live %>
 <%# send - see docs/DECISIONS.md (2026-09-03).                               %>
-<%= _('Hello,') %>
+<%# `raw`, because ActionView escapes interpolated output in a text template %>
+<%# too, which would turn a name like O'Brien into O&#39;Brien.              %>
+<%= _('Hello {{user_name}},', user_name: raw(@user.name)) %>
 
-<%= _('You have an account on {{site_name}} ({{site_url}}). Our records show ' \
-      'no activity on it for at least two years: no requests, comments or ' \
-      'follows, and no sign-ins.',
+<%= _('You have an account on {{site_name}} ({{site_url}}) that was created ' \
+      'more than two years ago. It has no requests, comments or follows on ' \
+      'it.',
       site_name: site_name,
-      site_url: root_url) %>
+      site_url: root_url.chomp('/')) %>
 
-<%= _('We are removing unused accounts. This one will be removed on or after ' \
-      '{{removal_date}} unless you sign in before then.',
+<%= _("We're removing unused accounts, so we're not holding personal " \
+      "information we don't need. This one will be removed on or after " \
+      "{{removal_date}} unless you sign in before then. Once it's removed " \
+      "we can't get it back.",
       removal_date: @removal_date.strftime('%-d %B %Y')) %>
 
-<%= _('If you want to keep the account, sign in here:') %>
+<%= _('To keep the account, sign in here:') %>
 
 <%= signin_url %>
 
-<%= _('If you do not want to keep it, you do not need to do anything. ' \
-      'Nothing you have written is affected, because the account has no ' \
-      'requests or comments.') %>
+<%= _("If you'd rather not follow a link in an email, go to {{site_domain}} " \
+      'and sign in from there.',
+      site_domain: AlaveteliConfiguration.domain) %>
+
+<%= _("If you don't want to keep it, you don't need to do anything. Nothing " \
+      "on the public site changes, because there's nothing published under " \
+      'the account.') %>
+
+<%= _("You're getting this because you have an account on {{site_name}}. " \
+      "It's a notice about that account, not a newsletter or an appeal for " \
+      "donations. There's no unsubscribe link, because unsubscribing " \
+      "wouldn't stop the account being removed.",
+      site_name: site_name) %>
 
 <%= _('If you have any questions, reply to this email or write to ' \
       '{{contact_email}}.', contact_email: AlaveteliConfiguration.contact_email) %>
 
--- <%= _('the {{site_name}} team', site_name: site_name) %>
+<%= _('Kind regards,') %>
+<%= _('the {{site_name}} team', site_name: site_name) %>

--- a/lib/views/dormant_account_mailer/notice.text.erb
+++ b/lib/views/dormant_account_mailer/notice.text.erb
@@ -1,0 +1,28 @@
+<%# All of the wording for the dormant-account notice (#1095) lives in this  %>
+<%# file and the subject line in lib/dormant_account_mailer.rb, so the copy  %>
+<%# can be revised in one place. Signed off by the CEO before the first live %>
+<%# send - see docs/DECISIONS.md (2026-09-03).                               %>
+<%= _('Hello,') %>
+
+<%= _('You have an account on {{site_name}} ({{site_url}}). Our records show ' \
+      'no activity on it for at least two years: no requests, comments or ' \
+      'follows, and no sign-ins.',
+      site_name: site_name,
+      site_url: root_url) %>
+
+<%= _('We are removing unused accounts. This one will be removed on or after ' \
+      '{{removal_date}} unless you sign in before then.',
+      removal_date: @removal_date.strftime('%-d %B %Y')) %>
+
+<%= _('If you want to keep the account, sign in here:') %>
+
+<%= signin_url %>
+
+<%= _('If you do not want to keep it, you do not need to do anything. ' \
+      'Nothing you have written is affected, because the account has no ' \
+      'requests or comments.') %>
+
+<%= _('If you have any questions, reply to this email or write to ' \
+      '{{contact_email}}.', contact_email: AlaveteliConfiguration.contact_email) %>
+
+-- <%= _('the {{site_name}} team', site_name: site_name) %>

--- a/lib/views/dormant_account_mailer/notice.text.erb
+++ b/lib/views/dormant_account_mailer/notice.text.erb
@@ -1,7 +1,7 @@
 <%# All of the wording for the dormant-account notice (#1095) lives in this  %>
 <%# file and the subject line in lib/dormant_account_mailer.rb, so the copy  %>
 <%# can be revised in one place. Signed off by the CEO before the first live %>
-<%# send - see docs/DECISIONS.md (2026-09-03).                               %>
+<%# send - see doc/adr/0003.                                                 %>
 <%# `raw`, because ActionView escapes interpolated output in a text template %>
 <%# too, which would turn a name like O'Brien into O&#39;Brien.              %>
 <%= _('Hello {{user_name}},', user_name: raw(@user.name)) %>

--- a/script/send-dormant-account-notices
+++ b/script/send-dormant-account-notices
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Tell dormant accounts they will be removed unless they sign in
+# (openaustralia/righttoknow#1095).
+#
+# Dry unless DRYRUN=0. LIMIT caps the tranche, default 200. Prints one account
+# id per notice, then a count and the removal date it quoted.
+#
+# Do not run live until bounce recording works (#1094): without it nothing
+# suppresses repeat sends to dead addresses, and there is no way to judge the
+# send. Watch the bounce count between tranches.
+#
+# Run from a shell on the server; from your own machine use
+# `bundle exec cap production accounts:send_dormant_notices` instead. See
+# "Account housekeeping" in README.md.
+set -euo pipefail
+
+# This theme is checked out at alaveteli/lib/themes/righttoknow, so the host
+# app root is four levels up from script/.
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
+bundle exec rails runner 'DormantAccountMailer.send_notices'

--- a/spec/dormant_account_mailer_spec.rb
+++ b/spec/dormant_account_mailer_spec.rb
@@ -51,10 +51,22 @@ RSpec.describe DormantAccountMailer, '#notice' do
       end
     end
 
-    it 'says the account will be removed unless they sign in' do
+    it 'asks them to sign in to keep the account' do
       expect(mail.subject)
-        .to eq("Your #{AlaveteliConfiguration.site_name} account will be " \
-               'removed unless you sign in')
+        .to eq("Sign in to keep your #{AlaveteliConfiguration.site_name} " \
+               'account')
+    end
+
+    it 'greets the account holder by name' do
+      dormant.update!(name: 'Jane Citizen')
+      expect(mail.body.to_s).to include('Hello Jane Citizen,')
+    end
+
+    # A text template is escaped like any other, so without `raw` an apostrophe
+    # in a name would reach the recipient as O&#39;Brien.
+    it 'does not escape punctuation in the name' do
+      dormant.update!(name: "Ann O'Brien-Smith & Co")
+      expect(mail.body.to_s).to include("Hello Ann O'Brien-Smith & Co,")
     end
 
     it 'quotes the removal date in words' do
@@ -70,8 +82,11 @@ RSpec.describe DormantAccountMailer, '#notice' do
     end
 
     # Unsubscribing would not stop the deletion, so offering it would mislead.
-    it 'does not offer an unsubscribe link' do
-      expect(mail.body.to_s.downcase).not_to include('unsubscribe')
+    # The copy says so rather than staying silent, hence matching the sentence
+    # instead of the word.
+    it 'says there is no unsubscribe link, and offers none' do
+      expect(mail.body.to_s).to include("There's no unsubscribe link")
+      expect(mail.body.to_s).not_to match(%r{https?://\S*unsubscribe}i)
     end
   end
 end

--- a/spec/dormant_account_mailer_spec.rb
+++ b/spec/dormant_account_mailer_spec.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper'))
+
+RSpec.describe DormantAccountMailer, '#notice' do
+  # The host loads spec/fixtures/users.yml globally, and some of those accounts
+  # fall in this cohort, so these examples assert on the records they create
+  # rather than on absolute counts.
+  let(:out) { StringIO.new }
+  let(:removal_date) { Date.new(2026, 11, 2) }
+
+  let!(:dormant) { FactoryBot.create(:user, created_at: 3.years.ago) }
+
+  before do
+    # `User.unused` creates the CONTACT_EMAIL account if it is missing, so
+    # reference it up front and keep that side effect out of the examples.
+    User.internal_admin_user
+  end
+
+  describe '#notice' do
+    subject(:mail) { described_class.notice(dormant, removal_date) }
+
+    it 'is addressed to the account holder' do
+      expect(mail.to).to eq([dormant.email])
+    end
+
+    it 'returns bounces to the blackhole address, so they can be recorded' do
+      expect(mail['Return-Path'].to_s).to include(
+        AlaveteliConfiguration.blackhole_prefix
+      )
+    end
+
+    it 'sends replies to the contact address' do
+      expect(mail['Reply-To'].to_s).to include(
+        AlaveteliConfiguration.contact_email
+      )
+    end
+
+    it 'marks itself auto-generated and suppresses out of office replies' do
+      expect(mail['Auto-Submitted'].value).to eq('auto-generated')
+      expect(mail['X-Auto-Response-Suppress'].value).to eq('OOF')
+    end
+
+    # `mail_user` sets these too, so setting them in the action as SurveyMailer
+    # does would send each one twice.
+    it 'sets each header only once' do
+      %w[Return-Path Reply-To Auto-Submitted X-Auto-Response-Suppress].each do |header|
+        expect(Array(mail[header]).size).to eq(1), "#{header} appears more than once"
+      end
+    end
+
+    it 'says the account will be removed unless they sign in' do
+      expect(mail.subject)
+        .to eq("Your #{AlaveteliConfiguration.site_name} account will be " \
+               'removed unless you sign in')
+    end
+
+    it 'quotes the removal date in words' do
+      expect(mail.body.to_s).to include('2 November 2026')
+    end
+
+    it 'links to the sign in page' do
+      expect(mail.body.to_s).to include('/profile/sign_in')
+    end
+
+    it 'gives the contact address' do
+      expect(mail.body.to_s).to include(AlaveteliConfiguration.contact_email)
+    end
+
+    # Unsubscribing would not stop the deletion, so offering it would mislead.
+    it 'does not offer an unsubscribe link' do
+      expect(mail.body.to_s.downcase).not_to include('unsubscribe')
+    end
+  end
+end
+
+RSpec.describe DormantAccountMailer, '.send_notices' do
+  # The host loads spec/fixtures/users.yml globally, and some of those accounts
+  # fall in this cohort, so these examples assert on the records they create
+  # rather than on absolute counts.
+  let(:out) { StringIO.new }
+  let(:removal_date) { Date.new(2026, 11, 2) }
+
+  let!(:dormant) { FactoryBot.create(:user, created_at: 3.years.ago) }
+
+  before do
+    # `User.unused` creates the CONTACT_EMAIL account if it is missing, so
+    # reference it up front and keep that side effect out of the examples.
+    User.internal_admin_user
+  end
+
+  describe '.send_notices' do
+    context 'by default' do
+      it 'sends nothing' do
+        described_class.send_notices(out: out)
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+
+      it 'records nothing against the account' do
+        described_class.send_notices(out: out)
+        expect(dormant.reload.has_tag?(described_class::TAG)).to eq(false)
+      end
+
+      it 'lists the account it would notify' do
+        described_class.send_notices(out: out)
+        expect(out.string).to match(/^#{dormant.id}$/)
+        expect(out.string).to match(/DRY RUN: would notify \d+ dormant accounts/)
+      end
+
+      it 'names the removal date it would quote' do
+        travel_to(Date.new(2026, 9, 3)) do
+          described_class.send_notices(out: out)
+          expect(out.string).to include('2026-11-02')
+        end
+      end
+    end
+
+    context 'when DRYRUN is off' do
+      it 'notifies the dormant account' do
+        described_class.send_notices(dryrun: false, out: out)
+        expect(ActionMailer::Base.deliveries.map(&:to).flatten)
+          .to include(dormant.email)
+      end
+
+      it 'tags the account with the date it was notified' do
+        travel_to(Date.new(2026, 9, 3)) do
+          described_class.send_notices(dryrun: false, out: out)
+        end
+
+        expect(dormant.reload.tag_string)
+          .to include("#{described_class::TAG}:2026-09-03")
+      end
+
+      it 'does not notify the same account twice' do
+        described_class.send_notices(dryrun: false, out: out)
+        ActionMailer::Base.deliveries = []
+
+        described_class.send_notices(dryrun: false, out: out)
+
+        expect(ActionMailer::Base.deliveries.map(&:to).flatten)
+          .not_to include(dormant.email)
+      end
+
+      context 'with an account that should not be emailed' do
+        # should_be_emailed? is the single gate for all outgoing mail, so each
+        # of its four conditions is checked here.
+        {
+          'banned' => { ban_text: 'Banned' },
+          'closed' => { closed_at: Time.zone.now },
+          'never confirmed' => { email_confirmed: false },
+          'opted out of alerts' => { receive_email_alerts: false },
+          'already bounced' => { email_bounced_at: Time.zone.now }
+        }.each do |description, attributes|
+          it "does not notify an account that is #{description}" do
+            dormant.update_columns(attributes)
+
+            described_class.send_notices(dryrun: false, out: out)
+
+            expect(ActionMailer::Base.deliveries.map(&:to).flatten)
+              .not_to include(dormant.email)
+          end
+        end
+      end
+
+      it 'does not notify an account created within the last two years' do
+        recent = FactoryBot.create(:user, created_at: 1.year.ago)
+
+        described_class.send_notices(dryrun: false, out: out)
+
+        expect(ActionMailer::Base.deliveries.map(&:to).flatten)
+          .not_to include(recent.email)
+      end
+
+      context 'when a delivery fails' do
+        # The :test delivery method cannot fail on its own, so the failure is
+        # injected at the transport, which is the seam sendmail fails at in
+        # production. raise_delivery_errors is on, so this is what the run sees.
+        before do
+          call = 0
+          allow_any_instance_of(Mail::TestMailer)
+            .to receive(:deliver!).and_wrap_original do |original, *args|
+              call += 1
+              raise Errno::EPIPE if call == 1
+
+              original.call(*args)
+            end
+        end
+
+        let!(:second_dormant) do
+          FactoryBot.create(:user, created_at: 3.years.ago)
+        end
+
+        it 'carries on to the next account' do
+          described_class.send_notices(dryrun: false, out: out)
+
+          expect(ActionMailer::Base.deliveries.map(&:to).flatten)
+            .to include(second_dormant.email)
+        end
+
+        it 'leaves the failed account untagged, so a later run retries it' do
+          described_class.send_notices(dryrun: false, out: out)
+
+          expect(dormant.reload.has_tag?(described_class::TAG)).to eq(false)
+        end
+
+        it 'logs the account id and error class, not the address' do
+          described_class.send_notices(dryrun: false, out: out)
+
+          expect(out.string)
+            .to include("user #{dormant.id}: delivery failed (Errno::EPIPE)")
+          expect(out.string).not_to include(dormant.email)
+        end
+      end
+
+      context 'when every delivery fails' do
+        before do
+          allow_any_instance_of(Mail::TestMailer)
+            .to receive(:deliver!).and_raise(Errno::EPIPE)
+
+          Array.new(described_class::MAX_CONSECUTIVE_FAILURES) do
+            FactoryBot.create(:user, created_at: 3.years.ago)
+          end
+        end
+
+        # A local pipe that is broken would fail for the whole tranche, so the
+        # run stops rather than attempting every account.
+        it 'stops after too many consecutive failures' do
+          described_class.send_notices(dryrun: false, limit: 100, out: out)
+
+          expect(out.string).to match(/Stopping: \d+ consecutive failures/)
+        end
+      end
+    end
+
+    context 'with a limit' do
+      before do
+        Array.new(2) { FactoryBot.create(:user, created_at: 3.years.ago) }
+      end
+
+      it 'notifies no more than the limit' do
+        described_class.send_notices(dryrun: false, limit: 2, out: out)
+
+        expect(ActionMailer::Base.deliveries.size).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What and why

The host's `users:destroy_unused` cron is shipped disabled (#1031), because its first run would destroy 2,732 accounts, 26.9% of the site. Upstream did not enable it blind: the commit that added its dormancy guard (mysociety/alaveteli `2c5176b2e`) records that WhatDoTheyKnow mailed their unused accounts first, prompting people to sign in to keep them. There is no upstream code for that mailing - core has no dormant-account mailer and `mysociety/whatdotheyknow-theme` has no mailers at all - so this builds it, following `SurveyMailer`'s shape. Resolves #1095.

> Stacked on #1097 (now merged, so this targets `staging`). The decision-record references in the code point at `doc/adr/0003-dormant-account-deletion-is-three-ordered-passes.md`, which #1113 creates from the old `docs/DECISIONS.md` entry, so merge #1113 first so those links don't dangle.

- `DormantAccountMailer.send_notices` walks the shared dormant cohort, honours `should_be_emailed?`, and mails each person a notice quoting a removal date. Reach is 1,364 of the 2,732: the 969 never-confirmed accounts cannot be emailed and are handled in #1096 / #1097, and banned, closed, opted-out and already-bounced accounts are excluded by that same gate, as upstream did.
- Recipients are tagged `dormant_account_notice:<date>`, so a re-run never mails the same person twice. Tags rather than `UserInfoRequestSentAlert`, which requires an `info_request_id` these accounts do not have.
- Capped per run and triggered by hand, so the bounce rate can be watched between tranches instead of discovered after 1,364 messages. Failures are caught per account and only a successful send tags it, so a failure is retried next run. Several consecutive failures stop the run: mail goes to a local Postfix, so a run of failures means the pipe is broken rather than the addresses.
- The removal date is the run date plus 60 days, computed at send time and stated in full. **The host cron must not be enabled before the latest date any tranche was told**, so each run prints it.
- The action sets only `Reply-To`, unlike `SurveyMailer`. `mail_user` already sets `Return-Path` and the auto-generated headers, and setting them again puts each one in the message twice. A spec pins that.

**This cannot send until bounce recording lands (#1094).** Without it nothing suppresses repeat sends to dead addresses, and there is no measurement to judge the send by. The code can merge before that; the first `DRYRUN=0` run cannot.

### The copy

Approved by the CEO on 4 September 2026 after a revision, so this is what will go out. All the wording is in `lib/views/dormant_account_mailer/notice.text.erb` plus the subject line, so a further change stays a one-file edit. Rendered from the branch with production values and a fictional name, and wrapped here for reading - the real email leaves each paragraph as one line for the mail client to wrap.

```
Subject: Sign in to keep your Right to Know account

Hello Jane Citizen,

You have an account on Right to Know (https://www.righttoknow.org.au) that was created
more than two years ago. It has no requests, comments or follows on it.

We're removing unused accounts, so we're not holding personal information we don't need.
This one will be removed on or after 2 November 2026 unless you sign in before then. Once
it's removed we can't get it back.

To keep the account, sign in here:

https://www.righttoknow.org.au/profile/sign_in

If you'd rather not follow a link in an email, go to www.righttoknow.org.au and sign in
from there.

If you don't want to keep it, you don't need to do anything. Nothing on the public site
changes, because there's nothing published under the account.

You're getting this because you have an account on Right to Know. It's a notice about that
account, not a newsletter or an appeal for donations. There's no unsubscribe link, because
unsubscribing wouldn't stop the account being removed.

If you have any questions, reply to this email or write to contact@righttoknow.org.au.

Kind regards,
the Right to Know team
```

Four choices in it worth knowing about:

- **It does not claim there have been no sign-ins.** `last_sign_in_at` is null for every account predating the 0.46 upgrade, so we cannot honestly say that to an individual. "Created more than two years ago", and the absence of requests, comments and follows, are both things we can stand behind. The cohort is unchanged; only the wording is.
- **It raises the missing unsubscribe link rather than staying silent.** Unsubscribing would not stop the removal, so offering one would mislead, and saying so beats leaving someone to wonder. It also offers a way to sign in without following a link from an email.
- **The greeting names the account holder.** `users.name` is `NOT NULL` and validated present, so there is always a name. `raw` is needed because a text template is escaped like any other and would otherwise send `O&#39;Brien`. `User#name` appends "(Account suspended)" for banned and closed accounts, but `should_be_emailed?` requires `active?`, so that cannot reach a recipient. Checked against production, counts only and no names or addresses pulled: of the 1,364 mailable accounts none has a blank name, looks like an email address or contains a URL, but 462 (34%) are a single word and 210 (15%) are all lowercase, so a visible minority will read "Hello jd,". Title-casing for display would mangle names like `de Silva` and `McDonald`, so it is deliberately not done.
- **The date is computed, not hardcoded.** The example shows what a 4 September run would quote.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation

## How this was checked

- [x] Checked the affected area on my own or a staging system
- [x] Ran the automated tests
- [ ] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below
- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [x] Documentation updated, or not needed

30 examples in `spec/dormant_account_mailer_spec.rb`, run from the host checkout, and the whole theme suite for comparison:

```
bundle exec rspec lib/themes/righttoknow/spec/dormant_account_mailer_spec.rb
30 examples, 0 failures

bundle exec rspec lib/themes/righttoknow/spec
144 examples, 6 failures
```

Those six are the pre-existing `whatismyip_spec.rb` failures, unchanged from the base commit. `bundle exec rubocop` is clean, with no new `.rubocop_todo.yml` entries.

The specs exercise real records, real tags and `ActionMailer::Base.deliveries`. Each of the four conditions in `should_be_emailed?` gets its own example. The one stub is the delivery failure: the `:test` delivery method cannot fail on its own, so `Errno::EPIPE` is injected at the transport, which is the seam sendmail actually fails at in production. The reason is in a comment.

I also rendered the email to read it as it will arrive, before and after the copy revision. That is where the duplicate-header problem showed up originally, and where I confirmed an apostrophe in a name survives unescaped.

Documentation: "Account housekeeping" in `README.md` covers how to run this, and [ADR-0003](https://github.com/openaustralia/righttoknow/blob/docs/create-changelog/doc/adr/0003-dormant-account-deletion-is-three-ordered-passes.md) (added by #1113, converted from the former `docs/DECISIONS.md` 2026-09-03 entry) records why never-confirmed accounts are handled separately and why the three steps are ordered as they are.

## AI assistance

Written with Claude Code (claude-opus-5). I have reviewed the change and am responsible for it.

