### PR TITLE
Mask Australian mobile numbers automatically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,17 @@ only). Run via `rails runner` from the **host app**, not this repo — see
   state-name formatting conventions, request-email preference order, public
   notes, and short names is all in `README.md` under "Authorities" — read it
   before making bulk authority-data changes.
+- **Text masks vs censor rules**: Alaveteli has two redaction mechanisms and
+  the issue tracker tends to call both "censoring". A *text mask* is
+  automatic, applied at render/mask time, replaces matches with a readable
+  label like `[mobile number]`, and reaches text content only (message
+  bodies, text/HTML attachments) - this theme registers one for Australian
+  mobile numbers in `lib/text_mask_patches.rb`. A *censor rule* is an
+  admin-created database record scoped to a request/user/authority (or
+  global), and is the only mechanism that reaches PDFs and other binaries,
+  where it overwrites matched characters with `x`. Global censor rules
+  re-mask the entire corpus on creation and are off-limits here - see the
+  2026-09-07 entry in `docs/DECISIONS.md`.
 - **Pro coupons**: Stripe coupons restrict by product, not by individual price,
   so a monthly-only coupon can't be stopped from discounting the annual plan
   using Stripe's own `applies_to`. This theme layers its own restriction via

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,6 +5,34 @@ wouldn't surface them. A decision local to one file/view/patch belongs as a comm
 
 Append new entries at the top and date them. Don't edit past entries except to mark them superseded (and say by what).
 
+## 2026-09-07: Australian mobile numbers are masked as text, never via a global censor rule
+
+Issue #706 asked for automatic censoring of mobile numbers. Alaveteli has two mechanisms and they are not
+interchangeable (see "Text masks vs censor rules" in `AGENTS.md` for the vocabulary): we chose a **text mask**,
+registered by `lib/text_mask_patches.rb` through `AlaveteliTextMasker.add_mask`. Three decisions to preserve:
+
+- **No global censor rule, ever, for this.** A global `CensorRule` is the only mechanism that reaches PDFs and
+  other binary attachments, which makes it tempting, but creating one expires and re-masks every request on the
+  site. When we tried this years ago it flooded the server with logs and left PDFs inaccessible, and
+  WhatDoTheyKnow's theme goes as far as raising `NotImplementedError` when an admin tries to create one. If PDF
+  coverage is ever wanted, the path is upstream: make core's `apply_binary_masks` (which already x's out email
+  addresses in binaries, size-preservingly) customisable the way text masks now are.
+- **Text content only, on purpose.** The mask covers message bodies and text/HTML attachments. PDFs and binaries
+  keep core's email-only redaction; masks never reach the binary path even on upstream develop. The spec guards
+  this boundary so crossing it is a conscious decision.
+- **Tight pattern, tolerate misses.** The match/no-match table in `spec/au_mobile_number_mask_spec.rb` is the
+  source of truth; the regex is whatever passes it. A missed number is recoverable with a per-request censor rule;
+  an over-match silently corrupts the published record and, unlike a censor rule, leaves no admin trail. Known
+  accepted edge: the bare international form (`61 4xx xxx xxx` without a `+`) can collide with an ABN that begins
+  with 61 4.
+
+Mechanics worth knowing: `add_mask` is an upstream API (mysociety/alaveteli@34a3d7be2, April 2026) that is not in
+a tagged release yet, so our Alaveteli fork carries it as three cherry-picks; `text_mask_patches.rb` guards with
+`respond_to?(:add_mask)` so the theme still boots against an older host, and the guard can go once a release
+containing the API is merged into the fork. Message bodies pick the mask up at render time, but attachments are
+masked once by `FoiAttachmentMaskJob` and stored, so pre-existing text attachments keep their old masking unless
+deliberately re-masked - we chose not to bulk re-mask at deploy time.
+
 ## 2026-08-24: the personal information gate fails open, and Sentry RIGHT-TO-KNOW-JS-5 is our canary
 
 The new request form asks whether you're requesting personal information that should be confidential, and hides the

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -31,7 +31,8 @@ end
 ['controller_patches.rb',
  'model_patches.rb',
  'helper_patches.rb',
- 'patch_mailer_paths.rb'].each do |patch|
+ 'patch_mailer_paths.rb',
+ 'text_mask_patches.rb'].each do |patch|
   require File.expand_path "../#{patch}", __FILE__
 end
 

