### PR TITLE
Adopt canonical Sentry configuration and release tracking

### DIFF
--- a/.sentryclirc
+++ b/.sentryclirc
@@ -1,0 +1,8 @@
+# Non-secret defaults for the Sentry CLI. Credentials come from each
+# deployer's `sentry auth` login (v4) or ~/.sentryclirc (v3) - see
+# "Monitoring" in the infrastructure repo (docs/monitoring.md). Never commit
+# tokens here. The url matters: this org lives in Sentry's EU region.
+[defaults]
+url = https://de.sentry.io
+org = oaf-org-au
+project = right-to-know

--- a/Gemfile.theme
+++ b/Gemfile.theme
@@ -9,9 +9,16 @@
 
 source 'https://rubygems.org'
 
-# Error monitoring and APM (https://github.com/openaustralia/righttoknow/issues/1004).
+# Error monitoring, tracing and profiling
+# (https://github.com/openaustralia/righttoknow/issues/1004), following the
+# canonical configuration in the infrastructure repo's docs/monitoring.md.
 # Initialised in lib/sentry_config.rb; does nothing unless SENTRY_DSN is set
-# in the host's config/general.yml.
-gem 'sentry-rails'
-gem 'sentry-ruby'
-gem 'sentry-sidekiq'
+# in the host's config/general.yml. Pinned with ~> because this Gemfile is
+# merged at deploy time and constrained by no lockfile - without a pin every
+# deploy silently takes whatever was released that day. Keep the minor in
+# step with the other collections (see docs/monitoring.md).
+gem 'sentry-rails', '~> 6.7'
+gem 'sentry-ruby', '~> 6.7'
+gem 'sentry-sidekiq', '~> 6.7'
+# Profiler used by Sentry profiling (requires Ruby 3.2+)
+gem 'vernier', '~> 1.10'

--- a/Gemfile.theme
+++ b/Gemfile.theme
@@ -17,8 +17,8 @@ source 'https://rubygems.org'
 # merged at deploy time and constrained by no lockfile - without a pin every
 # deploy silently takes whatever was released that day. Keep the minor in
 # step with the other collections (see docs/monitoring.md).
-gem 'sentry-rails', '~> 6.7'
-gem 'sentry-ruby', '~> 6.7'
-gem 'sentry-sidekiq', '~> 6.7'
+gem 'sentry-rails', '~> 7.0'
+gem 'sentry-ruby', '~> 7.0'
+gem 'sentry-sidekiq', '~> 7.0'
 # Profiler used by Sentry profiling (requires Ruby 3.2+)
 gem 'vernier', '~> 1.10'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -61,6 +61,14 @@ set :maintenance_template_path,
 # Tagging options
 set :tagging3_format, ':stage_:release'
 
+# The repository Sentry release tracking associates commits from (see
+# lib/capistrano/tasks/sentry.rake). What actually runs in production is
+# Alaveteli - this theme is merged into it at deploy time - so suspect
+# commits should come from there, and it is also where :repo_url points via
+# each operator's config/deploy.yml. Set explicitly so release tracking
+# doesn't depend on that local file's remote spelling.
+set :sentry_release_repo, 'openaustralia/alaveteli'
+
 # Read the Ruby version from the server's shared rbenv-version file,
 # matching the version installed by the infrastructure repo.
 task :set_rbenv_ruby do

--- a/lib/capistrano/tasks/sentry.rake
+++ b/lib/capistrano/tasks/sentry.rake
@@ -102,16 +102,7 @@ namespace :sentry do
             execute :"sentry-cli", 'releases', 'set-commits', release, '--commit', "#{repo}@#{release}"
           end
         rescue StandardError => e
-          warn "Sentry: set-commits via the GitHub integration failed, trying local git history: #{e.message}"
-          begin
-            if cli == 'sentry'
-              execute :sentry, 'release', 'set-commits', versioned, '--local'
-            else
-              execute :"sentry-cli", 'releases', 'set-commits', release, '--local'
-            end
-          rescue StandardError => e
-            warn "Sentry: associating commits failed, continuing deploy: #{e.message}"
-          end
+          warn "Sentry: associating commits failed, continuing deploy: #{e.message}"
         end
 
         begin

