### PR TITLE
Survive dev code reloads in whatismyip controller

### DIFF
--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -4,6 +4,14 @@ require 'ipaddr'
 require 'net/http'
 
 Rails.configuration.to_prepare do
+  # In development ApplicationController is reloadable, so it is a brand-new
+  # class object each time this block re-runs, while this hand-defined
+  # constant (not managed by Zeitwerk) survives the reload still pointing at
+  # the old one. Redefining would then raise "superclass mismatch", breaking
+  # docker/setup's `db:migrate db:seed` and every dev reload (issue #1100),
+  # so drop the stale constant first.
+  Object.send(:remove_const, :WhatismyipController) if Object.const_defined?(:WhatismyipController, false)
+
   # Diagnostic for the nginx/Cloudflare real-IP trust boundary (see
   # ,plan-staging-rtk.md) - off by default since an open whatismyip would let
   # anyone check whether a forged CF-Connecting-IP is being trusted.

--- a/spec/whatismyip_spec.rb
+++ b/spec/whatismyip_spec.rb
@@ -114,3 +114,43 @@ RSpec.describe WhatismyipController, type: :controller do
     end
   end
 end
+
+# Guards against issue #1100: in development ApplicationController is
+# reloadable, so after every code reload it is a brand-new class object while
+# the theme's hand-defined WhatismyipController constant survives, still
+# subclassing the old one. Re-running the theme's to_prepare block then raised
+# "superclass mismatch", which broke docker/setup (db:migrate reloads before
+# db:seed) and every dev-mode reload.
+#
+# A real reload can't reproduce this here - the test environment doesn't
+# reload classes, so ApplicationController would keep its identity - so this
+# simulates one instead: swap ApplicationController for a fresh class object
+# (exactly what a dev reload does) and re-run the theme's registered
+# to_prepare block, restoring both afterwards.
+RSpec.describe 'WhatismyipController code reloading' do
+  def theme_to_prepare_block
+    Rails.application.reloader._prepare_callbacks.map(&:filter).find do |filter|
+      filter.respond_to?(:source_location) &&
+        filter.source_location&.first&.end_with?('whatismyip_controller.rb')
+    end
+  end
+
+  it 'redefines the controller when ApplicationController is a new class object' do
+    block = theme_to_prepare_block
+    expect(block).not_to be_nil
+
+    original = ApplicationController
+    begin
+      Object.send(:remove_const, :ApplicationController)
+      Object.const_set(:ApplicationController, Class.new(original))
+
+      expect { block.call }.not_to raise_error
+      expect(WhatismyipController.superclass).to eq(ApplicationController)
+    ensure
+      Object.send(:remove_const, :ApplicationController)
+      Object.const_set(:ApplicationController, original)
+      # Leave WhatismyipController subclassing the real class again
+      block.call
+    end
+  end
+end


### PR DESCRIPTION
## What and why

In development `ApplicationController` is reloadable, so it is a brand-new class object after every code reload, while the theme's hand-defined `WhatismyipController` constant (not managed by Zeitwerk) survived the reload still subclassing the old one. Re-running the `to_prepare` block then raised `TypeError: superclass mismatch`, which broke `docker/setup` at `bin/rails db:migrate db:seed` (migrate triggers a reload before seed runs) and every dev-mode page load after a file edit. The fix drops the stale constant at the top of the `to_prepare` block so each reload rebuilds the controller against the current `ApplicationController`; production is unaffected since it eager loads and runs `to_prepare` once. A regression spec simulates a dev reload (swaps `ApplicationController` for a fresh class object and re-runs the theme's registered `to_prepare` callback) because the test environment doesn't reload classes, so a real reload can't reproduce the bug there.

Resolves #1100

## Type of change

- [x] Bug fix

## How this was checked

Ran the issue's minimal repro in the host app's dev container (`docker compose run --rm app bin/rails runner '2.times { Rails.application.reloader.reload! }'`): fails with the superclass mismatch on `staging`, passes with this change (also across 5 reloads, with the constant tracking the current `ApplicationController`). The new spec is red without the fix and green with it. Rubocop passes locally.

- [x] Checked the affected area on my own or a staging system
- [x] Ran the automated tests
- [ ] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below
- [x] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [x] Documentation updated, or not needed

Note: the other six examples in `spec/whatismyip_spec.rb` currently fail against the host app's `develop` because `ApplicationController#set_gettext_locale` now calls `AlaveteliConfiguration.get('USE_DEFAULT_BROWSER_LANGUAGE', true)`, which the spec's narrow stub doesn't allow. That failure exists on `staging` without this change (verified: 6 examples / 6 failures before, 7 examples / same 6 failures after) and is left for a separate issue.

Assisted-by: Claude Code:anthropic.claude-fable-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development reload stability by preventing controller superclass mismatch errors when application classes are reloaded.

* **Tests**
  * Added coverage to verify controllers are safely rebuilt after reloads and continue using the current application superclass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->