--- a/lib/text_mask_patches.rb
+++ b/lib/text_mask_patches.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Automatically mask Australian mobile phone numbers in published
+# correspondence (issue #706).
+#
+# Registers a text mask via AlaveteliTextMasker.add_mask, the API upstream
+# added in mysociety/alaveteli@34a3d7be2 (cherry-picked into our Alaveteli
+# fork until it arrives in a tagged release). Text masks apply to text-type
+# content only (message bodies, text and HTML attachments); PDFs and other
+# binaries keep core's built-in email-only redaction. See "Australian mobile
+# numbers are masked as text, not censored" in docs/DECISIONS.md for why.
+#
+# The pattern is deliberately tight (see the match/no-match table in
+# spec/au_mobile_number_mask_spec.rb, which is the source of truth): a missed
+# number can still be handled with a per-request censor rule, but an
+# over-match silently corrupts the published record.
+#
+# Registered in after_initialize, not to_prepare: add_mask raises on
+# duplicate names and to_prepare re-runs on every reload in development.
+Rails.application.config.after_initialize do
+  # The respond_to? guard lets this theme boot against a host Alaveteli that
+  # predates the add_mask API (our fork gains it via cherry-pick; a tagged
+  # release will follow). Remove the guard once the API is in a release the
+  # fork has merged.
+  if AlaveteliTextMasker.respond_to?(:add_mask)
+    au_mobile_number = /
+      (?<![\w-])                          # not inside a longer number, word or reference code
+      (?:
+        \+?61[ .-]?(?:\(0\)[ .-]?)?4      # international: +61 4..., 61 4..., +61 (0) 4...
+        |
+        04                                # domestic: 04...
+      )
+      \d{2}[ .-]?\d{3}[ .-]?\d{3}         # the remaining eight digits, standard groupings
+      (?![\w-])                           # not running into more digits or letters
+    /x
+
+    AlaveteliTextMasker.add_mask(
+      :au_mobile_number,
+      pattern: au_mobile_number,
+      replacement: "[#{_('mobile number')}]"
+    )
+  else
+    Rails.logger.warn(
+      'righttoknow theme: AlaveteliTextMasker.add_mask is unavailable in ' \
+      'this Alaveteli version; Australian mobile numbers will not be masked'
+    )
+  end
+end

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -121,8 +121,8 @@ circumstances, see our <a href="/help/privacy#takedown">take down policy</a>.
 
 <dt id="mobiles">Do you publish email addresses or mobile phone numbers? <a href="#mobiles">#</a> </dt>
 
-<dd><p>To prevent spam, we automatically remove most emails and some mobile numbers from
-responses to requests.  Please <a href="/help/contact">contact us</a> if we've
+<dd><p>To prevent spam, we automatically remove most email addresses and Australian
+mobile phone numbers from responses to requests.  Please <a href="/help/contact">contact us</a> if we've
 missed one.
 For technical reasons we don't always remove them from attachments, such as certain PDFs.</p>
 <p>If you need to know what an address was that we've removed, please <a

