### PR TITLE
Release staging to production: sentry pin, deploy profile and dev setup fixes

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -5,8 +5,9 @@
 # Idempotent: safe to re-run at any time. On first run it clones the
 # openaustralia/alaveteli fork into /alaveteli (a Docker volume), wires this
 # theme in with Alaveteli's switch-theme script, then migrates and seeds the
-# databases and builds the search index. Subsequent runs only update gems and
-# re-link the theme.
+# databases and builds the search index. Subsequent runs update gems, re-link
+# the theme and run any pending migrations, but leave the sample data alone
+# unless --reset-data is passed.
 #
 # Runs as the Dev Container onCreateCommand, and via `make setup` for the
 # plain Docker workflow. Mirrors the steps in alaveteli's docker/bootstrap and
@@ -61,8 +62,8 @@ ln -sfn "$THEME_DIR" lib/themes/righttoknow
 bin/rails assets:clean >/dev/null
 success_msg 'done'
 
-# If the database has never been seeded, load schema and data (matching
-# alaveteli's docker/setup). Pass --reset-data to force a reload.
+# Sample data is loaded once, on a database that has never been seeded. Pass
+# --reset-data to force a reload.
 set +e
 bin/rails runner 'User.find(1)' >/dev/null 2>&1
 RESET_DATA_FLAG=$?
@@ -74,16 +75,20 @@ for arg in "$@"; do
   esac
 done
 
-if [ $RESET_DATA_FLAG -eq 0 ]; then
-  success_msg 'Database already set up; skipping migrations and sample data'
-  success_msg 'Setup finished'
-  exit 0
-fi
-
+# Migrations run every time, not just on first setup: /alaveteli is a
+# persistent volume, so a re-run after the checkout moves to a revision with
+# new migrations is exactly when the schemas would otherwise go stale. Both
+# db:migrate and db:seed are idempotent.
 notice_msg 'Migrating development and test databases...'
 bin/rails db:migrate db:seed >/dev/null
 bin/rails db:migrate RAILS_ENV=test >/dev/null
 success_msg 'done'
+
+if [ $RESET_DATA_FLAG -eq 0 ]; then
+  success_msg 'Sample data already loaded; skipping'
+  success_msg 'Setup finished'
+  exit 0
+fi
 
 notice_msg 'Loading sample data...'
 bundle exec script/load-sample-data >/dev/null

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,20 @@ only). Run via `rails runner` from the **host app**, not this repo — see
   a coupon `interval` metadata key, enforced identically in the checkout path
   and the live price-preview endpoint (both in `controller_patches.rb`). See
   "Pro subscriptions" in `README.md`.
+- **Account lifecycle**: an **unused account** is the host's `User.unused`
+  scope (no content, no admin/pro role, no retained `user_sign_ins` row); it
+  says nothing about whether the address was confirmed or the account banned. A
+  **dormant account** is an unused account created more than two years ago that
+  has not signed in within two years — exactly the cohort the host's
+  `users:destroy_unused` cron would destroy, mirrored here by
+  `DormantAccounts.scope` so the deletion pass and the notice can't disagree
+  about who is at risk. A **never-confirmed account** has
+  `email_confirmed = false` and can never be emailed, because
+  `User#should_be_emailed?` requires confirmation. A **bounce** is the host's
+  `email_bounced_at`, which only `script/handle-mail-replies` ever sets. Use
+  those four terms rather than drifting to "inactive", "stale" or "abandoned".
+  See `docs/DECISIONS.md` (2026-09-03) and "Account housekeeping" in
+  `README.md`.
 
 ## Working with AI tools
 

--- a/Gemfile.theme
+++ b/Gemfile.theme
@@ -12,6 +12,11 @@ source 'https://rubygems.org'
 # Error monitoring and APM (https://github.com/openaustralia/righttoknow/issues/1004).
 # Initialised in lib/sentry_config.rb; does nothing unless SENTRY_DSN is set
 # in the host's config/general.yml.
-gem 'sentry-rails'
-gem 'sentry-ruby'
-gem 'sentry-sidekiq'
+#
+# Pinned to the 6.x line: 7.0.0 removed `enable_logs` (used in
+# lib/sentry_config.rb) and changed the PII/metrics defaults. Nothing here
+# is covered by the host's Gemfile.lock, so without a constraint every
+# deploy re-resolves and can pull an untested major.
+gem 'sentry-rails', '~> 6.7'
+gem 'sentry-ruby', '~> 6.7'
+gem 'sentry-sidekiq', '~> 6.7'

