### PR TITLE
Use short timeout with whatismyip Cloudflare fetch

### DIFF
--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -87,15 +87,15 @@ Rails.configuration.to_prepare do
       raise RangesUnavailable
     end
 
-    # Fetch from uri with short open and read timeout.
-    # Throws Net::OpenTimeout or Net::ReadTimeout, both descend from Timeout::Error
-    # which fetch_ranges already rescues, so a slow Cloudflare reports
-    # ' UNABLE TO CHECK' on the same path as any other failed fetch.
+    # Fetch from uri with short open, read and write timeouts.
+    # Throws Net::OpenTimeout, Net::ReadTimeout or Net::WriteTimeout, all of
+    # which descend from Timeout::Error
     def fetch(uri)
       Net::HTTP.start(uri.host, uri.port,
                       use_ssl: uri.scheme == 'https',
                       open_timeout: FETCH_TIMEOUT,
-                      read_timeout: FETCH_TIMEOUT) do |http|
+                      read_timeout: FETCH_TIMEOUT,
+                      write_timeout: FETCH_TIMEOUT) do |http|
         http.request(Net::HTTP::Get.new(uri))
       end
     end

--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -32,6 +32,12 @@ Rails.configuration.to_prepare do
     # Cloudflare erroring or truncating rather than a genuine empty list.
     MIN_EXPECTED_RANGES = 4
 
+    # A short fetch timeout so a Cloudflare outage can not lock the Rails worker
+    # as long as the default minute.
+    # Failures are deliberately not cached, so this reduces the possible impact.
+    # Issue: openaustralia/infrastructure#733
+    FETCH_TIMEOUT = 5
+
     class RangesUnavailable < StandardError; end
 
     def index
@@ -51,6 +57,7 @@ Rails.configuration.to_prepare do
       ' UNABLE TO CHECK'
     end
 
+    # Return IPv4 and IPv6 cloudflare ranges as one array
     # Cached a day so this doesn't depend on cloudflare.com being reachable on
     # every check. Validated and parsed to IPAddr before caching, not after -
     # a failed/truncated fetch must raise inside the block so Rails.cache
@@ -63,10 +70,12 @@ Rails.configuration.to_prepare do
       end
     end
 
-    # Each list checked independently - a truncated v6 list shouldn't pass
-    # just because v4 came back full-sized.
+    # Fetch one range of ip addresses (IPv4 or IPv6)
+    # Checked independently so one truncated list shouldn't pass
+    # just because the other came back full-sized.
+    # raises RangeUnavailable for network or content errors
     def fetch_ranges(url)
-      response = Net::HTTP.get_response(URI(url))
+      response = fetch(URI(url))
       raise RangesUnavailable unless response.is_a?(Net::HTTPSuccess)
 
       ranges = response.body.lines.map(&:strip).reject(&:empty?)
@@ -76,6 +85,19 @@ Rails.configuration.to_prepare do
     rescue Timeout::Error, SocketError, SystemCallError, OpenSSL::SSL::SSLError, EOFError, Net::ProtocolError,
            Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError
       raise RangesUnavailable
+    end
+
+    # Fetch from uri with short open and read timeout.
+    # Throws Net::OpenTimeout or Net::ReadTimeout, both descend from Timeout::Error
+    # which fetch_ranges already rescues, so a slow Cloudflare reports
+    # ' UNABLE TO CHECK' on the same path as any other failed fetch.
+    def fetch(uri)
+      Net::HTTP.start(uri.host, uri.port,
+                      use_ssl: uri.scheme == 'https',
+                      open_timeout: FETCH_TIMEOUT,
+                      read_timeout: FETCH_TIMEOUT) do |http|
+        http.request(Net::HTTP::Get.new(uri))
+      end
     end
   end
 end

--- a/spec/whatismyip_spec.rb
+++ b/spec/whatismyip_spec.rb
@@ -2,12 +2,15 @@
 
 # Exercises lib/whatismyip_controller.rb, routed in lib/config/custom-routes.rb.
 #