--- a/lib/capistrano/tasks/sentry.rake
+++ b/lib/capistrano/tasks/sentry.rake
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+# Records a release and deploy in Sentry after each successful deploy so
+# issues can be tied to the deploy that introduced them.
+#
+# This is the canonical OAF release-tracking task, carried verbatim by each
+# collection's repo. The convention lives in the infrastructure repo's
+# docs/monitoring.md; change it there first, then update every copy.
+#
+# Runs locally on the deployer's machine (not the servers) because that's
+# where the Sentry CLI and the full git history live. Org/project defaults
+# come from the committed .sentryclirc; credentials come from each deployer's
+# `sentry auth` login (CLI v4) or ~/.sentryclirc (v3).
+namespace :sentry do
+  desc 'Record the release and deploy in Sentry'
+  task :release do
+    run_locally do
+      # CLI v4 renamed the binary from sentry-cli to sentry, so support both,
+      # preferring v4 (https://cli.sentry.dev/migrating-from-v3/). A candidate
+      # only counts if it exists AND is authenticated.
+      #
+      # The two CLIs report authentication differently. v4 has `auth status`;
+      # v3 has no such command and reports it through `info`. Don't reach for
+      # `sentry info` on v4: it exits non-zero whenever no default org/project
+      # is configured, even when the token is fine, which made every deploy
+      # skip the release (openaustralia/planningalerts#2183).
+      #
+      # SSHKit's local backend execs commands directly rather than through a
+      # shell, so a missing binary raises Errno::ENOENT instead of making
+      # `test` return false. Treat it the same as an unauthenticated CLI.
+      cli = %w[sentry sentry-cli].find do |candidate|
+        test(candidate == 'sentry' ? 'sentry auth status' : 'sentry-cli info')
+      rescue Errno::ENOENT
+        false
+      end
+
+      if cli.nil?
+        warn <<~WARNING
+          ********************************************************************
+          WARNING: the Sentry CLI (sentry or sentry-cli) is not installed or
+          not authenticated.
+
+          This deploy was NOT recorded as a release in Sentry, so issues
+          won't be linked to it. The deploy itself has still succeeded.
+
+          To fix this for future deploys, see "Monitoring" in the
+          infrastructure repo (docs/monitoring.md).
+          ********************************************************************
+        WARNING
+        next
+      end
+
+      # Matches the release auto-detected by the Ruby SDK from the REVISION
+      # file that Capistrano writes. The Sentry environment is always the
+      # stage name (docs/monitoring.md).
+      release = fetch(:current_revision)
+      environment = fetch(:stage).to_s
+
+      # v3 reads org and project from the committed .sentryclirc. v4 ignores
+      # that file, so read the values here and pass them on the command line,
+      # which keeps .sentryclirc the single source of truth for both.
+      sentryclirc = File.read(File.expand_path('../../../.sentryclirc', __dir__))
+      org = sentryclirc[/^\s*org\s*=\s*(\S+)/, 1]
+      project = sentryclirc[/^\s*project\s*=\s*(\S+)/, 1]
+
+      # The repository as Sentry's GitHub integration knows it, for
+      # associating the exact deployed commit. Set :sentry_release_repo in
+      # deploy.rb when the deployed code lives in a different repository to
+      # the one being deployed from (Right to Know deploys
+      # openaustralia/alaveteli).
+      repo = fetch(:sentry_release_repo,
+                   fetch(:repo_url).to_s[%r{github\.com[:/](.+?)(?:\.git)?\z}, 1])
+
+      # v4 addresses a release as an "org/version" positional and scopes it
+      # with --project; v3 reads both from .sentryclirc.
+      versioned = "#{org}/#{release}"
+
+      # Every step after the release exists is best-effort: the deploy itself
+      # has already succeeded, so warn and continue rather than failing it on
+      # a Sentry hiccup.
+      created = begin
+        if cli == 'sentry'
+          execute :sentry, 'release', 'create', '--project', project, versioned
+        else
+          execute :"sentry-cli", 'releases', 'new', release
+        end
+        true
+      rescue StandardError => e
+        warn "Sentry: creating release #{release} failed, continuing deploy: #{e.message}"
+        false
+      end
+
+      if created
+        begin
+          # Associate the exact deployed commit server-side via Sentry's
+          # GitHub integration - Sentry works out the commit range from the
+          # previous release. (--auto would use the local checkout's HEAD,
+          # which isn't necessarily the deployed revision.)
+          if cli == 'sentry'
+            execute :sentry, 'release', 'set-commits', versioned, '--commit', "#{repo}@#{release}"
+          else
+            execute :"sentry-cli", 'releases', 'set-commits', release, '--commit', "#{repo}@#{release}"
+          end
+        rescue StandardError => e
+          warn "Sentry: set-commits via the GitHub integration failed, trying local git history: #{e.message}"
+          begin
+            if cli == 'sentry'
+              execute :sentry, 'release', 'set-commits', versioned, '--local'
+            else
+              execute :"sentry-cli", 'releases', 'set-commits', release, '--local'
+            end
+          rescue StandardError => e
+            warn "Sentry: associating commits failed, continuing deploy: #{e.message}"
+          end
+        end
+
+        begin
+          if cli == 'sentry'
+            execute :sentry, 'release', 'finalize', versioned
+          else
+            execute :"sentry-cli", 'releases', 'finalize', release
+          end
+        rescue StandardError => e
+          warn "Sentry: finalizing release failed, continuing deploy: #{e.message}"
+        end
+
+        begin
+          if cli == 'sentry'
+            # v4: "deploys new" is gone; the environment is a positional.
+            execute :sentry, 'release', 'deploy', versioned, environment
+          else
+            execute :"sentry-cli", 'deploys', 'new', '--release', release, '-e', environment
+          end
+        rescue StandardError => e
+          warn "Sentry: recording deploy failed, continuing deploy: #{e.message}"
+        end
+      end
+    end
+  end
+end
+
+after 'deploy:finished', 'sentry:release'