--- a/README.md
+++ b/README.md
@@ -337,6 +337,36 @@ bundle exec cap staging xapian:destroy_and_rebuild_index
 bundle exec cap production xapian:destroy_and_rebuild_index
 ```
 
+### Account housekeeping
+
+One-off jobs that act on people's accounts. Each is **dry unless you pass `DRYRUN=0`**, and each
+prints account ids and dates rather than email addresses, so the output is safe to paste into an
+issue as a record of what ran.
+
+Destroy never-confirmed accounts that have no content and are over two years old
+([#1096](https://github.com/openaustralia/righttoknow/issues/1096)):
+
+```bash
+# List what would go, and check the count against production before acting
+bundle exec cap production accounts:destroy_never_confirmed
+
+# Start small, check Sentry, then run the rest
+bundle exec cap production accounts:destroy_never_confirmed DRYRUN=0 LIMIT=10
+bundle exec cap production accounts:destroy_never_confirmed DRYRUN=0
+```
+
+These accounts never confirmed their email address, so they cannot be warned first and are handled
+separately from the dormant-account notice. What "never-confirmed" and "dormant" mean, and why the
+order matters, is in `AGENTS.md` under "Key domain knowledge" and in `docs/DECISIONS.md`
+(2026-09-03).
+
+The same job can be run from a shell on the server, with the same environment variables:
+
+```bash
+cd /srv/www/production/current
+lib/themes/righttoknow/script/destroy-never-confirmed-accounts
+```
+
 ### First-time server setup
 
 After the [infrastructure repo](https://github.com/openaustralia/infrastructure) has provisioned the host, the shared path needs the config files in place before the first deploy. The deploy itself auto-creates any missing shared directories (cache, logs, storage, xapian indexes, vendored bundle, etc.) on each run via `deploy:check_shared`.

--- a/README.md
+++ b/README.md
@@ -287,7 +287,10 @@ rather than connecting to a public hostname, so you need:
 - The [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
   and the [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
   installed
-- An AWS profile named `oaf` with permission to describe EC2 instances and start SSM sessions
+- An AWS profile named `oaf` with permission to describe EC2 instances and start SSM sessions.
+  `config/deploy.rb` sets `AWS_PROFILE` to `oaf` unless you have already set it, so instance
+  lookup and the SSM tunnel always use the same account; set `AWS_PROFILE` yourself if your
+  profile is named something else
 - An SSH key for the `deploy` user (SSH still runs as normal inside the SSM tunnel). If your
   key isn't picked up by default, add a `Host i-*` entry with `IdentityFile` to `~/.ssh/config`
 - Gems installed: `bundle install --with deployment`

--- a/README.md
+++ b/README.md
@@ -372,8 +372,8 @@ It should report the same value as https://whatismyip.akamai.com/
 Off by default; set `PROVIDE_WHATISMYIP: true` in `general.yml` to turn it on.
 
 ```bash
-curl https://staging.righttoknow.org.au/whatismyip
 curl https://www.righttoknow.org.au/whatismyip
+curl https://www-staging.righttoknow.org.au/whatismyip
 ```
 
 ## Authorities

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,6 +8,15 @@ set :use_sudo,    false
 
 set :rbenv_type, :user
 
+# capistrano-aws builds its Aws::EC2::Resource with a region and nothing else,
+# so instance lookup would otherwise use whatever the SDK resolves as the
+# default profile - a different account, or none, depending on the machine.
+# Name the profile here instead, so lookup and the SSM tunnel below are always
+# the same account. Set AWS_PROFILE yourself to override, and static
+# credentials in the environment still win over a profile in both the SDK and
+# the CLI.
+ENV['AWS_PROFILE'] ||= 'oaf'
+
 # Deploy targets are found dynamically by capistrano-aws using the Application,
 # Stage and Roles tags Terraform sets on the EC2 instances (see
 # terraform/righttoknow/*.tf in the infrastructure repo). The gem's default
@@ -22,8 +31,10 @@ set :ssh_options, {
   # SSH reaches the instances through an AWS SSM Session Manager tunnel rather
   # than a public hostname, so deploys work without the instances accepting
   # direct SSH from the internet.
+  # No --profile here: the CLI inherits AWS_PROFILE from the environment set
+  # above, so the tunnel cannot end up on a different account from the lookup.
   proxy: Net::SSH::Proxy::Command.new(
-    'aws ssm start-session --profile oaf --target %h ' \
+    'aws ssm start-session --target %h ' \
     '--document-name AWS-StartSSHSession --parameters portNumber=%p'
   ),
   # net-ssh misinterprets the ^ modifier syntax in ~/.ssh/config Ciphers entries,

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -113,6 +113,40 @@ namespace :xapian do
   end
 end
 
+# One-off account housekeeping jobs (#1095, #1096). Both are dry unless
+# DRYRUN=0, and both print user ids rather than email addresses. See "Account
+# housekeeping" in README.md.
+namespace :accounts do
+  # Runs `bundle exec rails runner` directly rather than the theme's script/
+  # wrappers: capistrano-rbenv maps the `bundle` command to `rbenv exec
+  # bundle`, and a bash wrapper calling bare `bundle` would not find Ruby.
+  #
+  # `capture` rather than `execute` because Airbrussh does not show command
+  # output by default, and the per-account ids these jobs print are the audit
+  # trail. `capture` also raises on a non-zero exit, so a failed run is loud.
+  #
+  # :bundle has to stay the first argument - SSHKit only applies `within` and
+  # `with` when the first argument has no whitespace in it.
+  def run_account_job(expression)
+    env = { rails_env: fetch(:rails_env), dryrun: ENV.fetch('DRYRUN', '1') }
+    env[:limit] = ENV['LIMIT'] if ENV['LIMIT']
+
+    on roles(:app) do
+      within current_path do
+        with env do
+          puts capture(:bundle, "exec rails runner '#{expression}' 2>&1")
+        end
+      end
+    end
+  end
+
+  desc 'Destroy never-confirmed accounts with no content, over two years old ' \
+       '(#1096). DRYRUN=0 to destroy, LIMIT=n to cap the batch'
+  task :destroy_never_confirmed do
+    run_account_job('DormantAccounts.destroy_never_confirmed')
+  end
+end
+
 namespace :deploy do
   # The shared files on this server are laid out by basename
   # (shared/database.yml rather than shared/config/database.yml), which does

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,6 +5,41 @@ wouldn't surface them. A decision local to one file/view/patch belongs as a comm
 
 Append new entries at the top and date them. Don't edit past entries except to mark them superseded (and say by what).
 