-# Net::HTTP is stubbed rather than exercised for real so the spec doesn't
-# depend on cloudflare.com being reachable. Rails.cache is real (:null_store
-# in test, per config/environments/test.rb) so the fetch/validate block in
-# cloudflare_ranges actually runs on every request - important since the bug
-# this spec guards against (a bad fetch getting cached and poisoning every
-# check for 24 hours) is specifically about what happens inside that block.
+# Cloudflare's range lists are stubbed with WebMock rather than fetched for
+# real, so the spec doesn't depend on cloudflare.com being reachable. The
+# stubbing is at the HTTP layer, so the controller's own Net::HTTP call (and
+# its open/read timeouts) runs as written. Rails.cache is real (:null_store in
+# test, per config/environments/test.rb) so the fetch/validate block in
+# cloudflare_ranges actually runs on every request - important since one of
+# the bugs this spec guards against (a bad fetch getting cached and poisoning
+# every check for 24 hours) is specifically about what happens inside that
+# block.
 #
 # If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
 ALAVETELI_TEST_THEME = 'righttoknow'
@@ -16,47 +19,44 @@ require File.expand_path(
 )
 
 RSpec.describe WhatismyipController, type: :controller do
-  def stub_cloudflare(ipv4:, ipv6:)
-    responses = {
-      'https://www.cloudflare.com/ips-v4' => ipv4,
-      'https://www.cloudflare.com/ips-v6' => ipv6
-    }
-    allow(Net::HTTP).to receive(:get_response) do |uri|
-      responses.fetch(uri.to_s)
-    end
+  def ipv4_url = 'https://www.cloudflare.com/ips-v4'
+  def ipv6_url = 'https://www.cloudflare.com/ips-v6'
+
+  def full_ipv4 = %w[173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22]
+  def full_ipv6 = %w[2400:cb00::/32 2606:4700::/32 2803:f800::/32 2405:b500::/32]
+
+  def stub_ranges(url, cidrs)
+    stub_request(:get, url).to_return(status: 200, body: cidrs.join("\n"))
   end
 
-  def success(*cidrs)
-    double('response', is_a?: true, body: cidrs.join("\n"))
+  def stub_healthy_cloudflare
+    stub_ranges(ipv4_url, full_ipv4)
+    stub_ranges(ipv6_url, full_ipv6)
   end
 
-  def failure
-    double('response', is_a?: false)
+  # A default stub is needed alongside the PROVIDE_WHATISMYIP one: rendering
+  # goes through ApplicationController#set_gettext_locale, which reads other
+  # settings, and a bare `with` stub would make those raise.
+  def stub_whatismyip_setting(enabled)
+    allow(AlaveteliConfiguration).to receive(:get).and_call_original
+    allow(AlaveteliConfiguration).to receive(:get)
+      .with('PROVIDE_WHATISMYIP', false).and_return(enabled)
   end
 
   describe 'GET #index' do
     context 'when PROVIDE_WHATISMYIP is off' do
       it 'is not found' do
-        allow(AlaveteliConfiguration).to receive(:get)
-          .with('PROVIDE_WHATISMYIP', false).and_return(false)
+        stub_whatismyip_setting(false)
         get :index
         expect(response).to have_http_status(:not_found)
       end
     end
 
     context 'when PROVIDE_WHATISMYIP is on' do
-      before do
-        allow(AlaveteliConfiguration).to receive(:get)
-          .with('PROVIDE_WHATISMYIP', false).and_return(true)
-      end
+      before { stub_whatismyip_setting(true) }
 
       context 'with a healthy Cloudflare response' do
-        before do
-          stub_cloudflare(
-            ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
-            ipv6: success('2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32')
-          )
-        end
+        before { stub_healthy_cloudflare }
 
         it 'returns the IP alone when outside Cloudflare\'s ranges' do
           request.remote_addr = '1.2.3.4'