--- a/lib/sentry_config.rb
+++ b/lib/sentry_config.rb
@@ -1,34 +1,90 @@
 # frozen_string_literal: true
 
-# Sentry error monitoring and APM for Right To Know
-# (https://github.com/openaustralia/righttoknow/issues/1004).
+# Sentry error monitoring, tracing and profiling for Right To Know
+# (https://github.com/openaustralia/righttoknow/issues/1004), following the
+# canonical OAF configuration in the infrastructure repo's docs/monitoring.md.
+# Change the convention there first, then update every copy.
 #
 # The sentry gems are only present in the server bundle, where Gemfile.theme
 # is merged into the host Alaveteli Gemfile at deploy time, so do nothing
 # when they aren't loaded (local development and CI).
 if defined?(Sentry)
+  # Matches most email addresses. Used to scrub personal information from
+  # breadcrumbs (e.g. log lines that mention a person's email address) in
+  # line with the Australian Privacy Principles.
+  email_pattern = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/
+
+  scrub_value = lambda do |value|
+    case value
+    when String then value.gsub(email_pattern, '[FILTERED]')
+    when Hash then value.transform_values { |v| scrub_value.call(v) }
+    when Array then value.map { |v| scrub_value.call(v) }
+    else value
+    end
+  end
+
+  scrub_breadcrumbs = lambda do |event, _hint|
+    event.breadcrumbs&.buffer&.each do |crumb|
+      crumb.message = scrub_value.call(crumb.message) if crumb.message
+      crumb.data = scrub_value.call(crumb.data) if crumb.data
+    end
+    event
+  end
+
   Sentry.init do |config|
-    # With no DSN configured the SDK stays disabled.
+    # With no DSN configured the SDK stays disabled - that is the off switch.
     config.dsn = AlaveteliConfiguration.get('SENTRY_DSN', nil)
 
-    # Both servers run RAILS_ENV=production, so STAGING_SITE is what
-    # distinguishes them. Read it with `get` and a default: it is not one of
-    # AlaveteliConfiguration's DEFAULTS keys, so the `staging_site` reader
-    # method does not exist and would raise NoMethodError here.
+    # The Sentry environment is always the stage name, delivered as
+    # SENTRY_ENVIRONMENT in general.yml by the infrastructure repo. Both
+    # servers run RAILS_ENV=production, so falling back to the old
+    # STAGING_SITE derivation keeps events labelled correctly if this deploys
+    # before the provisioning change that adds the key. Read settings with
+    # `get` and a default: they are not AlaveteliConfiguration DEFAULTS keys,
+    # so the generated reader methods do not exist and would raise
+    # NoMethodError here.
     config.environment =
-      if Rails.env.production?
+      if (env = AlaveteliConfiguration.get('SENTRY_ENVIRONMENT', '')) != ''
+        env
+      elsif Rails.env.production?
         AlaveteliConfiguration.get('STAGING_SITE', 0).to_i == 1 ? 'staging' : 'production'
       else
         Rails.env.to_s
       end
 
     config.breadcrumbs_logger = %i[active_support_logger http_logger]
+    # Include IP addresses, request headers and request parameters for
+    # debugging context. Emails are scrubbed from breadcrumbs above.
     config.send_default_pii = true
+    config.before_send = scrub_breadcrumbs
+    config.before_send_transaction = scrub_breadcrumbs
+    # Send Rails logs to Sentry as structured logs
     config.enable_logs = true