+## 2026-09-03: dormant accounts are handled in three ordered steps, and the blackhole address is the bounce address
+
+The host's `users:destroy_unused` cron has been shipped disabled since #1031, because its first run
+would destroy 2,732 of the site's 10,149 accounts and its "dormant for two years" guard reads
+`last_sign_in_at`, a column added in 0.46 with no backfill. Four accounts have it set, so for anyone
+who last signed in before the upgrade the guard sees a null and calls that "never signed in". Three
+issues sequence getting to a point where the cron can be enabled honestly, and the order is the
+decision worth recording:
+
+- **Never-confirmed accounts go first, with no notice (#1096).** 969 of the 2,732 never confirmed
+  their email address. `User#should_be_emailed?` requires `email_confirmed`, so there is no way to
+  warn them and no reason to think a warning would arrive. Waiting gains nothing, so this pass is
+  deliberately separate and unblocked: `DormantAccounts.destroy_never_confirmed`, a hard `destroy`
+  like the host task, two years to stay consistent with it, `DRYRUN` on unless told otherwise. It
+  logs account ids and creation dates, never addresses or names — the point is to hold less personal
+  data, not to copy it into a terminal.
+- **Bounce recording before any bulk send (#1094).** No account on the site has ever had a bounce
+  recorded. Every mail the app sends sets `Return-Path` to the blackhole address
+  (`ApplicationMailer#mail_user`), so **the blackhole, not `CONTACT_EMAIL`, is where bounces
+  arrive** — which is the opposite of what upstream's install guide assumes, and the reason
+  `script/handle-mail-replies` has never seen a single message here. It is also currently a Google
+  Group that archives them. Fixing it is Workspace routing plus a Postfix pipe in the
+  `infrastructure` repo, with no application code. Right to Know's sending reputation is what gets
+  FOI requests delivered to authorities, so this lands before anything is mailed in bulk.
+- **Notice to the accounts that can actually receive one (#1095).** `DormantAccountMailer` honours
+  `should_be_emailed?`, so banned, opted-out and bounced accounts get no notice and are left to the
+  cron, as upstream did on WhatDoTheyKnow. Recipients are tagged `dormant_account_notice:<date>`
+  so a re-run can't mail them twice; user tags are used because `UserInfoRequestSentAlert` requires
+  an `info_request_id` and these accounts have no requests by definition. Sends are capped per run
+  and triggered by hand so the bounce rate can be watched between tranches rather than discovered
+  afterwards. The email states a removal date computed as the run date plus 60 days, so **the cron
+  must not be enabled before the latest date any tranche was told**.
+
+The notice mailer's code may land before bounce recording works; its first live send may not.
+
 ## 2026-08-24: the personal information gate fails open, and Sentry RIGHT-TO-KNOW-JS-5 is our canary
 
 The new request form asks whether you're requesting personal information that should be confidential, and hides the

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -41,6 +41,9 @@ require File.expand_path('sentry_config.rb', __dir__)
 # A new controller (not a patch to an existing one) - see its own file for why
 require File.expand_path('whatismyip_controller.rb', __dir__)
 
+# Account housekeeping (#1095, #1096) - see "Account housekeeping" in README.md
+require File.expand_path('dormant_accounts.rb', __dir__)
+
 # Note you should rename the file at "config/custom-routes.rb" to
 # something unique (e.g. yourtheme-custom-routes.rb":
 $alaveteli_route_extensions << 'custom-routes.rb'

--- a/lib/dormant_accounts.rb
+++ b/lib/dormant_accounts.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+##
+# Housekeeping for accounts that have never been used, and the shared
+# definition of the cohort the host's `users:destroy_unused` cron would
+# destroy (openaustralia/righttoknow#1031, #1095, #1096).
+#
+# See "Account housekeeping" in README.md for how to run this, and
+# docs/DECISIONS.md (2026-09-03) for why never-confirmed accounts are
+# handled separately and without notice.
+#
+module DormantAccounts
+  # Exactly the cohort of the host's `users:destroy_unused`
+  # (alaveteli/lib/tasks/users.rake). Kept in one place so this pass and the
+  # dormant-account notice (DormantAccountMailer) can never disagree about who
+  # is at risk of deletion.
+  #
+  # `last_sign_in_at` is nil for every account that predates the 0.46 upgrade,
+  # which is why the host cron is still disabled - see #1031.
+  def self.scope
+    time_range = ...2.years.ago
+    User.unused.where(created_at: time_range, last_sign_in_at: [nil, time_range])
+  end
+
+  # Accounts in that cohort that never confirmed their email address. They
+  # cannot be sent the notice at all (`User#should_be_emailed?` requires
+  # `email_confirmed`), so there is nothing to wait for before deleting them.
+  def self.never_confirmed
+    scope.where(email_confirmed: false)
+  end
+
+  # Destroy the never-confirmed cohort. Dry unless DRYRUN=0, so a bare run is
+  # always safe; LIMIT caps the batch, which is how to start a live run small.
+  #
+  # Prints one line per account as `id<TAB>created_at`, deliberately without
+  # the email address or name - the point of the exercise is to hold less
+  # personal data, not to copy it into a terminal and an issue comment.
+  def self.destroy_never_confirmed(dryrun: ENV['DRYRUN'] != '0',
+                                   limit: ENV['LIMIT'].presence&.to_i,
+                                   out: $stderr)
+    users = never_confirmed.order(:id)
+    users = users.limit(limit) if limit
+
+    users.pluck(:id, :created_at).each do |id, created_at|
+      out.puts "#{id}\t#{created_at.iso8601}"
+    end
+
+    if dryrun
+      out.puts "DRY RUN: would destroy #{users.count} never-confirmed accounts"
+      return
+    end
+
+    out.puts "Destroyed #{destroy_users(users)} never-confirmed accounts"
+  end
+
+  # Same shape as the host task: clear the inbound TrackThing references that
+  # have a foreign key but no association to cascade them, preload everything
+  # so the cascade isn't an N+1, and silence the logger so a large run doesn't
+  # write a line of SQL per row.
+  #
+  # `destroy!` rather than `destroy` so that a destroy blocked by a callback or
+  # a foreign key fails the run instead of being counted as a success.
+  def self.destroy_users(users)
+    TrackThing.where(tracked_user_id: users.select(:id))
+              .update_all(tracked_user_id: nil)
+
+    destroyed = 0
+    ActiveRecord::Base.logger.silence do
+      users.preload(User.reflect_on_all_associations.map(&:name))
+           .in_batches.each_record do |user|
+        user.destroy!
+        destroyed += 1
+      end
+    end
+    destroyed
+  end
+  private_class_method :destroy_users
+end

--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -4,6 +4,14 @@ require 'ipaddr'
 require 'net/http'
 
 Rails.configuration.to_prepare do
+  # In development ApplicationController is reloadable, so it is a brand-new
+  # class object each time this block re-runs, while this hand-defined
+  # constant (not managed by Zeitwerk) survives the reload still pointing at
+  # the old one. Redefining would then raise "superclass mismatch", breaking
+  # docker/setup's `db:migrate db:seed` and every dev reload (issue #1100),
+  # so drop the stale constant first.
+  Object.send(:remove_const, :WhatismyipController) if Object.const_defined?(:WhatismyipController, false)
+
   # Diagnostic for the nginx/Cloudflare real-IP trust boundary (see
   # ,plan-staging-rtk.md) - off by default since an open whatismyip would let
   # anyone check whether a forged CF-Connecting-IP is being trusted.

--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -87,15 +87,15 @@ Rails.configuration.to_prepare do
       raise RangesUnavailable
     end
 
-    # Fetch from uri with short open and read timeout.
-    # Throws Net::OpenTimeout or Net::ReadTimeout, both descend from Timeout::Error
-    # which fetch_ranges already rescues, so a slow Cloudflare reports
-    # ' UNABLE TO CHECK' on the same path as any other failed fetch.
+    # Fetch from uri with short open, read and write timeouts.
+    # Throws Net::OpenTimeout, Net::ReadTimeout or Net::WriteTimeout, all of
+    # which descend from Timeout::Error
     def fetch(uri)
       Net::HTTP.start(uri.host, uri.port,
                       use_ssl: uri.scheme == 'https',
                       open_timeout: FETCH_TIMEOUT,
-                      read_timeout: FETCH_TIMEOUT) do |http|
+                      read_timeout: FETCH_TIMEOUT,
+                      write_timeout: FETCH_TIMEOUT) do |http|
         http.request(Net::HTTP::Get.new(uri))
       end
     end

--- a/lib/whatismyip_controller.rb
+++ b/lib/whatismyip_controller.rb
@@ -32,6 +32,12 @@ Rails.configuration.to_prepare do
     # Cloudflare erroring or truncating rather than a genuine empty list.
     MIN_EXPECTED_RANGES = 4
 
+    # A short fetch timeout so a Cloudflare outage can not lock the Rails worker
+    # as long as the default minute.
+    # Failures are deliberately not cached, so this reduces the possible impact.
+    # Issue: openaustralia/infrastructure#733
+    FETCH_TIMEOUT = 5
+
     class RangesUnavailable < StandardError; end
 
     def index
@@ -51,6 +57,7 @@ Rails.configuration.to_prepare do
       ' UNABLE TO CHECK'
     end
 
+    # Return IPv4 and IPv6 cloudflare ranges as one array
     # Cached a day so this doesn't depend on cloudflare.com being reachable on
     # every check. Validated and parsed to IPAddr before caching, not after -
     # a failed/truncated fetch must raise inside the block so Rails.cache
@@ -63,10 +70,12 @@ Rails.configuration.to_prepare do
       end
     end
 
-    # Each list checked independently - a truncated v6 list shouldn't pass
-    # just because v4 came back full-sized.
+    # Fetch one range of ip addresses (IPv4 or IPv6)
+    # Checked independently so one truncated list shouldn't pass
+    # just because the other came back full-sized.
+    # raises RangeUnavailable for network or content errors
     def fetch_ranges(url)
-      response = Net::HTTP.get_response(URI(url))
+      response = fetch(URI(url))
       raise RangesUnavailable unless response.is_a?(Net::HTTPSuccess)
 
       ranges = response.body.lines.map(&:strip).reject(&:empty?)
@@ -76,6 +85,19 @@ Rails.configuration.to_prepare do
     rescue Timeout::Error, SocketError, SystemCallError, OpenSSL::SSL::SSLError, EOFError, Net::ProtocolError,
            Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError
       raise RangesUnavailable
+    end
+
+    # Fetch from uri with short open and read timeout.
+    # Throws Net::OpenTimeout or Net::ReadTimeout, both descend from Timeout::Error
+    # which fetch_ranges already rescues, so a slow Cloudflare reports
+    # ' UNABLE TO CHECK' on the same path as any other failed fetch.
+    def fetch(uri)
+      Net::HTTP.start(uri.host, uri.port,
+                      use_ssl: uri.scheme == 'https',
+                      open_timeout: FETCH_TIMEOUT,
+                      read_timeout: FETCH_TIMEOUT) do |http|
+        http.request(Net::HTTP::Get.new(uri))
+      end
     end
   end
 end

--- a/script/destroy-never-confirmed-accounts
+++ b/script/destroy-never-confirmed-accounts
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Destroy never-confirmed, content-free accounts older than two years
+# (openaustralia/righttoknow#1096).
+#
+# Dry unless DRYRUN=0. LIMIT=n caps the batch. Prints one id and created_at per
+# account, then a count.
+#
+# Run from a shell on the server; from your own machine use
+# `bundle exec cap production accounts:destroy_never_confirmed` instead. See
+# "Account housekeeping" in README.md.
+set -euo pipefail
+
+# This theme is checked out at alaveteli/lib/themes/righttoknow, so the host
+# app root is four levels up from script/.
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
+bundle exec rails runner 'DormantAccounts.destroy_never_confirmed'

--- a/spec/dormant_accounts_spec.rb
+++ b/spec/dormant_accounts_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'righttoknow'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'spec', 'spec_helper'))
+
+RSpec.describe DormantAccounts do
+  # The host loads spec/fixtures/users.yml globally, and those fixtures include
+  # accounts that legitimately fall in this cohort (`unconfirmed_user` was
+  # created in 2007). So these examples assert on the records they create
+  # rather than on absolute counts.
+  let(:out) { StringIO.new }
+
+  let!(:dormant_unconfirmed) do
+    FactoryBot.create(:user, :unconfirmed, created_at: 3.years.ago)
+  end
+
+  before do
+    # `User.unused` creates the CONTACT_EMAIL account if it is missing, so
+    # reference it up front and keep that side effect out of the examples.
+    User.internal_admin_user
+  end
+
+  describe '.scope' do
+    subject { described_class.scope }
+
+    it 'includes a content-free confirmed account over two years old' do
+      user = FactoryBot.create(:user, created_at: 3.years.ago)
+      is_expected.to include(user)
+    end
+
+    it 'includes a content-free never-confirmed account over two years old' do
+      is_expected.to include(dormant_unconfirmed)
+    end
+
+    it 'excludes an account created within the last two years' do
+      user = FactoryBot.create(:user, :unconfirmed, created_at: 1.year.ago)
+      is_expected.not_to include(user)
+    end
+
+    it 'excludes an account that signed in within the last two years' do
+      user = FactoryBot.create(:user, :unconfirmed, created_at: 3.years.ago,
+                                                    last_sign_in_at: 1.year.ago)
+      is_expected.not_to include(user)
+    end
+
+    it 'excludes an account with a retained sign-in record' do
+      # Inserted rather than built through the factory: this environment sets
+      # USER_SIGN_IN_ACTIVITY_RETENTION_DAYS to 0, so User::SignIn's
+      # before_create aborts and the factory can never save a row. The scope
+      # reads the table, so a directly inserted row is the real thing.
+      now = Time.zone.now
+      User::SignIn.insert_all(
+        [{ user_id: dormant_unconfirmed.id, created_at: now, updated_at: now }]
+      )
+
+      is_expected.not_to include(dormant_unconfirmed)
+    end
+
+    # One example only, to prove the scope delegates to User.unused. The host's
+    # spec/models/user/unused_spec.rb covers the rest of its conditions.
+    it 'excludes an account that has made a request' do
+      dormant_unconfirmed.update_columns(info_requests_count: 1)
+      is_expected.not_to include(dormant_unconfirmed)
+    end
+
+    it 'excludes the internal admin account' do
+      is_expected.not_to include(User.internal_admin_user)
+    end
+  end
+
+  describe '.never_confirmed' do
+    subject { described_class.never_confirmed }
+
+    it 'includes a never-confirmed account in the cohort' do
+      is_expected.to include(dormant_unconfirmed)
+    end
+
+    it 'excludes a confirmed account in the cohort' do
+      confirmed = FactoryBot.create(:user, created_at: 3.years.ago)
+      is_expected.not_to include(confirmed)
+    end
+  end
+
+  describe '.destroy_never_confirmed' do
+    context 'by default' do
+      it 'destroys nothing' do
+        described_class.destroy_never_confirmed(out: out)
+        expect(User.exists?(dormant_unconfirmed.id)).to eq(true)
+      end
+
+      it 'lists the account it would destroy' do
+        described_class.destroy_never_confirmed(out: out)
+        expect(out.string).to include(
+          "#{dormant_unconfirmed.id}\t#{dormant_unconfirmed.created_at.iso8601}"
+        )
+        expect(out.string).to match(/DRY RUN: would destroy \d+ never-confirmed/)
+      end
+
+      it 'does not list a confirmed account in the cohort' do
+        confirmed = FactoryBot.create(:user, created_at: 3.years.ago)
+        described_class.destroy_never_confirmed(out: out)
+        expect(out.string).not_to match(/^#{confirmed.id}\t/)
+      end
+
+      it 'does not print personal details' do
+        described_class.destroy_never_confirmed(out: out)
+        expect(out.string).not_to include(dormant_unconfirmed.email)
+        expect(out.string).not_to include(dormant_unconfirmed.name)
+      end
+    end
+
+    context 'when DRYRUN is off' do
+      it 'destroys the never-confirmed account' do
+        described_class.destroy_never_confirmed(dryrun: false, out: out)
+        expect(User.exists?(dormant_unconfirmed.id)).to eq(false)
+      end
+
+      it 'reports how many it destroyed' do
+        described_class.destroy_never_confirmed(dryrun: false, out: out)
+        expect(out.string).to match(/Destroyed \d+ never-confirmed accounts/)
+      end
+
+      it 'keeps a confirmed account in the cohort' do
+        confirmed = FactoryBot.create(:user, created_at: 3.years.ago)
+        described_class.destroy_never_confirmed(dryrun: false, out: out)
+        expect(User.exists?(confirmed.id)).to eq(true)
+      end
+
+      it 'keeps a never-confirmed account created within two years' do
+        recent = FactoryBot.create(:user, :unconfirmed, created_at: 1.year.ago)
+        described_class.destroy_never_confirmed(dryrun: false, out: out)
+        expect(User.exists?(recent.id)).to eq(true)
+      end
+
+      it 'keeps a never-confirmed account that has content' do
+        dormant_unconfirmed.update_columns(comments_count: 1)
+        described_class.destroy_never_confirmed(dryrun: false, out: out)
+        expect(User.exists?(dormant_unconfirmed.id)).to eq(true)
+      end
+
+      it 'clears inbound TrackThing references before destroying' do
+        # Built directly rather than with the :user_track factory, whose own
+        # after(:create) hook raises NameError in the host app.
+        track = TrackThing.create!(
+          track_type: 'user_updates',
+          track_query: 'requested_by:example',
+          track_medium: 'email_daily',
+          tracking_user: FactoryBot.create(:user, created_at: 1.day.ago),
+          tracked_user: dormant_unconfirmed
+        )
+
+        described_class.destroy_never_confirmed(dryrun: false, out: out)
+
+        expect(track.reload.tracked_user_id).to be_nil
+        expect(User.exists?(dormant_unconfirmed.id)).to eq(false)
+      end
+    end
+
+    context 'with a limit' do
+      before do
+        Array.new(2) do
+          FactoryBot.create(:user, :unconfirmed, created_at: 3.years.ago)
+        end
+      end
+
+      it 'destroys exactly the limit, not the whole cohort' do
+        expect { described_class.destroy_never_confirmed(dryrun: false, limit: 2, out: out) }
+          .to change { described_class.never_confirmed.count }.by(-2)
+      end
+
+      it 'lists only the accounts within the limit' do
+        described_class.destroy_never_confirmed(limit: 2, out: out)
+        expect(out.string.lines.grep(/\t/).size).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/whatismyip_spec.rb
+++ b/spec/whatismyip_spec.rb
@@ -114,3 +114,43 @@ RSpec.describe WhatismyipController, type: :controller do
     end
   end
 end
+
+# Guards against issue #1100: in development ApplicationController is
+# reloadable, so after every code reload it is a brand-new class object while
+# the theme's hand-defined WhatismyipController constant survives, still
+# subclassing the old one. Re-running the theme's to_prepare block then raised
+# "superclass mismatch", which broke docker/setup (db:migrate reloads before
+# db:seed) and every dev-mode reload.
+#
+# A real reload can't reproduce this here - the test environment doesn't
+# reload classes, so ApplicationController would keep its identity - so this
+# simulates one instead: swap ApplicationController for a fresh class object
+# (exactly what a dev reload does) and re-run the theme's registered
+# to_prepare block, restoring both afterwards.
+RSpec.describe 'WhatismyipController code reloading' do
+  def theme_to_prepare_block
+    Rails.application.reloader._prepare_callbacks.map(&:filter).find do |filter|
+      filter.respond_to?(:source_location) &&
+        filter.source_location&.first&.end_with?('whatismyip_controller.rb')
+    end
+  end
+
+  it 'redefines the controller when ApplicationController is a new class object' do
+    block = theme_to_prepare_block
+    expect(block).not_to be_nil
+
+    original = ApplicationController
+    begin
+      Object.send(:remove_const, :ApplicationController)
+      Object.const_set(:ApplicationController, Class.new(original))
+
+      expect { block.call }.not_to raise_error
+      expect(WhatismyipController.superclass).to eq(ApplicationController)
+    ensure
+      Object.send(:remove_const, :ApplicationController)
+      Object.const_set(:ApplicationController, original)
+      # Leave WhatismyipController subclassing the real class again
+      block.call
+    end
+  end
+end

--- a/spec/whatismyip_spec.rb
+++ b/spec/whatismyip_spec.rb
@@ -2,12 +2,15 @@
 
 # Exercises lib/whatismyip_controller.rb, routed in lib/config/custom-routes.rb.
 #
-# Net::HTTP is stubbed rather than exercised for real so the spec doesn't
-# depend on cloudflare.com being reachable. Rails.cache is real (:null_store
-# in test, per config/environments/test.rb) so the fetch/validate block in
-# cloudflare_ranges actually runs on every request - important since the bug
-# this spec guards against (a bad fetch getting cached and poisoning every
-# check for 24 hours) is specifically about what happens inside that block.
+# Cloudflare's range lists are stubbed with WebMock rather than fetched for
+# real, so the spec doesn't depend on cloudflare.com being reachable. The
+# stubbing is at the HTTP layer, so the controller's own Net::HTTP call (and
+# its open/read timeouts) runs as written. Rails.cache is real (:null_store in
+# test, per config/environments/test.rb) so the fetch/validate block in
+# cloudflare_ranges actually runs on every request - important since one of
+# the bugs this spec guards against (a bad fetch getting cached and poisoning
+# every check for 24 hours) is specifically about what happens inside that
+# block.
 #
 # If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
 ALAVETELI_TEST_THEME = 'righttoknow'
@@ -16,47 +19,44 @@ require File.expand_path(
 )
 
 RSpec.describe WhatismyipController, type: :controller do
-  def stub_cloudflare(ipv4:, ipv6:)
-    responses = {
-      'https://www.cloudflare.com/ips-v4' => ipv4,
-      'https://www.cloudflare.com/ips-v6' => ipv6
-    }
-    allow(Net::HTTP).to receive(:get_response) do |uri|
-      responses.fetch(uri.to_s)
-    end
+  def ipv4_url = 'https://www.cloudflare.com/ips-v4'
+  def ipv6_url = 'https://www.cloudflare.com/ips-v6'
+
+  def full_ipv4 = %w[173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22]
+  def full_ipv6 = %w[2400:cb00::/32 2606:4700::/32 2803:f800::/32 2405:b500::/32]
+
+  def stub_ranges(url, cidrs)
+    stub_request(:get, url).to_return(status: 200, body: cidrs.join("\n"))
   end
 
-  def success(*cidrs)
-    double('response', is_a?: true, body: cidrs.join("\n"))
+  def stub_healthy_cloudflare
+    stub_ranges(ipv4_url, full_ipv4)
+    stub_ranges(ipv6_url, full_ipv6)
   end
 
-  def failure
-    double('response', is_a?: false)
+  # A default stub is needed alongside the PROVIDE_WHATISMYIP one: rendering
+  # goes through ApplicationController#set_gettext_locale, which reads other
+  # settings, and a bare `with` stub would make those raise.
+  def stub_whatismyip_setting(enabled)
+    allow(AlaveteliConfiguration).to receive(:get).and_call_original
+    allow(AlaveteliConfiguration).to receive(:get)
+      .with('PROVIDE_WHATISMYIP', false).and_return(enabled)
   end
 
   describe 'GET #index' do
     context 'when PROVIDE_WHATISMYIP is off' do
       it 'is not found' do
-        allow(AlaveteliConfiguration).to receive(:get)
-          .with('PROVIDE_WHATISMYIP', false).and_return(false)
+        stub_whatismyip_setting(false)
         get :index
         expect(response).to have_http_status(:not_found)
       end
     end
 
     context 'when PROVIDE_WHATISMYIP is on' do
-      before do
-        allow(AlaveteliConfiguration).to receive(:get)
-          .with('PROVIDE_WHATISMYIP', false).and_return(true)
-      end
+      before { stub_whatismyip_setting(true) }
 
       context 'with a healthy Cloudflare response' do
-        before do
-          stub_cloudflare(
-            ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
-            ipv6: success('2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32')
-          )
-        end
+        before { stub_healthy_cloudflare }
 
         it 'returns the IP alone when outside Cloudflare\'s ranges' do
           request.remote_addr = '1.2.3.4'
@@ -73,7 +73,8 @@ RSpec.describe WhatismyipController, type: :controller do
 
       context 'when Cloudflare returns an error status' do
         before do
-          stub_cloudflare(ipv4: failure, ipv6: success('2400:cb00::/32'))
+          stub_request(:get, ipv4_url).to_return(status: 500)
+          stub_ranges(ipv6_url, full_ipv6)
           request.remote_addr = '1.2.3.4'
         end
 
@@ -85,10 +86,7 @@ RSpec.describe WhatismyipController, type: :controller do
         it 'recovers once Cloudflare responds normally again' do
           get :index
 
-          stub_cloudflare(
-            ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
-            ipv6: success('2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32')
-          )
+          stub_healthy_cloudflare
           get :index
 
           expect(response.body).to eq('1.2.3.4')
@@ -99,14 +97,25 @@ RSpec.describe WhatismyipController, type: :controller do
         before do
           # A full-sized v4 list must not offset a truncated v6 one - each is
           # checked independently.
-          stub_cloudflare(
-            ipv4: success('173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22'),
-            ipv6: success('2400:cb00::/32')
-          )
+          stub_ranges(ipv4_url, full_ipv4)
+          stub_ranges(ipv6_url, %w[2400:cb00::/32])
           request.remote_addr = '1.2.3.4'
         end
 
         it 'reports UNABLE TO CHECK rather than trusting the truncated list' do
+          get :index
+          expect(response.body).to eq('1.2.3.4 UNABLE TO CHECK')
+        end
+      end
+
+      context 'when Cloudflare does not respond in time' do
+        before do
+          stub_request(:get, ipv4_url).to_timeout
+          stub_ranges(ipv6_url, full_ipv6)
+          request.remote_addr = '1.2.3.4'
+        end
+
+        it 'reports UNABLE TO CHECK rather than hanging' do
           get :index
           expect(response.body).to eq('1.2.3.4 UNABLE TO CHECK')
         end


### PR DESCRIPTION
## What and why

Release merge of `staging` into `production`.
Six pull requests, all already reviewed and merged into `staging`.
Head at time of opening: `67df1a1`, which is byte-identical to what staging is running now (`staging_20260909092642`, deployed 9 September).

- #1091 Pin sentry gems to the 6.x line
- #1101 Survive dev code reloads in whatismyip controller (resolves #1100)
- #1106 Use short timeout with whatismyip Cloudflare fetch (refs openaustralia/infrastructure#733)
- #1105 Use www-staging hostname consistently in whatismyip README section
- #1089 Pin EC2 discovery and the SSM tunnel to the same AWS profile
- #1088 Always run migrations in the dev container setup

14 commits, 6 files changed, 161 insertions, 58 deletions.
**Nothing in this release changes what people see on the site**, which is the main thing a reviewer needs to know.
The four groups:

- **Already live on production (#1091).**
  The sentry `~> 6.7` pin is what production is running: `themes:pre_bundle_setup` uploads `Gemfile.theme` from the local working copy, so the 3 September re-deploy succeeded with the change uncommitted.
  This puts the branch back in line with the server.
  Until it merges, any deploy from a clean checkout of `production` would re-resolve sentry to 7.x and fail at `deploy:assets:precompile` again.
- **Deploy tooling (#1089).**
  `config/deploy.rb` now sets `AWS_PROFILE` to `oaf` unless already set, so `capistrano-aws` instance lookup and the SSM tunnel cannot land on different accounts.
  Changes how a deploy is run, not what runs on the server.
- **Development only (#1088, #1101).**
  The dev container now runs migrations on every setup rather than only the first, and `WhatismyipController` drops its stale constant before redefining so a code reload no longer raises `superclass mismatch`.
  The `remove_const` also runs in production, where `to_prepare` fires once and the constant is not yet defined, so it is a no-op there.
- **Inert on both stages (#1106).**
  The 5s open/read/write timeout on `/whatismyip`'s Cloudflare range fetch only has an effect while `PROVIDE_WHATISMYIP` is on.
  The Ansible template (`roles/internal/righttoknow/templates/general.yml.j2:1395`) sets it `false` with no per-stage override, so the endpoint 404s on production and staging alike and this is hardening ahead of the infrastructure#733 work.

Two things a reviewer will reasonably ask about:

- **This wants pairing with a host Alaveteli release.**
  openaustralia/alaveteli `staging` is 7 commits ahead of its `production`, including the wkhtmltopdf removal (#1083) and the stringio pin (#1092).
  No release PR is open there yet.
  Nothing in this theme PR depends on those commits, so the two can go separately, but a `cap production deploy` run after only this one leaves both of those fixes on staging.
- **Sentry 7.x is deferred, not forgotten.**
  #1090 covers lifting the pin deliberately, including the `data_collection` change that replaces `send_default_pii` and deserves a look at what we send given the correspondence this site handles.

## Type of change

- [x] Bug fix
- [x] Chore
- [x] Already deployed
- [x] Documentation

## How this was checked

- [x] Checked the affected area on my own or a staging system
- [ ] Ran the automated tests
- [ ] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues above, or noted why they are not important above
- [x] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [x] Documentation updated, or not needed

Checked by comparing branches rather than by exercising features, since this adds no code of its own.
`origin/staging` is at `67df1a1` and `staging_20260909092642` points at that same commit, so everything here has been on the staging server since 9 September.
Production is at `a453d96` and `production_20260903071114` points there too, so the branch and the server agree on both sides and this merge is a clean fast-forward of six reviewed PRs.
Verified with `git rev-list --count origin/staging..origin/production` (1, the previous release merge commit) and `git diff --stat`.

Automated tests not run for this PR.
The theme suite needs a host Alaveteli checkout with this theme symlinked into `lib/themes/righttoknow`, and that symlink is currently pointed at an unrelated feature worktree; repointing it and standing up the Docker environment to re-run specs over commits that already passed on their own PRs did not seem a good trade.
Note that CI here runs Rubocop and CodeQL only, never RSpec.
The one spec change in this release (#1106, `spec/whatismyip_spec.rb`) was run on that PR, where it also fixed a pre-existing failure in 7 of 8 examples against core 0.46.7.0.

`/code-review` not run, for the same reason: there is no new code to review, only merge commits.
Each constituent PR recorded its own review state.

GitHub Actions on the staging head `67df1a1`: Socket Security and all three CodeQL Analyze jobs (actions, ruby, javascript-typescript) pass.

### Deploy notes

- No infrastructure change pairs with this, and no migrations. A plain `bundle exec cap production deploy` is enough.
- Sentry should keep reporting exactly as it does now. The pin matches the gem versions already installed, so the deploy is not moving sentry in either direction.
- Consider whether to release openaustralia/alaveteli `staging` to `production` first, or in the same window, so one deploy carries both.

---

AI disclosure: this description was drafted with Claude Code, model `claude-opus-5`, from the branch state, deploy tags, CI history, the infrastructure repo and the linked issues and PRs.
No code was written for this pull request; it is a merge of already-reviewed commits.
Reviewed by me before submitting.

Assisted-by: Claude Code:claude-opus-5