@@ -73,7 +73,8 @@ RSpec.describe WhatismyipController, type: :controller do
 
       context 'when Cloudflare returns an error status' do
         before do
-          stub_cloudflare(ipv4: failure, ipv6: success('2400:cb00::/32'))
+          stub_request(:get, ipv4_url).to_return(status: 500)
+          stub_ranges(ipv6_url, full_ipv6)
           request.remote_addr = '1.2.3.4'
         end
 
@@ -85,10 +86,7 @@ RSpec.describe WhatismyipController, type: :controller do
         it 'recovers once Cloudflare responds normally again' do
           get :index
 
-          stub_cloudflare(
-            ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
-            ipv6: success('2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32')
-          )
+          stub_healthy_cloudflare
           get :index
 
           expect(response.body).to eq('1.2.3.4')
@@ -99,14 +97,25 @@ RSpec.describe WhatismyipController, type: :controller do
         before do
           # A full-sized v4 list must not offset a truncated v6 one - each is
           # checked independently.
-          stub_cloudflare(
-            ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
-            ipv6: success('2400:cb00::/32')
-          )
+          stub_ranges(ipv4_url, full_ipv4)
+          stub_ranges(ipv6_url, %w[2400:cb00::/32])
           request.remote_addr = '1.2.3.4'
         end
 
         it 'reports UNABLE TO CHECK rather than trusting the truncated list' do
+          get :index
+          expect(response.body).to eq('1.2.3.4 UNABLE TO CHECK')
+        end
+      end
+
+      context 'when Cloudflare does not respond in time' do
+        before do
+          stub_request(:get, ipv4_url).to_timeout
+          stub_ranges(ipv6_url, full_ipv6)
+          request.remote_addr = '1.2.3.4'
+        end
+
+        it 'reports UNABLE TO CHECK rather than hanging' do
           get :index
           expect(response.body).to eq('1.2.3.4 UNABLE TO CHECK')
         end


### PR DESCRIPTION
## What and why

Imported the defensive measures from Ben's PR (which I rejected for other reasons)
* #1086

`/whatismyip`'s Cloudflare IP-range fetch used `Net::HTTP.get_response`, which
carries ~1 minute default timeouts for both connect and read. Since failures
here are deliberately not cached, a Cloudflare outage could tie up a Rails
worker for that long on every repeat request while `PROVIDE_WHATISMYIP` is on.
Now fetched via `Net::HTTP.start` with an explicit 5s open/read timeout, which
degrades to the existing `UNABLE TO CHECK` path on a timeout.

Also fixes a pre-existing spec failure (7 of 8 examples) against core
0.46.7.0: a bare `AlaveteliConfiguration.get` stub made `set_gettext_locale`
raise, since rendering reads other settings besides `PROVIDE_WHATISMYIP`.

This is the timeout half of #1086 (closed in review). #1086 also swapped
`request.remote_ip` for `request.remote_addr`; that swap is not included here,
since it's `remote_ip` that's actually used by the real proxy chain (Varnish
sits between nginx and Rails and deliberately leaves `X-Forwarded-For`
untouched, so `remote_addr` at the Rails layer would always be Varnish's own
loopback address, never a Cloudflare edge IP).

Note: this this is unlikely to be an issue in practice as its a manual test endpoint, but it more satisfying to be thorough and cherry pick it than explain why not for not much less work!

- Refs openaustralia/infrastructure#733

## Type of change

- [x] New feature

## How this was checked

- [x] Checked the affected area on my own or a staging system
- [x] Ran the automated tests
- [x] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below
- [x] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [x] Documentation not needed

Manual run test - last lines of output:

```
Finished in 5.5 seconds (files took 4.93 seconds to load)
95 examples, 0 failures

$ bundle exec rubocop
42 files inspected, no offenses detected
```

Assisted-by: Claude Code:claude-sonnet-5