+    config.enabled_patches << :logger
 
     # Fraction of requests traced for APM. Tune in general.yml without a
     # code change if quota becomes a problem.
     config.traces_sample_rate =
       AlaveteliConfiguration.get('SENTRY_TRACES_SAMPLE_RATE', 0.1).to_f
+    # Relative to traces_sample_rate - profile 1 in 10 sampled transactions,
+    # using vernier
+    config.profiles_sample_rate = 0.1
+    config.profiler_class = Sentry::Vernier::Profiler
+  end
+
+  # Attach the signed-in user to Sentry events so errors show who was
+  # affected. The id only, never email or name - look the id up in the admin
+  # backend if you need to contact someone about an error (Australian Privacy
+  # Principles, and the canonical configuration in docs/monitoring.md).
+  # Sentry's Rack middleware resets the scope every request, so this can't
+  # leak between requests.
+  Rails.configuration.to_prepare do
+    ApplicationController.class_eval do
+      before_action :set_sentry_user
+
+      def set_sentry_user
+        Sentry.set_user(id: current_user.id) if current_user
+      end
+    end
   end
 end

--- a/lib/sentry_config.rb
+++ b/lib/sentry_config.rb
@@ -58,8 +58,9 @@ if defined?(Sentry)
     config.send_default_pii = true
     config.before_send = scrub_breadcrumbs
     config.before_send_transaction = scrub_breadcrumbs
-    # Send Rails logs to Sentry as structured logs
-    config.enable_logs = true
+    # Rails logs arrive via sentry-rails' structured logging, on by default
+    # since 7.0; the logger patch additionally forwards non-Rails stdlib
+    # logging (e.g. Sidekiq's)
     config.enabled_patches << :logger
 
     # Fraction of requests traced for APM. Tune in general.yml without a

--- a/lib/sentry_config.rb
+++ b/lib/sentry_config.rb
@@ -17,7 +17,8 @@ if defined?(Sentry)
   scrub_value = lambda do |value|
     case value
     when String then value.gsub(email_pattern, '[FILTERED]')
-    when Hash then value.transform_values { |v| scrub_value.call(v) }
+    when Hash
+      value.to_h { |key, item| [scrub_value.call(key), scrub_value.call(item)] }
     when Array then value.map { |v| scrub_value.call(v) }
     else value
     end

--- a/lib/views/general/_before_head_end.html.erb
+++ b/lib/views/general/_before_head_end.html.erb
@@ -7,16 +7,71 @@
 <script defer data-domain="righttoknow.org.au" src="https://plausible.io/js/script.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
 <% end %>
-<%# Sentry browser error monitoring (issue #1004). The loader URL is set in
-    general.yml on the servers, so this renders nothing in development. %>
-<% sentry_js_loader_url = AlaveteliConfiguration.get('SENTRY_JS_LOADER_URL', '') %>
-<% unless sentry_js_loader_url.empty? %>
+<%# The canonical OAF Sentry browser partial (issue #1004; see the
+    infrastructure repo's docs/monitoring.md - change it there first, then
+    update every copy). Renders only when the server SDK is present and has a
+    DSN - the same off switch as the backend, so browser events land in the
+    same right-to-know project - and never for crawlers, whose errors we
+    can't act on and which vastly outnumber real people. Deliberately narrow:
+    facebookexternalhit is the crawler, while the Facebook in-app browser is
+    a real person whose errors are worth seeing. %>
+<% crawler = /bot\b|crawler|spider|facebookexternalhit|slurp|archiver|inspectiontool/i.match?(request.user_agent.to_s) %>
+<% if (dsn = defined?(Sentry) && Sentry.initialized? && Sentry.configuration&.dsn) && !crawler %>
+<%# Meta tags the browser SDK reads on pageload to continue the backend trace,
+    stitching the browser transaction to the Rails transaction that rendered
+    it. SDK-generated markup with no user input, so raw output is safe. %>
+<%== Sentry.get_trace_propagation_meta %>
+<%# sentryOnLoad must be defined before the loader script so the lazy-loaded
+    SDK picks up our configuration when it initialises %>
 <script>
   window.sentryOnLoad = function () {
     Sentry.init({
-      environment: <%= (defined?(Sentry) && Sentry.initialized? ? Sentry.configuration.environment : Rails.env).to_json.html_safe %>
+      <% if Sentry.configuration.release %>
+        release: "<%= j(Sentry.configuration.release) %>",
+      <% end %>
+      environment: "<%= j(Sentry.configuration.environment) %>",
+      // Sample 10% of pageloads/navigations for browser tracing
+      tracesSampleRate: 0.1,
+      // Only record session replays when an error occurs, with default
+      // privacy masking (maskAllText/blockAllMedia) left enabled
+      replaysSessionSampleRate: 0,
+      replaysOnErrorSampleRate: 1.0,
+      // Send user IP with events, matching the backend's send_default_pii
+      sendDefaultPii: true,
+      // Errors thrown by browser extensions, in-app webview bridges and email
+      // link scanners rather than by our own code. We cannot fix any of these
+      // and they drown out real problems. Anything our own JavaScript causes
+      // belongs in a fix, not in this list.
+      ignoreErrors: [
+        // Microsoft Outlook and Office scanning links in our alert emails
+        "Object Not Found Matching Id",
+        // Android webview tearing down its JavaScript bridge mid-page
+        "Error invoking postMessage: Java object is gone",
+        // Cryptocurrency wallet extensions
+        "Failed to connect to MetaMask",
+        // Accessibility and screen reader extensions reading their own state
+        "isHighContrast",
+        // iOS in-app browsers and extensions expecting their native bridge
+        "window.webkit.messageHandlers",
+        // In-app browsers' autofill bridge (e.g. Facebook/Instagram on iOS)
+        "_AutofillCallbackHandler"
+      ],
+      denyUrls: [
+        /^chrome-extension:\/\//i,
+        /^moz-extension:\/\//i,
+        /^safari-(web-)?extension:\/\//i
+      ]
     });
+    <% if current_user %>
+      <%# Tie browser events to the same user as server events - id only, no
+          email or name, matching the backend's set_sentry_user %>
+      Sentry.setUser({ id: "<%= j(current_user.id.to_s) %>" });
+    <% end %>
   };
 </script>