--- a/spec/au_mobile_number_mask_spec.rb
+++ b/spec/au_mobile_number_mask_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Exercises the Australian mobile number text mask registered by
+# lib/text_mask_patches.rb (issue #706).
+#
+# This table of masked / not-masked examples is the source of truth for the
+# pattern: the regex is whatever passes it. The pattern is deliberately tight
+# (see docs/DECISIONS.md): a missed number can still be redacted with a
+# per-request censor rule, but an over-match silently corrupts the published
+# record, so the not-masked half of the table matters as much as the masked
+# half.
+#
+# Mobile numbers here are ones ACMA reserves for fictional use (0491 570 1xx),
+# and the landline is from the fictional (02) 5550 xxxx range, so no real
+# person's number ever appears in this repo. The ABN is the Australian
+# Taxation Office's own, a public agency identifier, not personal data.
+
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper'))
+
+describe 'Australian mobile number text mask' do
+  def apply(text, content_type = 'text/plain')
+    AlaveteliTextMasker.apply_masks(text.dup, content_type)
+  end
+
+  it 'is registered with the host masker' do
+    expect(AlaveteliTextMasker.masks).to have_key(:au_mobile_number)
+  end
+
+  describe 'mobile number formats that are masked' do
+    ['0491 570 156',
+     '0491570156',
+     '0491-570-156',
+     '0491.570.156',
+     '+61 491 570 156',
+     '+61491570156',
+     '61 491 570 156',
+     '+61 (0) 491 570 156'].each do |number|
+      it "masks #{number}" do
+        expect(apply("Call me on #{number} after lunch."))
+          .to eq('Call me on [mobile number] after lunch.')
+      end
+    end
+  end
+
+  describe 'digit strings that are not masked' do
+    {
+      'an eight digit local number' => 'Ring 5550 1234 for details.',
+      'a landline with an area code' => 'Ring (02) 5550 1234 for details.',
+      'an ABN' => 'Our ABN is 51 824 753 556.',
+      'an ACN containing 04 after another digit' => 'ACN 004 000 000 applies.',
+      'a hyphenated file reference' => 'See FOI-2026-0491570156 for details.',
+      'a date' => 'Received on 04/12/2026 at noon.',
+      'a dollar amount' => 'The contract cost $1,041,234,567.80 in total.',
+      'a ten digit number not starting with 04' => 'Quote 0391 570 156 when replying.',
+      'an eleven digit run starting with 0491' => 'Barcode 04915701567 was scanned.',
+      'digits embedded in an alphanumeric reference' => 'See REF0491570156A for details.'
+    }.each do |label, text|
+      it "leaves #{label} alone" do
+        expect(apply(text)).to eq(text)
+      end
+    end
+  end
+
+  # Text masks never reach the binary path (core's apply_binary_masks only
+  # x's out email addresses and applies censor rules), so PDFs and other
+  # binary attachments are deliberately unaffected by this mask. Guard that
+  # boundary so a future change to it is a conscious one.
+  it 'does not alter binary content' do
+    binary = 'Call 0491 570 156 now'
+    expect(apply(binary, 'application/octet-stream')).to eq(binary)
+  end
+end


### PR DESCRIPTION
## What and why

Automatically masks Australian mobile numbers as `[mobile number]` in published correspondence, the mobile-number half of the issue below.
Registers a text mask through the `AlaveteliTextMasker.add_mask` API (cherry-picked into our fork by the PR below), guarded with `respond_to?` so the theme still boots on a host that predates the API.
The pattern is deliberately tight, preferring missed numbers over corrupting the published record; the match/no-match table in `spec/au_mobile_number_mask_spec.rb` is the source of truth, and the new `docs/DECISIONS.md` entry records why a global censor rule is off the table and why PDFs/binaries are intentionally out of scope.

- Resolves #706 (mobile numbers; credit card numbers split out to #1110)
- Depends on openaustralia/alaveteli#61 (without it the mask is skipped with a logged warning, nothing breaks)
- Spec data uses ACMA-reserved fictional numbers (0491 570 1xx mobiles, (02) 5550 xxxx landline) so no real number appears in the repo

Deferred / not done, by design (see `docs/DECISIONS.md`):

- PDF and binary attachment coverage: #1109 (upstream feature request)
- Credit card numbers: #1110
- No bulk re-mask of historical attachments at deploy; message bodies pick the mask up at render time

## Type of change

- [x] New feature
- [x] Documentation

## How this was checked

Ran the new spec through the host app in the Docker dev environment (`bundle exec rspec lib/themes/righttoknow/spec/au_mobile_number_mask_spec.rb`): 20 examples, 0 failures; full theme suite 115 examples, 0 failures.
RuboCop clean on the touched files.

- [x] Ran the automated tests
- [x] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues above, or noted why they are not important above
- [x] Documentation updated, or not needed

CodeRabbit's one finding (digits embedded in alphanumeric references like `REF0491570156A` would have been masked) was fixed by widening the boundary guards to `[\w-]`, with the case added to the spec table; the re-run was clean.

Assisted-by: OpenCode:anthropic.claude-fable-5
