### PR TITLE
Use www-staging hostname consistently in whatismyip README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,8 +372,8 @@ It should report the same value as https://whatismyip.akamai.com/
 Off by default; set `PROVIDE_WHATISMYIP: true` in `general.yml` to turn it on.
 
 ```bash
-curl https://staging.righttoknow.org.au/whatismyip
 curl https://www.righttoknow.org.au/whatismyip
+curl https://www-staging.righttoknow.org.au/whatismyip
 ```
 
 ## Authorities


### PR DESCRIPTION
## What and why

The `whatismyip` verification snippet in the README used two different staging hostnames from the version-check snippet earlier in the file (`staging.righttoknow.org.au` vs `www-staging.righttoknow.org.au`), reading as two separate environments. They're the same server - `www-staging` is a CNAME for `staging` (`terraform/righttoknow/dns.tf`). Both snippets now use `www-staging`, and the curl lines are ordered production-then-staging to match the rest of the file.

- Related: https://github.com/openaustralia/infrastructure/issues/733

## Type of change

- [x] Documentation

## How this was checked

- [x] Documentation updated, or not needed
- [x] GitHub Actions passed (as expected)

Doc-only one-line fix, no functional change to check.