-<script src="<%= sentry_js_loader_url %>" crossorigin="anonymous"></script>
+<%# The loader script key is the public key from the DSN. The host is
+    region-specific and our org is in Sentry's EU region: the US host
+    (js.sentry-cdn.com) answers 200 with a no-op stub, which would leave
+    every browser signal silently inert. %>
+<script src="https://js-de.sentry-cdn.com/<%= dsn.public_key %>.min.js" crossorigin="anonymous"></script>
 <% end %>


### PR DESCRIPTION
## What and why

Converges Right to Know on the canonical OAF Sentry configuration (openaustralia/infrastructure#744, documented in that repo's docs/monitoring.md). The biggest gaps this closes: releases were tagged on events but never created, finalised or associated with commits and deploys in Sentry (so no suspect commits); the sentry gems floated unpinned with no lockfile; no breadcrumb email scrubbing or user id context; browser errors went to a separate right-to-know-js project via an out-of-band loader URL. Browser events now land in the one right-to-know project with the loader derived from the DSN. Closes #1102.

Sequencing: the environment key and the removal of SENTRY_JS_LOADER_URL from general.yml come from openaustralia/infrastructure#749. This PR is safe to deploy before or after it - the environment falls back to the old STAGING_SITE derivation, and the loader URL setting is no longer read - but browser monitoring is only fully consistent once both are live. Deploy staging first and confirm a browser test error arrives in right-to-know with platform:javascript before production. The right-to-know-js project is deleted 30 days after that (tracked in openaustralia/infrastructure#744).

## Type of change

- [x] New feature

## How this was checked

`rubocop` clean across the repo (the only CI check). The Capistrano task is the same canonical file just landed in Planning Alerts and They Vote For You (openaustralia/planningalerts#2214, openaustralia/theyvoteforyou#1726), where the suites pass; its v4 CLI syntax was verified against `sentry release --help`. The rewritten browser partial's compiled ERB was verified to parse. The theme spec suite needs the full Alaveteli devcontainer stack and doesn't touch these files, so the real verification is the staging deploy:

- [ ] Staging deploy: test exception arrives with environment staging, user id only, no email in breadcrumbs; browser test error arrives in right-to-know with platform:javascript; release shows commits from openaustralia/alaveteli and a deploy

Assisted-by: OpenCode:amazon-bedrock/anthropic.claude-fable-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved error monitoring across server-side and browser experiences, including performance tracing, profiling, session replay and deployment release tracking.
  * Monitoring now records the signed-in user’s identifier to help correlate reported issues.
  * Browser monitoring includes release and environment details, enhanced trace propagation and EU-region data routing.

* **Bug Fixes**
  * Sensitive email addresses are removed from monitoring breadcrumbs and event data.
  * Monitoring scripts are excluded for recognised crawlers and filtered browser-extension errors are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->